### PR TITLE
Issue14 panic i386

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"sync"
 	"time"
+        "unsafe"
 
 	// Allow dynamic profiling.
 	_ "net/http/pprof"
@@ -91,6 +92,12 @@ func New(opts *Options) *Server {
 		done:  make(chan bool, 1),
 		start: time.Now(),
 	}
+
+        // Make sure gcid is properly aligned (on 32bit machines)
+        offs := unsafe.Offsetof(s.gcid)
+        if offs % 0x7 != 0x0 {
+            PrintAndDie(fmt.Sprintf("can't run on this machine - gcid not properly aligned (%02x)\n", offs))
+        }
 
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/server/server.go
+++ b/server/server.go
@@ -39,6 +39,7 @@ type Server struct {
 	info     Info
 	infoJSON []byte
 	sl       *sublist.Sublist
+	_	 uint32
 	gcid     uint64
 	opts     *Options
 	trace    bool
@@ -95,8 +96,8 @@ func New(opts *Options) *Server {
 
         // Make sure gcid is properly aligned (on 32bit machines)
         offs := unsafe.Offsetof(s.gcid)
-        if offs % 0x7 != 0x0 {
-            PrintAndDie(fmt.Sprintf("can't run on this machine - gcid not properly aligned (%02x)\n", offs))
+        if offs & 0x7 != 0x0 {
+            PrintAndDie(fmt.Sprintf("can't run on this machine - gcid not properly aligned (offset %02x/%02x)\n", offs, offs & 0x7))
         }
 
 	s.mu.Lock()


### PR DESCRIPTION
Here is a fix for issue14. I did two things:

- added an  "assert" for alignment of Server.gcid (needs to be 8-bytes aligned). You may want to change the error message.
- added an int32 "padding" to re-align gcid. It should work until something else is added before it.
