### PR TITLE
Listen to SIGHUP to reload config

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -41,6 +41,7 @@ type Options struct {
 	ClusterAuthTimeout float64       `json:"auth_timeout"`
 	Routes             []*url.URL    `json:"-"`
 	ProfPort           int           `json:"-"`
+	ConfigFile         string        `json:"-"`
 	PidFile            string        `json:"-"`
 	LogFile            string        `json:"-"`
 	Syslog             bool          `json:"-"`
@@ -203,6 +204,9 @@ func MergeOptions(fileOpts, flagOpts *Options) *Options {
 	}
 	if flagOpts.Logtime {
 		opts.Logtime = true
+	}
+	if flagOpts.ConfigFile != "" {
+		opts.ConfigFile = flagOpts.ConfigFile
 	}
 	if flagOpts.LogFile != "" {
 		opts.LogFile = flagOpts.LogFile

--- a/server/server.go
+++ b/server/server.go
@@ -180,8 +180,8 @@ func (s *Server) handleSignals() {
 	c := make(chan os.Signal, 1)
 
 	signal.Notify(c, os.Interrupt, syscall.SIGHUP)
- 	go func() {
- 		for sig := range c {
+	go func() {
+		for sig := range c {
 			Debugf("Trapped Signal; %v", sig)
 			switch sig {
 			case syscall.SIGHUP:
@@ -192,6 +192,7 @@ func (s *Server) handleSignals() {
 				Noticef("Server Exiting..")
 				os.Exit(0)
 			}
+		}
 	}()
 }
 


### PR DESCRIPTION
This PR tries to fix the lingering problem of not being able to configure routes dynamically, not allowing gnatsd to change it's infrastructure on the fly. There is another PR (#52) but @derekcollison raised some security concerns and suggested the 'traditional' UNIX way of doing things - sending a SIGHUP to reload the config file, this PR implements a very basic version of just that. 

I'd be happy to keep working on this but would like some feedback on what is the preferred way to close connections (for example, doing it this way does *not* cancel pending route connections as they are not in server.routes until they succesfully connect - which means it includes connections failing to connect and redialing). 

Note that no other data from config is used to reconfigure gnatsd on the fly, I'm planning to figure those out as well. If you know of any pitfalls related to any of the parameters, I'd be glad to know. Changing authorization details is probably the biggest one, should it just disconnect all connections if they change?

As a bonus, there's also another Windows bug fix included, commit ff47f56 that fixed getInterfaceIps for Windows. This was not obvious before due to it throwing errors before logger is initialized properly (maybe executelogcall should just fmt.printf when log.logger == nil instead of dropping the messages quietly?).