### PR TITLE
Add query parameter to sort connz by the monitor server 

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -86,14 +86,21 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 		sort.Sort(sort.Reverse(ByOutBytes(pairs)))
 	case byInBytes:
 		sort.Sort(sort.Reverse(ByInBytes(pairs)))
+	default:
+		if sortOpt != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("Invalid sorting option"))
+			s.mu.Unlock()
+			return
+		}
 	}
 
 	var limit int
 	if c.Offset == c.Limit {
-		// Get the immediate one after the offset
+		// get the immediate one after the offset
 		pairs = pairs[c.Offset:][0:]
 	} else if c.NumConns < c.Limit {
-		// Chop to actual number of connections instead of default limit
+		// chop to actual number of connections instead of default limit
 		limit = c.NumConns
 		pairs = pairs[c.Offset:limit]
 	} else {

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -98,19 +98,19 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 		}
 	case "msgs_to":
 		for i, c := range s.clients {
-			pairs = append(pairs, Pair{Key: int(i), Val: int(c.inMsgs)})
+			pairs = append(pairs, Pair{Key: int(i), Val: int(c.outMsgs)})
 		}
 	case "msgs_from":
 		for i, c := range s.clients {
-			pairs = append(pairs, Pair{Key: int(i), Val: int(c.outMsgs)})
+			pairs = append(pairs, Pair{Key: int(i), Val: int(c.inMsgs)})
 		}
 	case "bytes_to":
 		for i, c := range s.clients {
-			pairs = append(pairs, Pair{Key: int(i), Val: int(c.inBytes)})
+			pairs = append(pairs, Pair{Key: int(i), Val: int(c.outBytes)})
 		}
 	case "bytes_from":
 		for i, c := range s.clients {
-			pairs = append(pairs, Pair{Key: int(i), Val: int(c.outBytes)})
+			pairs = append(pairs, Pair{Key: int(i), Val: int(c.inBytes)})
 		}
 	default:
 		// Just get the unsorted keys

--- a/server/monitor_sort_opts.go
+++ b/server/monitor_sort_opts.go
@@ -1,0 +1,92 @@
+// Copyright 2013-2015 Apcera Inc. All rights reserved.
+
+package server
+
+// Helper types to sort by ConnInfo values
+type SortOpt string
+
+const (
+	byCid      SortOpt = "cid"
+	bySubs             = "subs"
+	byOutMsgs          = "msgs_to"
+	byInMsgs           = "msgs_from"
+	byOutBytes         = "bytes_to"
+	byInBytes          = "bytes_from"
+)
+
+type Pair struct {
+	Key uint64
+	Val *client
+}
+
+type ByCid []Pair
+
+func (d ByCid) Len() int {
+	return len(d)
+}
+func (d ByCid) Swap(i, j int) {
+	d[uint64(i)], d[uint64(j)] = d[uint64(j)], d[uint64(i)]
+}
+func (d ByCid) Less(i, j int) bool {
+	return d[uint64(i)].Val.cid < d[uint64(j)].Val.cid
+}
+
+type BySubs []Pair
+
+func (d BySubs) Len() int {
+	return len(d)
+}
+func (d BySubs) Swap(i, j int) {
+	d[uint64(i)], d[uint64(j)] = d[uint64(j)], d[uint64(i)]
+}
+func (d BySubs) Less(i, j int) bool {
+	return d[uint64(i)].Val.subs.Count() < d[uint64(j)].Val.subs.Count()
+}
+
+type ByOutMsgs []Pair
+
+func (d ByOutMsgs) Len() int {
+	return len(d)
+}
+func (d ByOutMsgs) Swap(i, j int) {
+	d[uint64(i)], d[uint64(j)] = d[uint64(j)], d[uint64(i)]
+}
+func (d ByOutMsgs) Less(i, j int) bool {
+	return d[uint64(i)].Val.outMsgs < d[uint64(j)].Val.outMsgs
+}
+
+type ByInMsgs []Pair
+
+func (d ByInMsgs) Len() int {
+	return len(d)
+}
+func (d ByInMsgs) Swap(i, j int) {
+	d[uint64(i)], d[uint64(j)] = d[uint64(j)], d[uint64(i)]
+}
+func (d ByInMsgs) Less(i, j int) bool {
+	return d[uint64(i)].Val.inMsgs < d[uint64(j)].Val.inMsgs
+}
+
+type ByOutBytes []Pair
+
+func (d ByOutBytes) Len() int {
+	return len(d)
+}
+func (d ByOutBytes) Swap(i, j int) {
+	d[uint64(i)], d[uint64(j)] = d[uint64(j)], d[uint64(i)]
+}
+func (d ByOutBytes) Less(i, j int) bool {
+	return d[uint64(i)].Val.outBytes < d[uint64(j)].Val.outBytes
+}
+
+type ByInBytes []Pair
+
+func (d ByInBytes) Len() int {
+	return len(d)
+}
+func (d ByInBytes) Swap(i, j int) {
+	d[uint64(i)], d[uint64(j)] = d[uint64(j)], d[uint64(i)]
+}
+func (d ByInBytes) Less(i, j int) bool {
+	return d[uint64(i)].Val.inBytes < d[uint64(j)].Val.inBytes
+}

--- a/server/monitor_sort_opts.go
+++ b/server/monitor_sort_opts.go
@@ -25,10 +25,10 @@ func (d ByCid) Len() int {
 	return len(d)
 }
 func (d ByCid) Swap(i, j int) {
-	d[uint64(i)], d[uint64(j)] = d[uint64(j)], d[uint64(i)]
+	d[i], d[j] = d[j], d[i]
 }
 func (d ByCid) Less(i, j int) bool {
-	return d[uint64(i)].Val.cid < d[uint64(j)].Val.cid
+	return d[i].Val.cid < d[j].Val.cid
 }
 
 type BySubs []Pair
@@ -37,10 +37,10 @@ func (d BySubs) Len() int {
 	return len(d)
 }
 func (d BySubs) Swap(i, j int) {
-	d[uint64(i)], d[uint64(j)] = d[uint64(j)], d[uint64(i)]
+	d[i], d[j] = d[j], d[i]
 }
 func (d BySubs) Less(i, j int) bool {
-	return d[uint64(i)].Val.subs.Count() < d[uint64(j)].Val.subs.Count()
+	return d[i].Val.subs.Count() < d[j].Val.subs.Count()
 }
 
 type ByOutMsgs []Pair
@@ -49,10 +49,10 @@ func (d ByOutMsgs) Len() int {
 	return len(d)
 }
 func (d ByOutMsgs) Swap(i, j int) {
-	d[uint64(i)], d[uint64(j)] = d[uint64(j)], d[uint64(i)]
+	d[i], d[j] = d[j], d[i]
 }
 func (d ByOutMsgs) Less(i, j int) bool {
-	return d[uint64(i)].Val.outMsgs < d[uint64(j)].Val.outMsgs
+	return d[i].Val.outMsgs < d[j].Val.outMsgs
 }
 
 type ByInMsgs []Pair
@@ -61,10 +61,10 @@ func (d ByInMsgs) Len() int {
 	return len(d)
 }
 func (d ByInMsgs) Swap(i, j int) {
-	d[uint64(i)], d[uint64(j)] = d[uint64(j)], d[uint64(i)]
+	d[i], d[j] = d[j], d[i]
 }
 func (d ByInMsgs) Less(i, j int) bool {
-	return d[uint64(i)].Val.inMsgs < d[uint64(j)].Val.inMsgs
+	return d[i].Val.inMsgs < d[j].Val.inMsgs
 }
 
 type ByOutBytes []Pair
@@ -73,10 +73,10 @@ func (d ByOutBytes) Len() int {
 	return len(d)
 }
 func (d ByOutBytes) Swap(i, j int) {
-	d[uint64(i)], d[uint64(j)] = d[uint64(j)], d[uint64(i)]
+	d[i], d[j] = d[j], d[i]
 }
 func (d ByOutBytes) Less(i, j int) bool {
-	return d[uint64(i)].Val.outBytes < d[uint64(j)].Val.outBytes
+	return d[i].Val.outBytes < d[j].Val.outBytes
 }
 
 type ByInBytes []Pair
@@ -85,8 +85,8 @@ func (d ByInBytes) Len() int {
 	return len(d)
 }
 func (d ByInBytes) Swap(i, j int) {
-	d[uint64(i)], d[uint64(j)] = d[uint64(j)], d[uint64(i)]
+	d[i], d[j] = d[j], d[i]
 }
 func (d ByInBytes) Less(i, j int) bool {
-	return d[uint64(i)].Val.inBytes < d[uint64(j)].Val.inBytes
+	return d[i].Val.inBytes < d[j].Val.inBytes
 }

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -354,10 +354,10 @@ func TestConnzSortedByCid(t *testing.T) {
 		t.Fatalf("Got an error unmarshalling the body: %v\n", err)
 	}
 
-	if c.Conns[0].Cid < c.Conns[1].Cid ||
-		c.Conns[1].Cid < c.Conns[2].Cid ||
-		c.Conns[2].Cid < c.Conns[3].Cid {
-		t.Fatalf("Expected conns sorted in descending order by cid, got %v < %v\n", c.Conns[0].Cid, c.Conns[3].Cid)
+	if c.Conns[0].Cid > c.Conns[1].Cid ||
+		c.Conns[1].Cid > c.Conns[2].Cid ||
+		c.Conns[2].Cid > c.Conns[3].Cid {
+		t.Fatalf("Expected conns sorted in ascending order by cid, got %v < %v\n", c.Conns[0].Cid, c.Conns[3].Cid)
 	}
 }
 
@@ -400,7 +400,7 @@ func TestConnzSortedByBytesAndMsgs(t *testing.T) {
 	if c.Conns[0].OutBytes < c.Conns[1].OutBytes ||
 		c.Conns[0].OutBytes < c.Conns[2].OutBytes ||
 		c.Conns[0].OutBytes < c.Conns[3].OutBytes {
-		t.Fatalf("Expected conns sorted in descending order by bytes from, got %v < one of [%v, %v, %v]\n",
+		t.Fatalf("Expected conns sorted in descending order by bytes to, got %v < one of [%v, %v, %v]\n",
 			c.Conns[0].OutBytes, c.Conns[1].OutBytes, c.Conns[2].OutBytes, c.Conns[3].OutBytes)
 	}
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -325,6 +325,204 @@ func TestConnzWithOffsetAndLimit(t *testing.T) {
 	}
 }
 
+func TestConnzSortedByCid(t *testing.T) {
+	s := runMonitorServer(DEFAULT_HTTP_PORT)
+	defer s.Shutdown()
+
+	clients := make([]*nats.Conn, 4)
+	for i, _ := range clients {
+		clients[i] = createClientConnSubscribeAndPublish(t)
+		defer clients[i].Close()
+	}
+
+	url := fmt.Sprintf("http://localhost:%d/", DEFAULT_HTTP_PORT)
+	resp, err := http.Get(url + "connz?sort=cid")
+	if err != nil {
+		t.Fatalf("Expected no error: Got %v\n", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected a 200 response, got %d\n", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Got an error reading the body: %v\n", err)
+	}
+
+	c := Connz{}
+	if err := json.Unmarshal(body, &c); err != nil {
+		t.Fatalf("Got an error unmarshalling the body: %v\n", err)
+	}
+
+	if c.Conns[0].Cid < c.Conns[1].Cid ||
+		c.Conns[1].Cid < c.Conns[2].Cid ||
+		c.Conns[2].Cid < c.Conns[3].Cid {
+		t.Fatalf("Expected conns sorted in descending order by cid, got %v < %v\n", c.Conns[0].Cid, c.Conns[3].Cid)
+	}
+}
+
+func TestConnzSortedByBytesAndMsgs(t *testing.T) {
+	s := runMonitorServer(DEFAULT_HTTP_PORT)
+	defer s.Shutdown()
+
+	// Create a connection and make it send more messages than others
+	firstClient := createClientConnSubscribeAndPublish(t)
+	for i := 0; i < 100; i++ {
+		firstClient.Publish("foo", []byte("Hello World"))
+	}
+	defer firstClient.Close()
+
+	clients := make([]*nats.Conn, 3)
+	for i, _ := range clients {
+		clients[i] = createClientConnSubscribeAndPublish(t)
+		defer clients[i].Close()
+	}
+
+	url := fmt.Sprintf("http://localhost:%d/", DEFAULT_HTTP_PORT)
+	resp, err := http.Get(url + "connz?sort=bytes_to")
+	if err != nil {
+		t.Fatalf("Expected no error: Got %v\n", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected a 200 response, got %d\n", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Got an error reading the body: %v\n", err)
+	}
+
+	c := Connz{}
+	if err := json.Unmarshal(body, &c); err != nil {
+		t.Fatalf("Got an error unmarshalling the body: %v\n", err)
+	}
+
+	if c.Conns[0].OutBytes < c.Conns[1].OutBytes ||
+		c.Conns[0].OutBytes < c.Conns[2].OutBytes ||
+		c.Conns[0].OutBytes < c.Conns[3].OutBytes {
+		t.Fatalf("Expected conns sorted in descending order by bytes from, got %v < one of [%v, %v, %v]\n",
+			c.Conns[0].OutBytes, c.Conns[1].OutBytes, c.Conns[2].OutBytes, c.Conns[3].OutBytes)
+	}
+
+	url = fmt.Sprintf("http://localhost:%d/", DEFAULT_HTTP_PORT)
+	resp, err = http.Get(url + "connz?sort=msgs_to")
+	if err != nil {
+		t.Fatalf("Expected no error: Got %v\n", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected a 200 response, got %d\n", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Got an error reading the body: %v\n", err)
+	}
+
+	c = Connz{}
+	if err := json.Unmarshal(body, &c); err != nil {
+		t.Fatalf("Got an error unmarshalling the body: %v\n", err)
+	}
+
+	if c.Conns[0].OutMsgs < c.Conns[1].OutMsgs ||
+		c.Conns[0].OutMsgs < c.Conns[2].OutMsgs ||
+		c.Conns[0].OutMsgs < c.Conns[3].OutMsgs {
+		t.Fatalf("Expected conns sorted in descending order by msgs from, got %v < one of [%v, %v, %v]\n",
+			c.Conns[0].OutMsgs, c.Conns[1].OutMsgs, c.Conns[2].OutMsgs, c.Conns[3].OutMsgs)
+	}
+
+	url = fmt.Sprintf("http://localhost:%d/", DEFAULT_HTTP_PORT)
+	resp, err = http.Get(url + "connz?sort=bytes_from")
+	if err != nil {
+		t.Fatalf("Expected no error: Got %v\n", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected a 200 response, got %d\n", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Got an error reading the body: %v\n", err)
+	}
+
+	c = Connz{}
+	if err := json.Unmarshal(body, &c); err != nil {
+		t.Fatalf("Got an error unmarshalling the body: %v\n", err)
+	}
+
+	if c.Conns[0].InBytes < c.Conns[1].InBytes ||
+		c.Conns[0].InBytes < c.Conns[2].InBytes ||
+		c.Conns[0].InBytes < c.Conns[3].InBytes {
+		t.Fatalf("Expected conns sorted in descending order by bytes from, got %v < one of [%v, %v, %v]\n",
+			c.Conns[0].InBytes, c.Conns[1].InBytes, c.Conns[2].InBytes, c.Conns[3].InBytes)
+	}
+
+	url = fmt.Sprintf("http://localhost:%d/", DEFAULT_HTTP_PORT)
+	resp, err = http.Get(url + "connz?sort=msgs_from")
+	if err != nil {
+		t.Fatalf("Expected no error: Got %v\n", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected a 200 response, got %d\n", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Got an error reading the body: %v\n", err)
+	}
+
+	c = Connz{}
+	if err := json.Unmarshal(body, &c); err != nil {
+		t.Fatalf("Got an error unmarshalling the body: %v\n", err)
+	}
+
+	if c.Conns[0].InMsgs < c.Conns[1].InMsgs ||
+		c.Conns[0].InMsgs < c.Conns[2].InMsgs ||
+		c.Conns[0].InMsgs < c.Conns[3].InMsgs {
+		t.Fatalf("Expected conns sorted in descending order by msgs from, got %v < one of [%v, %v, %v]\n",
+			c.Conns[0].InMsgs, c.Conns[1].InMsgs, c.Conns[2].InMsgs, c.Conns[3].InMsgs)
+	}
+}
+
+func TestConnzSortedBySubs(t *testing.T) {
+	s := runMonitorServer(DEFAULT_HTTP_PORT)
+	defer s.Shutdown()
+
+	firstClient := createClientConnSubscribeAndPublish(t)
+	firstClient.Subscribe("hello.world", func(m *nats.Msg) {})
+	clients := make([]*nats.Conn, 3)
+	for i, _ := range clients {
+		clients[i] = createClientConnSubscribeAndPublish(t)
+		defer clients[i].Close()
+	}
+	defer firstClient.Close()
+
+	url := fmt.Sprintf("http://localhost:%d/", DEFAULT_HTTP_PORT)
+	resp, err := http.Get(url + "connz?sort=subs")
+	if err != nil {
+		t.Fatalf("Expected no error: Got %v\n", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected a 200 response, got %d\n", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Got an error reading the body: %v\n", err)
+	}
+
+	c := Connz{}
+	if err := json.Unmarshal(body, &c); err != nil {
+		t.Fatalf("Got an error unmarshalling the body: %v\n", err)
+	}
+
+	if c.Conns[0].NumSubs < c.Conns[1].NumSubs ||
+		c.Conns[0].NumSubs < c.Conns[2].NumSubs ||
+		c.Conns[0].NumSubs < c.Conns[3].NumSubs {
+		t.Fatalf("Expected conns sorted in descending order by number of subs, got %v < one of [%v, %v, %v]\n",
+			c.Conns[0].NumSubs, c.Conns[1].NumSubs, c.Conns[2].NumSubs, c.Conns[3].NumSubs)
+	}
+}
+
 func TestConnzWithRoutes(t *testing.T) {
 	s := runMonitorServer(DEFAULT_HTTP_PORT)
 	defer s.Shutdown()


### PR DESCRIPTION
Implements option to sort connz in the server side so that queries to the monitor server like `?limit=1&sort=msgs_from`, return the client from which the server has processed the most messages, rather than what happened to be the first one from the unordered set. /cc @derekcollison 