### PR TITLE
Fix build via docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,5 @@ FROM google/golang:1.4
 MAINTAINER Derek Collison <derek@apcera.com>
 
 RUN CGO_ENABLED=0 go get -a -ldflags '-s' --installsuffix cgo github.com/apcera/gnatsd
-COPY Dockerfile.final /gopath/bin/Dockerfile
 
-CMD docker build -t apcera/gnatsd /gopath/bin
+CMD cp /gopath/bin/gnatsd /tmp/gnatsd_build/. && chmod 777 /tmp/gnatsd_build/

--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -2,7 +2,7 @@ FROM scratch
 
 MAINTAINER Derek Collison <derek@apcera.com>
 
-ADD gnatsd /gnatsd
+ADD gnatsd_build/gnatsd /gnatsd
 
 CMD []
 ENTRYPOINT ["/gnatsd", "-p", "4222", "-m", "8333"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 docker build -t apcera/gnatsd_build .
-docker run -v /var/run/docker.sock:/var/run/docker.sock -v $(which docker):$(which docker) -ti --name gnatsd_build apcera/gnatsd_build
-docker rm gnatsd_build
+docker run --rm=true -v `pwd`/gnatsd_build:/tmp/gnatsd_build \
+       -ti --name gnatsd_build apcera/gnatsd_build
+docker build -f Dockerfile.final -t apcera/gnatsd .
 docker rmi apcera/gnatsd_build
+rm -rf gnatsd_build/


### PR DESCRIPTION
Hi.

Current build with docker in docker cause problems with libraries, like

```
Sending build context to Docker daemon 333.8 kB
Sending build context to Docker daemon
Step 0 : FROM google/golang:1.4
---> c6c6bedccc0a
Step 1 : MAINTAINER Derek Collison <derek@apcera.com>
---> Using cache
---> e02314be67a3
Step 2 : RUN CGO_ENABLED=0 go get -a -ldflags '-s' --installsuffix cgo github.com/apcera/gnatsd
---> Using cache
---> 20f3cf91fea5
Step 3 : COPY Dockerfile.final /gopath/bin/Dockerfile
---> Using cache
---> c1028676d750
Step 4 : CMD docker build -t apcera/gnatsd /gopath/bin
---> Running in fe1c1ef203dd
---> ae350dc3e66b
Removing intermediate container fe1c1ef203dd
Successfully built ae350dc3e66b
docker: error while loading shared libraries: libdevmapper.so.1.02: cannot open shared object file: No such file or directory
gnatsd_build
Untagged: apcera/gnatsd_build:latest
Deleted: ae350dc3e66bda138a27485a052ef0193bbf745bbbbf2e3c9252a8f2b3dce2ae
```
It can be fixed by passing all library deps into build container, but require lot of changes, so there is more simpler solution to build:

1) build gnatsd and put it to `./gnatsd_build` directory
2) create `apcera/gnatsd` image	with build from point 1
3) remove `gnatsd_build` directory
