### PR TITLE
Fix off-by-one in matchLiteral

### DIFF
--- a/sublist/sublist.go
+++ b/sublist/sublist.go
@@ -193,7 +193,6 @@ func (s *Sublist) removeFromCache(subject []byte, sub interface{}) {
 // slice of results.
 func (s *Sublist) Match(subject []byte) []interface{} {
 	// Fastpath match on cache
-
 	s.mu.RLock()
 	atomic.AddUint64(&s.stats.matches, 1)
 	r := s.cache.Get(subject)
@@ -426,7 +425,7 @@ func matchLiteral(literal, subject []byte) bool {
 		li += 1
 	}
 	// Make sure we have processed all of the literal's chars..
-	if li < (ll - 1) {
+	if li < ll {
 		return false
 	}
 	return true

--- a/sublist/sublist_test.go
+++ b/sublist/sublist_test.go
@@ -250,6 +250,8 @@ func TestMatchLiterals(t *testing.T) {
 	checkBool(matchLiteral([]byte("stats.test.22"), []byte("stats.>")), true, t)
 	checkBool(matchLiteral([]byte("stats.test.22"), []byte("stats.*.*")), true, t)
 	checkBool(matchLiteral([]byte("foo.bar"), []byte("foo")), false, t)
+	checkBool(matchLiteral([]byte("stats.test.foos"), []byte("stats.test.foos")), true, t)
+	checkBool(matchLiteral([]byte("stats.test.foos"), []byte("stats.test.foo")), false, t)
 }
 
 func TestCacheBounds(t *testing.T) {


### PR DESCRIPTION
Could be the reason why messages would sometimes get delivered to the
wrong subscription, as matching would not differentiatie between
'foo.bar' and 'foo.bars'.