### PR TITLE
Compile cleanly on FreeBSD, using the Windows approach to `procUsage`

### DIFF
--- a/server/pse_freebsd.go
+++ b/server/pse_freebsd.go
@@ -1,0 +1,12 @@
+// Copyright 2015 Apcera Inc. All rights reserved.
+
+package server
+
+// This is a placeholder for now.
+func procUsage(pcpu *float64, rss, vss *int64) error {
+	*pcpu = 0.0
+	*rss = 0
+	*vss = 0
+
+	return nil
+}


### PR DESCRIPTION
This file is required to build against FreeBSD.

Tested on FreeBSD 10.1, Go versions 1.4.2 and 1.5.