### PR TITLE
Expose name label from client in connz

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -42,6 +42,7 @@ type ConnInfo struct {
 	InBytes  int64    `json:"in_bytes"`
 	OutBytes int64    `json:"out_bytes"`
 	NumSubs  uint32   `json:"subscriptions"`
+	Name     string   `json:"name,omitempty"`
 	Lang     string   `json:"lang,omitempty"`
 	Version  string   `json:"version,omitempty"`
 	Subs     []string `json:"subscriptions_list,omitempty"`
@@ -121,6 +122,7 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 			OutBytes: client.outBytes,
 			NumSubs:  client.subs.Count(),
 			Pending:  client.bw.Buffered(),
+			Name:     client.opts.Name,
 			Lang:     client.opts.Lang,
 			Version:  client.opts.Version,
 		}


### PR DESCRIPTION
Clients can optionally set a name label on `CONNECT`.  This just exposes the name set by the client so that it can be polled from the `/connz` endpoint.

```
curl http://127.0.0.1:8222/connz

{
  "now": "2015-11-01T17:57:12.340117801-08:00",
  "num_connections": 1,
  "offset": 0,
  "limit": 1024,
  "connections": [
    {
      "cid": 2,
      "ip": "127.0.0.1",
      "port": 53528,
      "pending_bytes": 0,
      "in_msgs": 0,
      "out_msgs": 0,
      "in_bytes": 0,
      "out_bytes": 0,
      "subscriptions": 0,
      "name": "sample"
    }
  ]
}
```
