### PR TITLE
Added basic support for illumos/Solaris

### DIFF
--- a/server/pse_solaris.go
+++ b/server/pse_solaris.go
@@ -1,0 +1,12 @@
+// Copyright 2015 Apcera Inc. All rights reserved.
+
+package server
+
+// This is a placeholder for now.
+func procUsage(pcpu *float64, rss, vss *int64) error {
+	*pcpu = 0.0
+	*rss = 0
+	*vss = 0
+
+	return nil
+}


### PR DESCRIPTION
Please review, it's only basic (same as freebsd) so to be able to compile on illumos and run on illumos.