### PR TITLE
Fix possible non-propagation of subscription interest to routed server.

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -50,7 +50,8 @@ type client struct {
 	parseState
 	stats
 
-	route *route
+	route         *route
+	sendLocalSubs bool
 }
 
 func (c *client) String() (id string) {


### PR DESCRIPTION
Fix for #138.

If processRoute executes before createRoute finishes registering the route, and before a subscriber has connected (or reconnected), and the subscriber connects (or reconnects) before the route is registered, then this subscription will stay local and not be forwarded to the route.

@derekcollison @olegshaldybin : Oleg, I think that this is the root cause for the un-explained timeouts on Bagel that only a restart of the component would solve.