### PR TITLE
Fix races, add a test and adjust others.

### DIFF
--- a/test/proto_test.go
+++ b/test/proto_test.go
@@ -72,6 +72,9 @@ func TestUnsubMax(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		send("PUB foo 2\r\nok\r\n")
 	}
+
+	time.Sleep(50 * time.Millisecond)
+
 	matches := expectMsgs(2)
 	checkMsg(t, matches[0], "foo", "22", "", "2", "ok")
 	checkMsg(t, matches[1], "foo", "22", "", "2", "ok")


### PR DESCRIPTION
* There was a race during unsubscribe()
* 'go test -race' reports a race in TestSetLogger test. This one could be ignored since we normally invoke SetLogger only on server startup. That being said, Travis failed when I tried to submit a PR for the fix of the unsubscribe race. So proposing to fix the logger too.