### PR TITLE
TLS strict route verifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Authorization Options:
         --user user                  User required for connections
         --pass password              Password required for connections
 
+TLS Options:
+        --tls                        Enable TLS, do not verify clients (default: false)
+        --tlscert FILE               Server certificate file
+        --tlskey FILE                Private key for server certificate
+        --tlsverify                  Enable TLS, very client certificates
+        --tlscacert client           Client certificate CA for verification
+
 Cluster Options:
         --routes [rurl-1, rurl-2]    Routes to solicit and connect
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -188,6 +188,11 @@ func parseCluster(cm map[string]interface{}, opts *Options) error {
 			if opts.ClusterTLSConfig, err = GenTLSConfig(tc); err != nil {
 				return err
 			}
+			// For clusters, we will force strict verification. We also act
+			// as both client and server, so will mirror the rootCA to the
+			// clientCA pool.
+			opts.ClusterTLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
+			opts.ClusterTLSConfig.ClientCAs = opts.ClusterTLSConfig.RootCAs
 			opts.ClusterTLSTimeout = tc.Timeout
 		}
 	}


### PR DESCRIPTION
We make sure to require client certs and verify them when connecting routes.