### PR TITLE
Avoid `cap out of range` error when handling split buffer

### DIFF
--- a/server/parser.go
+++ b/server/parser.go
@@ -663,7 +663,7 @@ parseErr:
 func protoSnippet(start int, buf []byte) string {
 	stop := start + PROTO_SNIPPET_SIZE
 	bufSize := len(buf)
-	if start == bufSize {
+	if start <= bufSize {
 		return ""
 	}
 	if stop > bufSize {


### PR DESCRIPTION
Found a corner case when a client can send corrupted PUB payloads and cause the server to panic.  Added a patch to detect this case disconnecting the client with protocol error to avoid server crashing.
/cc @derekcollison @kozlovic

```
panic: runtime error: makeslice: cap out of range

goroutine 51 [running]:
github.com/nats-io/gnatsd/server.(*client).parse(0xc208ffe000, 0xc208a28000, 0x8000, 0x8000, 0x0, 0x0)
        /home/vagrant/go/src/github.com/nats-io/gnatsd/server/parser.go:634 +0x2c6
github.com/nats-io/gnatsd/server.(*client).readLoop(0xc208ffe000)
        /home/vagrant/go/src/github.com/nats-io/gnatsd/server/client.go:156 +0x1b9
created by github.com/nats-io/gnatsd/server.(*client).initClient
        /home/vagrant/go/src/github.com/nats-io/gnatsd/server/client.go:133 +0x5fc

goroutine 1 [IO wait]:
net.(*pollDesc).Wait(0xc2080104c0, 0x72, 0x0, 0x0)
        /usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc2080104c0, 0x0, 0x0)
        /usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).accept(0xc208010460, 0x0, 0x7f3d7983dd30, 0xc2080de158)
        /usr/local/go/src/net/fd_unix.go:419 +0x40b
net.(*TCPListener).AcceptTCP(0xc20803a0b8, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/tcpsock_posix.go:234 +0x4e
net.(*TCPListener).Accept(0xc20803a0b8, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/tcpsock_posix.go:244 +0x4c
github.com/nats-io/gnatsd/server.(*Server).AcceptLoop(0xc208036820)
        /home/vagrant/go/src/github.com/nats-io/gnatsd/server/server.go:317 +0xaa5
github.com/nats-io/gnatsd/server.(*Server).Start(0xc208036820)
        /home/vagrant/go/src/github.com/nats-io/gnatsd/server/server.go:215 +0x18d
main.main()
        /home/vagrant/go/src/github.com/nats-io/gnatsd/gnatsd.go:111 +0xd65

goroutine 7 [chan receive, 32 minutes]:
github.com/nats-io/gnatsd/server.func·007()
        /home/vagrant/go/src/github.com/nats-io/gnatsd/server/server.go:164 +0x5c
created by github.com/nats-io/gnatsd/server.(*Server).handleSignals
        /home/vagrant/go/src/github.com/nats-io/gnatsd/server/server.go:170 +0x15f

goroutine 6 [syscall, 32 minutes]:
os/signal.loop()
        /usr/local/go/src/os/signal/signal_unix.go:21 +0x1f
created by os/signal.init·1
        /usr/local/go/src/os/signal/signal_unix.go:27 +0x35

goroutine 8 [IO wait, 31 minutes]:
net.(*pollDesc).Wait(0xc208010450, 0x72, 0x0, 0x0)
        /usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc208010450, 0x0, 0x0)
        /usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).accept(0xc2080103f0, 0x0, 0x7f3d7983dd30, 0xc2080de170)
        /usr/local/go/src/net/fd_unix.go:419 +0x40b  
net.(*TCPListener).AcceptTCP(0xc20803a0a8, 0xc208017e98, 0x0, 0x0)
        /usr/local/go/src/net/tcpsock_posix.go:234 +0x4e
net.(*TCPListener).Accept(0xc20803a0a8, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/tcpsock_posix.go:244 +0x4c
net/http.(*Server).Serve(0xc208042360, 0x7f3d7983e598, 0xc20803a0a8, 0x0, 0x0)
        /usr/local/go/src/net/http/server.go:1728 +0x92
github.com/nats-io/gnatsd/server.func·009()
        /home/vagrant/go/src/github.com/nats-io/gnatsd/server/server.go:391 +0x54
created by github.com/nats-io/gnatsd/server.(*Server).StartHTTPMonitoring
        /home/vagrant/go/src/github.com/nats-io/gnatsd/server/server.go:394 +0x864

goroutine 12 [runnable]:
net.(*pollDesc).Wait(0xc208010370, 0x72, 0x0, 0x0)   
        /usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc208010370, 0x0, 0x0)
        /usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).Read(0xc208010310, 0xc208083000, 0x1000, 0x1000, 0x0, 0x7f3d7983dd30, 0xc2080de0e0)
        /usr/local/go/src/net/fd_unix.go:242 +0x40f  
net.(*conn).Read(0xc20803a048, 0xc208083000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/net.go:121 +0xdc
net/http.(*liveSwitchReader).Read(0xc208044048, 0xc208083000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/http/server.go:214 +0xab
io.(*LimitedReader).Read(0xc208f632a0, 0xc208083000, 0x1000, 0x1000, 0x89baa0, 0x0, 0x0)
        /usr/local/go/src/io/io.go:408 +0xce
bufio.(*Reader).fill(0xc2080423c0)
        /usr/local/go/src/bufio/bufio.go:97 +0x1ce   
bufio.(*Reader).ReadSlice(0xc2080423c0, 0xc20805e90a, 0x0, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/bufio/bufio.go:295 +0x257  
bufio.(*Reader).ReadLine(0xc2080423c0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/bufio/bufio.go:324 +0x62   
net/textproto.(*Reader).readLineSlice(0xc2086ca180, 0x0, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/textproto/reader.go:55 +0x9e
net/textproto.(*Reader).ReadLine(0xc2086ca180, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/textproto/reader.go:36 +0x4f
net/http.ReadRequest(0xc2080423c0, 0xc208ff00d0, 0x0, 0x0)
        /usr/local/go/src/net/http/request.go:598 +0xcb
net/http.(*conn).readRequest(0xc208044000, 0x0, 0x0, 0x0)
        /usr/local/go/src/net/http/server.go:586 +0x26f
net/http.(*conn).serve(0xc208044000)
        /usr/local/go/src/net/http/server.go:1162 +0x69e
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:1751 +0x35e

```