### PR TITLE
Add --cluster_listen flag to set cluster addr and port

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -9,12 +9,12 @@ import (
 	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/nats-io/gnatsd/conf"
-	"os"
 )
 
 // Options block for gnatsd server.
@@ -44,6 +44,7 @@ type Options struct {
 	ClusterAuthTimeout float64       `json:"auth_timeout"`
 	ClusterTLSTimeout  float64       `json:"-"`
 	ClusterTLSConfig   *tls.Config   `json:"-"`
+	ClusterListenStr   string        `json:"-"`
 	ProfPort           int           `json:"-"`
 	PidFile            string        `json:"-"`
 	LogFile            string        `json:"-"`


### PR DESCRIPTION
This allows to set cluster addr and port as a url in the command line, would be useful to be able to set via flag in some scenarios.