### PR TITLE
Bcrypt Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ language: go
 go:
 - 1.5
 install:
-- DST=~/gopath/src/github.com/nats-io
-- mkdir -p "$DST"
-- git clone --depth=1 --quiet https://github.com/nats-io/nats.git "$DST"/nats
+- go get github.com/nats-io/nats
+- go get golang.org/x/crypto/bcrypt
 - go get golang.org/x/tools/cmd/vet
 - go get golang.org/x/tools/cmd/cover
 - go get github.com/mattn/goveralls
-- go get golang.org/x/crypto/bcrypt
 
 script:
 - go build

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ install:
 - go get golang.org/x/tools/cmd/vet
 - go get golang.org/x/tools/cmd/cover
 - go get github.com/mattn/goveralls
+- go get golang.org/x/crypto/bcrypt
+
 script:
 - go build
 - ./travis/gofmt.sh

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,6 @@
 
 # General
 
-- [ ] SSL/TLS support
-- [ ] Better user/pass support using bcrypt etc.
 - [ ] Pedantic state
 - [ ] brew, apt-get, rpm, chocately (windows)
 - [ ] Dynamic socket buffer sizes
@@ -19,6 +17,8 @@
 - [ ] Info updates contain other implicit route servers
 - [ ] Multi-tenant accounts with isolation of subject space
 - [ ] Add to varz, time for slow consumers, peek connections, memory, etc.
+- [X] Better user/pass support using bcrypt etc.
+- [X] SSL/TLS support
 - [X] Add support for / to point to varz, connz, etc..
 - [X] Support sort options for /connz via nats-top
 - [X] Dropped message statistics (slow consumers)

--- a/auth/plain.go
+++ b/auth/plain.go
@@ -1,8 +1,19 @@
+// Copyright 2014-2015 Apcera Inc. All rights reserved.
+
 package auth
 
 import (
+	"strings"
+
 	"github.com/nats-io/gnatsd/server"
+	"golang.org/x/crypto/bcrypt"
 )
+
+const BcryptPrefix = "$2a$"
+
+func isBcrypt(password string) bool {
+	return strings.HasPrefix(password, BcryptPrefix)
+}
 
 type Plain struct {
 	Username string
@@ -11,7 +22,15 @@ type Plain struct {
 
 func (p *Plain) Check(c server.ClientAuth) bool {
 	opts := c.GetOpts()
-	if p.Username != opts.Username || p.Password != opts.Password {
+	if p.Username != opts.Username {
+		return false
+	}
+	// Check to see if the password is a bcrypt hash
+	if isBcrypt(p.Password) {
+		if err := bcrypt.CompareHashAndPassword([]byte(p.Password), []byte(opts.Password)); err != nil {
+			return false
+		}
+	} else if p.Password != opts.Password {
 		return false
 	}
 

--- a/auth/token.go
+++ b/auth/token.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"github.com/nats-io/gnatsd/server"
+	"golang.org/x/crypto/bcrypt"
 )
 
 type Token struct {
@@ -10,7 +11,12 @@ type Token struct {
 
 func (p *Token) Check(c server.ClientAuth) bool {
 	opts := c.GetOpts()
-	if p.Token != opts.Authorization {
+	// Check to see if the token is a bcrypt hash
+	if isBcrypt(p.Token) {
+		if err := bcrypt.CompareHashAndPassword([]byte(p.Token), []byte(opts.Authorization)); err != nil {
+			return false
+		}
+	} else if p.Token != opts.Authorization {
 		return false
 	}
 

--- a/server/client.go
+++ b/server/client.go
@@ -247,7 +247,9 @@ func (c *client) processConnect(arg []byte) error {
 
 	// This will be resolved regardless before we exit this func,
 	// so we can just clear it here.
+	c.mu.Lock()
 	c.clearAuthTimer()
+	c.mu.Unlock()
 
 	if err := json.Unmarshal(arg, &c.opts); err != nil {
 		return err

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -297,9 +297,15 @@ func myUptime(d time.Duration) string {
 // HandleRoot will show basic info and links to others handlers.
 func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, `<html lang="en">
+        <head>
+        <style type="text/css">
+        body { font-family: “Century Gothic”, CenturyGothic, AppleGothic, sans-serif; }
+        a { margin-left: 32px; }
+        </style>
+        </head>
 		<body>
-			gnatsd monitoring
-			<br/><br/>
+            <img src="http://nats.io/img/logo.png" alt="NATS">
+			<br/>
 			<a href=http://%s/varz>http://%s/varz</a><br/>
 			<a href=http://%s/connz>http://%s/connz</a><br/>
 			<a href=http://%s/routez>http://%s/routez</a><br/>

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -156,3 +156,75 @@ func TestPasswordClientGoodConnect(t *testing.T) {
 	doAuthConnect(t, c, "", AUTH_USER, AUTH_PASS)
 	expectResult(t, c, okRe)
 }
+
+////////////////////////////////////////////////////////////
+// The bcrypt username/password version
+////////////////////////////////////////////////////////////
+
+// Generated with util/mkpasswd
+const BCRYPT_AUTH_PASS = "#00L2zPr!j11VsT@e9QGPt"
+const BCRYPT_AUTH_HASH = "$2a$11$wDaOBnEx0GbcFTOzJRywpexI/dxH3sqV3.adFefmDDMJggnOTNqKS"
+
+func runAuthServerWithBcryptUserPass() *server.Server {
+	opts := DefaultTestOptions
+	opts.Port = AUTH_PORT
+	opts.Username = AUTH_USER
+	opts.Password = BCRYPT_AUTH_HASH
+
+	auth := &auth.Plain{Username: AUTH_USER, Password: BCRYPT_AUTH_HASH}
+	return RunServerWithAuth(&opts, auth)
+}
+
+func TestBadBcryptPassword(t *testing.T) {
+	s := runAuthServerWithBcryptUserPass()
+	defer s.Shutdown()
+	c := createClientConn(t, "localhost", AUTH_PORT)
+	defer c.Close()
+	expectAuthRequired(t, c)
+	doAuthConnect(t, c, "", AUTH_USER, BCRYPT_AUTH_HASH)
+	expectResult(t, c, errRe)
+}
+
+func TestGoodBcryptPassword(t *testing.T) {
+	s := runAuthServerWithBcryptUserPass()
+	defer s.Shutdown()
+	c := createClientConn(t, "localhost", AUTH_PORT)
+	defer c.Close()
+	expectAuthRequired(t, c)
+	doAuthConnect(t, c, "", AUTH_USER, BCRYPT_AUTH_PASS)
+	expectResult(t, c, okRe)
+}
+
+////////////////////////////////////////////////////////////
+// The bcrypt authorization token version
+////////////////////////////////////////////////////////////
+
+const BCRYPT_AUTH_TOKEN = "743&@WeTlIwtHDytI5Bnxl"
+const BCRYPT_AUTH_TOKEN_HASH = "$2a$11$Gp5x2rvdzfm9rUREuyQeBOFd61oPYKoLWSI2fJN7DAFMF34Z9o4s2"
+
+func runAuthServerWithBcryptToken() *server.Server {
+	opts := DefaultTestOptions
+	opts.Port = AUTH_PORT
+	opts.Authorization = BCRYPT_AUTH_TOKEN_HASH
+	return RunServerWithAuth(&opts, &auth.Token{Token: BCRYPT_AUTH_TOKEN_HASH})
+}
+
+func TestBadBcryptToken(t *testing.T) {
+	s := runAuthServerWithBcryptToken()
+	defer s.Shutdown()
+	c := createClientConn(t, "localhost", AUTH_PORT)
+	defer c.Close()
+	expectAuthRequired(t, c)
+	doAuthConnect(t, c, BCRYPT_AUTH_TOKEN_HASH, "", "")
+	expectResult(t, c, errRe)
+}
+
+func TestGoodBcryptToken(t *testing.T) {
+	s := runAuthServerWithBcryptToken()
+	defer s.Shutdown()
+	c := createClientConn(t, "localhost", AUTH_PORT)
+	defer c.Close()
+	expectAuthRequired(t, c)
+	doAuthConnect(t, c, BCRYPT_AUTH_TOKEN, "", "")
+	expectResult(t, c, okRe)
+}

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -161,9 +161,9 @@ func TestPasswordClientGoodConnect(t *testing.T) {
 // The bcrypt username/password version
 ////////////////////////////////////////////////////////////
 
-// Generated with util/mkpasswd
-const BCRYPT_AUTH_PASS = "#00L2zPr!j11VsT@e9QGPt"
-const BCRYPT_AUTH_HASH = "$2a$11$wDaOBnEx0GbcFTOzJRywpexI/dxH3sqV3.adFefmDDMJggnOTNqKS"
+// Generated with util/mkpasswd (Cost 4 because of cost of --race, default is 11)
+const BCRYPT_AUTH_PASS = "IW@$6v(y1(t@fhPDvf!5^%"
+const BCRYPT_AUTH_HASH = "$2a$04$Q.CgCP2Sl9pkcTXEZHazaeMwPaAkSHk7AI51HkyMt5iJQQyUA4qxq"
 
 func runAuthServerWithBcryptUserPass() *server.Server {
 	opts := DefaultTestOptions
@@ -199,8 +199,8 @@ func TestGoodBcryptPassword(t *testing.T) {
 // The bcrypt authorization token version
 ////////////////////////////////////////////////////////////
 
-const BCRYPT_AUTH_TOKEN = "743&@WeTlIwtHDytI5Bnxl"
-const BCRYPT_AUTH_TOKEN_HASH = "$2a$11$Gp5x2rvdzfm9rUREuyQeBOFd61oPYKoLWSI2fJN7DAFMF34Z9o4s2"
+const BCRYPT_AUTH_TOKEN = "0uhJOSr3GW7xvHvtd^K6pa"
+const BCRYPT_AUTH_TOKEN_HASH = "$2a$04$u5ZClXpcjHgpfc61Ee0VKuwI1K3vTC4zq7SjphjnlHMeb1Llkb5Y6"
 
 func runAuthServerWithBcryptToken() *server.Server {
 	opts := DefaultTestOptions

--- a/test/gosrv_test.go
+++ b/test/gosrv_test.go
@@ -27,7 +27,7 @@ func TestGoServerShutdownWithClients(t *testing.T) {
 	}
 	s.Shutdown()
 	// Wait longer for client connections
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	delta := (runtime.NumGoroutine() - base)
 	// There may be some finalizers or IO, but in general more than
 	// 2 as a delta represents a problem.

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -272,9 +272,9 @@ func TestRouteQueueSemantics(t *testing.T) {
 	expectMsgs := expectMsgsCommand(t, routeExpect)
 
 	// Express multiple interest on this route for foo, queue group bar.
-	qrsid1 := "RSID:2:1"
+	qrsid1 := "QRSID:2:1"
 	routeSend(fmt.Sprintf("SUB foo bar %s\r\n", qrsid1))
-	qrsid2 := "RSID:2:2"
+	qrsid2 := "QRSID:2:2"
 	routeSend(fmt.Sprintf("SUB foo bar %s\r\n", qrsid2))
 
 	// Use ping roundtrip to make sure its processed.
@@ -341,6 +341,7 @@ func TestRouteQueueSemantics(t *testing.T) {
 
 	// Should be 2 now, 1 for all normal, and one for specific queue subscriber.
 	matches = clientExpectMsgs(2)
+
 	// Expect first to be the normal subscriber, next will be the queue one.
 	checkMsg(t, matches[0], "foo", "1", "", "2", "ok")
 	checkMsg(t, matches[1], "foo", "2", "", "2", "ok")

--- a/travis/coveralls-script.sh
+++ b/travis/coveralls-script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 echo "mode: count" > acc.out
-for Dir in $(find ./* -maxdepth 10 -type d | grep -v test);
+for Dir in $(find ./* -maxdepth 10 -type d | grep -v test | grep -v util);
 do
         if ls $Dir/*.go &> /dev/null;
         then

--- a/util/mkpasswd.go
+++ b/util/mkpasswd.go
@@ -1,0 +1,76 @@
+// Copyright 2015 Apcera Inc. All rights reserved.
+// +build ignore
+
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"flag"
+	"fmt"
+	"log"
+	"math/big"
+
+	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func usage() {
+	log.Fatalf("Usage: mkpasswd -p <stdin password> \n")
+}
+
+const (
+	PasswordLength = 22
+	Cost           = 11
+)
+
+func main() {
+	var pw = flag.Bool("p", false, "Input password via stdin")
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	var password string
+
+	if *pw {
+		fmt.Printf("Enter Password: ")
+		bytePassword, _ := terminal.ReadPassword(0)
+		fmt.Printf("\nReenter Password: ")
+		bytePassword2, _ := terminal.ReadPassword(0)
+		if !bytes.Equal(bytePassword, bytePassword2) {
+			log.Fatalf("Error, passwords do not match\n")
+		}
+		password = string(bytePassword)
+	}
+
+	if password == "" {
+		password = genPassword()
+	}
+
+	if *pw {
+		fmt.Printf("\n")
+	} else {
+		fmt.Printf("pass: %s\n", password)
+	}
+
+	cb, err := bcrypt.GenerateFromPassword([]byte(password), Cost)
+	if err != nil {
+		log.Fatalf("Error producing bcrypt hash: %v\n", err)
+	}
+	fmt.Printf("bcrypt hash: %s\n", cb)
+}
+
+func genPassword() string {
+	var ch = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@$#%^&*()")
+	b := make([]byte, PasswordLength)
+	max := big.NewInt(int64(len(ch)))
+	for i := range b {
+		ri, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			log.Fatalf("Error producing random integer: %v\n", err)
+		}
+		b[i] = ch[int(ri.Int64())]
+	}
+	return string(b)
+}

--- a/util/mkpasswd.go
+++ b/util/mkpasswd.go
@@ -42,15 +42,9 @@ func main() {
 			log.Fatalf("Error, passwords do not match\n")
 		}
 		password = string(bytePassword)
-	}
-
-	if password == "" {
-		password = genPassword()
-	}
-
-	if *pw {
 		fmt.Printf("\n")
 	} else {
+		password = genPassword()
 		fmt.Printf("pass: %s\n", password)
 	}
 

--- a/util/mkpasswd.go
+++ b/util/mkpasswd.go
@@ -16,18 +16,21 @@ import (
 )
 
 func usage() {
-	log.Fatalf("Usage: mkpasswd -p <stdin password> \n")
+	log.Fatalf("Usage: mkpasswd [-p <stdin password>] [-c COST] \n")
 }
 
 const (
-	// Make sure password reasonably long to generate enough entropy
+	// Make sure the password is reasonably long to generate enough entropy.
 	PasswordLength = 22
-	// Make cost reasonably expensive, min is 4, max is 31
-	Cost = 11
+	// Common advice from the past couple of years suggests that 10 should be sufficient.
+	// Up that a little, to 11. Feel free to raise this higher if this value from 2015 is
+	// no longer appropriate. Min is 4, Max is 31.
+	DefaultCost = 11
 )
 
 func main() {
 	var pw = flag.Bool("p", false, "Input password via stdin")
+	var cost = flag.Int("c", DefaultCost, "The cost weight, range of 4-31 (11)")
 
 	log.SetFlags(0)
 	flag.Usage = usage
@@ -50,7 +53,7 @@ func main() {
 		fmt.Printf("pass: %s\n", password)
 	}
 
-	cb, err := bcrypt.GenerateFromPassword([]byte(password), Cost)
+	cb, err := bcrypt.GenerateFromPassword([]byte(password), *cost)
 	if err != nil {
 		log.Fatalf("Error producing bcrypt hash: %v\n", err)
 	}

--- a/util/mkpasswd.go
+++ b/util/mkpasswd.go
@@ -20,8 +20,10 @@ func usage() {
 }
 
 const (
+	// Make sure password reasonably long to generate enough entropy
 	PasswordLength = 22
-	Cost           = 11
+	// Make cost reasonably expensive, min is 4, max is 31
+	Cost = 11
 )
 
 func main() {


### PR DESCRIPTION
This adds support for bcrypt hashes instead of passwords or tokens in configurations. Also added a utility to generate strong passwords/tokens and the associated bcrypt hash which can be used in the config files.

/cc @philpennock @eftychis