### PR TITLE
Increase TLS timeout in config files

### DIFF
--- a/server/configs/tls.conf
+++ b/server/configs/tls.conf
@@ -7,7 +7,7 @@ net: apcera.me # net interface
 tls {
   cert_file:  "./configs/certs/server.pem"
   key_file:   "./configs/certs/key.pem"
-  timeout:    0.5
+  timeout:    2
 }
 
 authorization {

--- a/server/configs/tls_bad_cipher.conf
+++ b/server/configs/tls_bad_cipher.conf
@@ -7,6 +7,7 @@ net: apcera.me # net interface
 tls {
   cert_file:  "./configs/certs/server.pem"
   key_file:   "./configs/certs/key.pem"
+  timeout: 2
 
   # this should generate an error
   cipher_suites: [

--- a/server/configs/tls_ciphers.conf
+++ b/server/configs/tls_ciphers.conf
@@ -7,6 +7,7 @@ net: apcera.me # net interface
 tls {
   cert_file:  "./configs/certs/server.pem"
   key_file:   "./configs/certs/key.pem"
+  timeout: 2
   cipher_suites: [
 	"TLS_RSA_WITH_RC4_128_SHA",
 	"TLS_RSA_WITH_3DES_EDE_CBC_SHA",

--- a/server/configs/tls_empty_cipher.conf
+++ b/server/configs/tls_empty_cipher.conf
@@ -7,6 +7,7 @@ net: apcera.me # net interface
 tls {
   cert_file:  "./configs/certs/server.pem"
   key_file:   "./configs/certs/key.pem"
+  timeout: 2
 
   # this should generate an error
   cipher_suites: [

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -86,7 +86,7 @@ func TestTLSConfigFile(t *testing.T) {
 		Username:    "derek",
 		Password:    "buckley",
 		AuthTimeout: 1.0,
-		TLSTimeout:  0.5,
+		TLSTimeout:  2.0,
 	}
 	opts, err := ProcessConfigFile("./configs/tls.conf")
 	if err != nil {

--- a/test/configs/srv_a_tls.conf
+++ b/test/configs/srv_a_tls.conf
@@ -13,6 +13,8 @@ cluster {
     cert_file: "./configs/certs/srva-cert.pem"
     # Private key
     key_file:  "./configs/certs/srva-key.pem"
+    # Specified time for handshake to complete
+    timeout: 2
 
     # Optional certificate authority verifying connected routes
     # Required when we have self-signed CA, etc.

--- a/test/configs/srv_b_tls.conf
+++ b/test/configs/srv_b_tls.conf
@@ -13,6 +13,8 @@ cluster {
     cert_file: "./configs/certs/srvb-cert.pem"
     # Private key
     key_file:  "./configs/certs/srvb-key.pem"
+    # Specified time for handshake to complete
+    timeout: 2
 
     # Optional certificate authority verifying connected routes
     # Required when we have self-signed CA, etc.

--- a/test/configs/tls.conf
+++ b/test/configs/tls.conf
@@ -10,7 +10,7 @@ tls {
   # Server private key
   key_file:  "./configs/certs/server-key.pem"
   # Specified time for handshake to complete
-  timeout: 0.25
+  timeout: 2
 }
 
 authorization {

--- a/test/configs/tlsverify.conf
+++ b/test/configs/tlsverify.conf
@@ -9,6 +9,8 @@ tls {
   cert_file: "./configs/certs/server-cert.pem"
   # Server private key
   key_file:  "./configs/certs/server-key.pem"
+  # Specified time for handshake to complete
+  timeout: 2
   # Optional certificate authority for clients
   ca_file:   "./configs/certs/ca.pem"
   # Require a client certificate

--- a/test/test.go
+++ b/test/test.go
@@ -48,12 +48,17 @@ func RunServer(opts *server.Options) *server.Server {
 	return RunServerWithAuth(opts, nil)
 }
 
-func RunServerWithConfig(configFile string) (srv *server.Server, opts *server.Options) {
+func LoadConfig(configFile string) (opts *server.Options) {
 	opts, err := server.ProcessConfigFile(configFile)
 	if err != nil {
 		panic(fmt.Sprintf("Error processing configuration file: %v", err))
 	}
 	opts.NoSigs, opts.NoLog = true, true
+	return
+}
+
+func RunServerWithConfig(configFile string) (srv *server.Server, opts *server.Options) {
+	opts = LoadConfig(configFile)
 
 	// Check for auth
 	var a server.Auth

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -131,7 +131,10 @@ func TestTLSClientCertificate(t *testing.T) {
 }
 
 func TestTLSConnectionTimeout(t *testing.T) {
-	srv, opts := RunServerWithConfig("./configs/tls.conf")
+	opts := LoadConfig("./configs/tls.conf")
+	opts.TLSTimeout = 0.25
+
+	srv := RunServer(opts)
 	defer srv.Shutdown()
 
 	// Dial with normal TCP


### PR DESCRIPTION
We would get failures on Travis, I would think because of small TLS timeout. Increase (or set) the TLS timeout to 2 seconds in most configuration files. Update tests that relied on the original value.