### PR TITLE
Adapt tests for Travis GCE.

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -33,13 +33,13 @@ func RunServer(opts *Options) *Server {
 
 	end := time.Now().Add(10 * time.Second)
 	for time.Now().Before(end) {
-		addr := s.Addr()
-		if addr == nil {
+		addr := s.GetListenEndpoint()
+		if addr == "" {
 			time.Sleep(10 * time.Millisecond)
 			// Retry. We might take a little while to open a connection.
 			continue
 		}
-		conn, err := net.Dial("tcp", addr.String())
+		conn, err := net.Dial("tcp", addr)
 		if err != nil {
 			// Retry after 50ms
 			time.Sleep(50 * time.Millisecond)

--- a/test/test.go
+++ b/test/test.go
@@ -91,13 +91,13 @@ func RunServerWithAuth(opts *server.Options, auth server.Auth) *server.Server {
 
 	end := time.Now().Add(10 * time.Second)
 	for time.Now().Before(end) {
-		addr := s.Addr()
-		if addr == nil {
+		addr := s.GetListenEndpoint()
+		if addr == "" {
 			time.Sleep(50 * time.Millisecond)
 			// Retry. We might take a little while to open a connection.
 			continue
 		}
-		conn, err := net.Dial("tcp", addr.String())
+		conn, err := net.Dial("tcp", addr)
 		if err != nil {
 			// Retry after 50ms
 			time.Sleep(50 * time.Millisecond)


### PR DESCRIPTION
* Add server.GetListenEndpoint() to return options' host and port when server is ready to accept client connections. The server can be asked to pick a random port. This function returns a string of the form "host:port" with the port selected by the net.Listen() call.
* Replace the use of server.Addr() with above function to connect to the starting server (using net.Dial) to check for success. The original issue was that, when no hostname is specified in the configuration, the server uses 0.0.0.0 for the listen address. However, server.Addr() would return "[::]", even on a machine with IPv6 disabled, which would cause the net.Dial call to fail with "network unreachable".