### PR TITLE
Make clientcert on cluster connection optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,10 @@ tls {
 }
 ```
 
-When setting up clusters, all servers in the cluster, if using TLS, will both verify the connecting endpoints and the server responses. So certificates are checked in
-both directions. Certificates can be configured only for the server's cluster identity, keeping client and server certificates separate from cluster formation.
+When setting up clusters, all servers in the cluster, if using TLS, will by default both verify the connecting endpoints and the server responses.
+That means certificates will be checked in both directions.
+If this is undesirable, you can set `verify: false` similarly to the example above, in which case no client certificate will be required and authentication relies purely on the configured cluster username/password.
+Certificates can be configured only for the server's cluster identity, keeping client and server certificates separate from cluster formation.
 
 ```
 cluster {

--- a/server/route.go
+++ b/server/route.go
@@ -244,6 +244,9 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 		} else {
 			c.Debugf("Starting TLS route server handshake")
 			c.nc = tls.Server(c.nc, &tlsConfig)
+			if tlsConfig.ClientAuth != tls.RequireAndVerifyClientCert {
+				c.Noticef("Client certificate validation of incoming route connections is disabled, this is NOT recommended")
+			}
 		}
 
 		conn := c.nc.(*tls.Conn)

--- a/test/cluster_tls_test.go
+++ b/test/cluster_tls_test.go
@@ -3,6 +3,7 @@
 package test
 
 import (
+	"crypto/tls"
 	"testing"
 	"time"
 
@@ -59,4 +60,20 @@ func TestBasicTLSClusterPubSub(t *testing.T) {
 
 	matches := expectMsgs(1)
 	checkMsg(t, matches[0], "foo", "22", "", "2", "ok")
+}
+
+func TestTLSClientCertRequiredByDefault(t *testing.T) {
+	opts := LoadConfig("./configs/srv_a_tls.conf")
+
+	if opts.ClusterTLSConfig.ClientAuth != tls.RequireAndVerifyClientCert {
+		t.Errorf("ClusterTLSConfig should have RequireAndVerifyClientCert set by default")
+	}
+}
+
+func TestTLSNoClientCertWhenVerifyFalse(t *testing.T) {
+	opts := LoadConfig("./configs/srv_a_tls_verify_false.conf")
+
+	if opts.ClusterTLSConfig.ClientAuth != tls.NoClientCert {
+		t.Errorf("ClusterTLSConfig should have NoClientCert set when 'verify: false'")
+	}
 }

--- a/test/configs/srv_a_tls_verify_false.conf
+++ b/test/configs/srv_a_tls_verify_false.conf
@@ -1,0 +1,35 @@
+# Copyright 2012-2015 Apcera Inc. All rights reserved.
+
+# Cluster Server A
+
+host: '127.0.0.1'
+port: 4222
+
+cluster {
+  host: '127.0.0.1'
+  port: 4244
+
+  tls {
+    # Route cert
+    cert_file: "./configs/certs/srva-cert.pem"
+    # Private key
+    key_file:  "./configs/certs/srva-key.pem"
+    # Specified time for handshake to complete
+    timeout: 2
+
+    # Optional certificate authority verifying connected routes
+    # Required when we have self-signed CA, etc.
+    ca_file:   "./configs/certs/ca.pem"
+
+    # Don't request or verify client certs
+    verify: false
+  }
+
+  # Routes are actively solicited and connected to from this server.
+  # Other servers can connect to us if they supply the correct credentials
+  # in their routes definitions from above.
+
+  routes = [
+    nats-route://127.0.0.1:4246
+  ]
+}


### PR DESCRIPTION
This change allows a user to disable the forced client certificate
verification on cluster routes by specifying `validate: false` similarly
to regular client connections.

Clustering is still protected by a username/password combination so being
able to disable client verification is desirable in situations where
there is a less robust PKI infrastructure in place.