### PR TITLE
Add trace field to CONNECT

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -112,7 +112,5 @@ func (l *Logger) Debugf(format string, v ...interface{}) {
 }
 
 func (l *Logger) Tracef(format string, v ...interface{}) {
-	if l.trace == true {
-		l.logger.Printf(l.traceLabel+format, v...)
-	}
+	l.logger.Printf(l.traceLabel+format, v...)
 }

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -79,13 +79,6 @@ func TestStdLoggerTrace(t *testing.T) {
 	}, "[TRC] foo\n")
 }
 
-func TestStdLoggerTraceWithOutDebug(t *testing.T) {
-	expectOutput(t, func() {
-		logger := NewStdLogger(false, false, false, false, false)
-		logger.Tracef("foo")
-	}, "")
-}
-
 func TestFileLogger(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "_gnatsd")
 	if err != nil {

--- a/server/client.go
+++ b/server/client.go
@@ -78,6 +78,7 @@ type subscription struct {
 type clientOpts struct {
 	Verbose       bool   `json:"verbose"`
 	Pedantic      bool   `json:"pedantic"`
+	Trace         bool   `json:"trace"`
 	SslRequired   bool   `json:"ssl_required"`
 	Authorization string `json:"auth_token"`
 	Username      string `json:"user"`
@@ -257,6 +258,12 @@ func (c *client) processConnect(arg []byte) error {
 
 	if err := json.Unmarshal(arg, &c.opts); err != nil {
 		return err
+	}
+
+	// Client-enabled tracing.
+	// TODO: This probably needs to support some kind of authorization?
+	if c.opts.Trace {
+		c.trace = true
 	}
 
 	if c.srv != nil {
@@ -991,5 +998,5 @@ func (c *client) Noticef(format string, v ...interface{}) {
 
 func (c *client) Tracef(format string, v ...interface{}) {
 	format = fmt.Sprintf("%s - %s", c, format)
-	Tracef(format, v...)
+	tracef(format, v...)
 }

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -107,7 +107,7 @@ func TestClientConnect(t *testing.T) {
 	_, c, _ := setupClient()
 
 	// Basic Connect setting flags
-	connectOp := []byte("CONNECT {\"verbose\":true,\"pedantic\":true,\"ssl_required\":false}\r\n")
+	connectOp := []byte("CONNECT {\"verbose\":true,\"pedantic\":true,\"trace\":true,\"ssl_required\":false}\r\n")
 	err := c.parse(connectOp)
 	if err != nil {
 		t.Fatalf("Received error: %v\n", err)
@@ -115,8 +115,11 @@ func TestClientConnect(t *testing.T) {
 	if c.state != OP_START {
 		t.Fatalf("Expected state of OP_START vs %d\n", c.state)
 	}
-	if !reflect.DeepEqual(c.opts, clientOpts{Verbose: true, Pedantic: true}) {
+	if !reflect.DeepEqual(c.opts, clientOpts{Verbose: true, Pedantic: true, Trace: true}) {
 		t.Fatalf("Did not parse connect options correctly: %+v\n", c.opts)
+	}
+	if !c.trace {
+		t.Fatal("Expected trace to be true")
 	}
 
 	// Test that we can capture user/pass

--- a/server/log.go
+++ b/server/log.go
@@ -76,6 +76,12 @@ func Tracef(format string, v ...interface{}) {
 	}, format, v...)
 }
 
+func tracef(format string, v ...interface{}) {
+	executeLogCall(func(logger Logger, format string, v ...interface{}) {
+		logger.Tracef(format, v...)
+	}, format, v...)
+}
+
 func executeLogCall(f func(logger Logger, format string, v ...interface{}), format string, args ...interface{}) {
 	log.Lock()
 	defer log.Unlock()


### PR DESCRIPTION
Currently, debugging gnatsd in production can prove extremely difficult.
Debug mode doesn't provide a lot of information, and tracing provides a
flood of information while significantly impacting performance. I'd like to
propose a way to provide per-publisher tracing. This is a rough first pass
at that by simply adding a `trace` field to the `CONNECT` message.

This allows clients to enable tracing for themselves within gnatsd. This
likely needs some kind of authorization support since we probably don't
want to allow any client to enable this.

Per-publisher tracing makes it much easier to debug issues in an ad hoc
fashion without significantly impacting performance like enabling full
tracing does.