### PR TITLE
Add 'auth' option, make all usage hints uniform with conventions

### DIFF
--- a/server/usage.go
+++ b/server/usage.go
@@ -8,37 +8,40 @@ import (
 )
 
 var usageStr = `
+Usage: gnatsd [options]
+ 
 Server Options:
-    -a, --addr HOST                  Bind to HOST address (default: 0.0.0.0)
-    -p, --port PORT                  Use PORT for clients (default: 4222)
-    -P, --pid FILE                   File to store PID
-    -m, --http_port PORT             Use HTTP PORT for monitoring
-    -ms,--https_port PORT            Use HTTPS PORT for monitoring
-    -c, --config FILE                Configuration File
+    -a, --addr <host>                Bind to host address (default: 0.0.0.0)
+    -p, --port <port>                Use port for clients (default: 4222)
+    -P, --pid <file>                 File to store PID
+    -m, --http_port <port>           Use port for http monitoring
+    -ms,--https_port <port>          Use port for https monitoring
+    -c, --config <file>              Configuration file
 
 Logging Options:
-    -l, --log FILE                   File to redirect log output
+    -l, --log <file>                 File to redirect log output
     -T, --logtime                    Timestamp log entries (default: true)
     -s, --syslog                     Enable syslog as log method
-    -r, --remote_syslog              Syslog server addr (udp://localhost:514)
+    -r, --remote_syslog <addr>       Syslog server addr (udp://localhost:514)
     -D, --debug                      Enable debugging output
     -V, --trace                      Trace the raw protocol
-    -DV                              Debug and Trace
+    -DV                              Debug and trace
 
 Authorization Options:
-        --user user                  User required for connections
-        --pass password              Password required for connections
+        --user <user>                User required for connections
+        --pass <password>            Password required for connections
+        --auth [token]               Authorization required for connections
 
 TLS Options:
         --tls                        Enable TLS, do not verify clients (default: false)
-        --tlscert FILE               Server certificate file
-        --tlskey FILE                Private key for server certificate
+        --tlscert <file>             Server certificate file
+        --tlskey <file>              Private key for server certificate
         --tlsverify                  Enable TLS, very client certificates
-        --tlscacert FILE             Client certificate CA for verification
+        --tlscacert <file>           Client certificate CA for verification
 
 Cluster Options:
-        --routes [rurl-1, rurl-2]    Routes to solicit and connect
-        --cluster [cluster url]      Cluster URL for solicited routes
+        --routes <rurl-1, rurl-2>    Routes to solicit and connect
+        --cluster <cluster-url>      Cluster URL for solicited routes
 
 Common Options:
     -h, --help                       Show this message

--- a/server/usage.go
+++ b/server/usage.go
@@ -30,7 +30,7 @@ Logging Options:
 Authorization Options:
         --user <user>                User required for connections
         --pass <password>            Password required for connections
-        --auth [token]               Authorization required for connections
+        --auth <token>               Authorization token required for connections
 
 TLS Options:
         --tls                        Enable TLS, do not verify clients (default: false)


### PR DESCRIPTION
- Added `Usage: gnatsd [options]` at the top
- `--auth` wasn't included in the usage menu, so added it.
- A couple of the options didn't indicate whether an argument was `<required>` or `[optional]`, so I fixed that.
- Capitalization was not uniform throughout, so fixed that. Other than acronyms and proper nouns, only the first letter is capitalized in descriptions.