### PR TITLE
Add UNSUB_SPC parser state

### DIFF
--- a/server/parser.go
+++ b/server/parser.go
@@ -66,6 +66,7 @@ const (
 	OP_UNS
 	OP_UNSU
 	OP_UNSUB
+	OP_UNSUB_SPC
 	UNSUB_ARG
 	OP_M
 	OP_MS
@@ -304,6 +305,13 @@ func (c *client) parse(buf []byte) error {
 				goto parseErr
 			}
 		case OP_UNSUB:
+			switch b {
+			case ' ', '\t':
+				c.state = OP_UNSUB_SPC
+			default:
+				goto parseErr
+			}
+		case OP_UNSUB_SPC:
 			switch b {
 			case ' ', '\t':
 				continue

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -380,6 +380,34 @@ func TestShouldFail(t *testing.T) {
 	if err := c.parse([]byte("PUB foo 2\r\nok\r \n")); err == nil {
 		t.Fatal("Should have received a parse error")
 	}
+	c.state = OP_START
+	if err := c.parse([]byte("UNSUBUNSUB 1\r\n")); err == nil {
+		t.Fatal("Should have received a parse error")
+	}
+	c.state = OP_START
+	if err := c.parse([]byte("UNSUB_2\r\n")); err == nil {
+		t.Fatal("Should have received a parse error")
+	}
+	c.state = OP_START
+	if err := c.parse([]byte("UNSUB_UNSUB_UNSUB 2\r\n")); err == nil {
+		t.Fatal("Should have received a parse error")
+	}
+	c.state = OP_START
+	if err := c.parse([]byte("UNSUB_\t2\r\n")); err == nil {
+		t.Fatal("Should have received a parse error")
+	}
+	c.state = OP_START
+	if err := c.parse([]byte("UNSUB\r\n")); err == nil {
+		t.Fatal("Should have received a parse error")
+	}
+	c.state = OP_START
+	if err := c.parse([]byte("UNSUB \r\n")); err == nil {
+		t.Fatal("Should have received a parse error")
+	}
+	c.state = OP_START
+	if err := c.parse([]byte("UNSUB          \t       \r\n")); err == nil {
+		t.Fatal("Should have received a parse error")
+	}
 }
 
 func TestProtoSnippet(t *testing.T) {


### PR DESCRIPTION
Noticed that currently parser is tolerant to not having spaces after `unsub`, for example:

```
telnet demo.nats.io 4222
INFO ...
unsub_hello_world 90
+OK
```

This change adds a new state to the parser in case we want to handle this and sends `-ERR 'Unknown Protocol Operation'` to clients sending `unsub` commands which are not following the protocol then disconnect due to parser error.