### PR TITLE
Fix code that checks that server is started + route test

### DIFF
--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -177,17 +177,6 @@ func TestConnz(t *testing.T) {
 	s := runMonitorServer(DEFAULT_HTTP_PORT)
 	defer s.Shutdown()
 
-	// Wait a bit to make sure that the "client" that was created
-	// by the connection checking that the server is started is gone.
-	end := time.Now().Add(5 * time.Second)
-	for time.Now().Before(end) {
-		if s.NumClients() > 0 {
-			time.Sleep(10 * time.Millisecond)
-		} else {
-			break
-		}
-	}
-
 	url := fmt.Sprintf("http://localhost:%d/", DEFAULT_HTTP_PORT)
 	resp, err := http.Get(url + "connz")
 	if err != nil {

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -177,6 +177,17 @@ func TestConnz(t *testing.T) {
 	s := runMonitorServer(DEFAULT_HTTP_PORT)
 	defer s.Shutdown()
 
+	// Wait a bit to make sure that the "client" that was created
+	// by the connection checking that the server is started is gone.
+	end := time.Now().Add(5 * time.Second)
+	for time.Now().Before(end) {
+		if s.NumClients() > 0 {
+			time.Sleep(10 * time.Millisecond)
+		} else {
+			break
+		}
+	}
+
 	url := fmt.Sprintf("http://localhost:%d/", DEFAULT_HTTP_PORT)
 	resp, err := http.Get(url + "connz")
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -28,7 +28,6 @@ func completeConnection(conn net.Conn) error {
 	defer conn.Close()
 
 	buf := bufio.NewReader(conn)
-	resp := ""
 
 	// Consume the INFO protocol
 	_, err := buf.ReadString('\n')
@@ -37,13 +36,13 @@ func completeConnection(conn net.Conn) error {
 		_, err = conn.Write([]byte("PING\r\n"))
 	}
 	if err == nil {
-		// Expect a PONG
-		resp, err = buf.ReadString('\n')
+		// Expect a PONG, but could be -ERR. We don't really care,
+		// the point is that if we received something, the client
+		// is initialized.
+		_, err = buf.ReadString('\n')
 	}
-	if err != nil || resp != "PONG\r\n" {
-		return err
-	}
-	return nil
+
+	return err
 }
 
 // New Go Routine based server

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -253,6 +253,12 @@ func TestRouteQueueSemantics(t *testing.T) {
 
 	defer client.Close()
 
+	// Make sure client connection is fully processed before creating route
+	// connection, so we are sure that client ID will be "2" ("1" being used
+	// by the connection created to check the server is started)
+	clientSend("PING\r\n")
+	clientExpect(pongRe)
+
 	route := createRouteConn(t, opts.ClusterHost, opts.ClusterPort)
 	defer route.Close()
 

--- a/test/test.go
+++ b/test/test.go
@@ -82,7 +82,6 @@ func completeConnection(conn net.Conn) error {
 	defer conn.Close()
 
 	buf := bufio.NewReader(conn)
-	resp := ""
 
 	// Consume the INFO protocol
 	_, err := buf.ReadString('\n')
@@ -91,13 +90,13 @@ func completeConnection(conn net.Conn) error {
 		_, err = conn.Write([]byte("PING\r\n"))
 	}
 	if err == nil {
-		// Expect a PONG
-		resp, err = buf.ReadString('\n')
+		// Expect a PONG, but could be -ERR. We don't really care,
+		// the point is that if we received something, the client
+		// is initialized.
+		_, err = buf.ReadString('\n')
 	}
-	if err != nil || resp != "PONG\r\n" {
-		return err
-	}
-	return nil
+
+	return err
 }
 
 // New Go Routine based server with auth


### PR DESCRIPTION
- The raw connection used to check that the server is started now consumes the INFO and sends PING and consumes PONG before returning.
- The route test needs to make sure that the client connection has client id 2. Using PING/PONG before creating route connection to make sure of that.