### PR TITLE
add nats-pub and nats-sub to util, and make util go gettable

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ In addition to TLS functionality, the server now also supports bcrypt for passwo
 There is a utility bundled under /util/mkpasswd. By default with no arguments it will generate a secure password and the associated hash. This can be used for a password or a token in the configuration. If you already have a password selected, you can supply that on stdin with the -p flag.
 
 ```bash
-~/go/src/github.com/nats-io/gnatsd/util> ./mkpasswd
+> $GOPATH/bin/mkpasswd
 pass: #IclkRPHUpsTmACWzmIGXr
 bcrypt hash: $2a$11$3kIDaCxw.Glsl1.u5nKa6eUnNDLV5HV9tIuUp7EHhMt6Nm9myW1aS
 ```
@@ -466,14 +466,13 @@ packagers provided by your OS vendor may not be sufficient.
 
 Run `go version` to see the version of Go which you have installed.
 
-Run `go build` inside the directory to build.
-
 Run `go test ./...` to run the unit regression tests.
 
-A successful build run produces no messages and creates an executable called
-`gnatsd` in this directory.  You can invoke that binary, with no options and
-no configuration file, to start a server with acceptable standalone defaults
-(no authentication, no clustering).
+Run `go install ./...` to build and install `gnatsd`, `mkpasswd`, `nats-pub` and `nats-sub` to $GOPATH/bin.
+
+You can invoke `$GOPATH/bin/gnatsd &`, with no options and no configuration file, to start a server 
+with acceptable standalone defaults (no authentication, no clustering). And start a subscriber via 
+`$GOPATH/bin/nats-sub foo &` and publish a message on the `foo` channel like `$GOPATH/bin/nats-pub foo hello`.
 
 Run `go help` for more guidance, and visit <http://golang.org/> for tutorials,
 presentations, references and more.

--- a/util/mkpasswd/mkpasswd.go
+++ b/util/mkpasswd/mkpasswd.go
@@ -1,5 +1,4 @@
 // Copyright 2015 Apcera Inc. All rights reserved.
-// +build ignore
 
 package main
 

--- a/util/nats-pub/nats-pub.go
+++ b/util/nats-pub/nats-pub.go
@@ -1,0 +1,41 @@
+// Copyright 2012-2016 Apcera Inc. All rights reserved.
+
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/nats-io/nats"
+)
+
+// NOTE: Use tls scheme for TLS, e.g. nats-pub -s tls://demo.nats.io:4443 foo hello
+func usage() {
+	log.Fatalf("Usage: nats-pub [-s server (%s)] <subject> <msg> \n", nats.DefaultURL)
+}
+
+func main() {
+	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) < 1 {
+		usage()
+	}
+
+	nc, err := nats.Connect(*urls)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer nc.Close()
+
+	subj, msg := args[0], []byte(args[1])
+
+	nc.Publish(subj, msg)
+	nc.Flush()
+
+	log.Printf("Published [%s] : '%s'\n", subj, msg)
+}

--- a/util/nats-sub/nats-sub.go
+++ b/util/nats-sub/nats-sub.go
@@ -1,0 +1,53 @@
+// Copyright 2012-2016 Apcera Inc. All rights reserved.
+
+package main
+
+import (
+	"flag"
+	"log"
+	"runtime"
+
+	"github.com/nats-io/nats"
+)
+
+// NOTE: Use tls scheme for TLS, e.g. nats-sub -s tls://demo.nats.io:4443 foo
+func usage() {
+	log.Fatalf("Usage: nats-sub [-s server] [-t] <subject> \n")
+}
+
+func printMsg(m *nats.Msg, i int) {
+	log.Printf("[#%d] Received on [%s]: '%s'\n", i, m.Subject, string(m.Data))
+}
+
+func main() {
+	var urls = flag.String("s", nats.DefaultURL, "The nats server URLs (separated by comma)")
+	var showTime = flag.Bool("t", false, "Display timestamps")
+
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) < 1 {
+		usage()
+	}
+
+	nc, err := nats.Connect(*urls)
+	if err != nil {
+		log.Fatalf("Can't connect: %v\n", err)
+	}
+
+	subj, i := args[0], 0
+
+	nc.Subscribe(subj, func(msg *nats.Msg) {
+		i += 1
+		printMsg(msg, i)
+	})
+
+	log.Printf("Listening on [%s]\n", subj)
+	if *showTime {
+		log.SetFlags(log.LstdFlags)
+	}
+
+	runtime.Goexit()
+}


### PR DESCRIPTION
Per https://github.com/nats-io/nats/pull/159 comments, copied 2 examples nats-pub and nats-sub to gnatsd/util. 
Also make the utilities build-able using "go get github.com/nats-io/gnatsd/..." or "go install ./...".
