### PR TITLE
Update test that would catch incorrect NumConns

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -178,23 +178,24 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 
 		// Now overwrite the field that was used as the sort key, so results
 		// still look sorted even if the value has changed since sort occurred.
+		sortValue := pair.Val
 		switch sortOpt {
 		case bySubs:
-			ci.NumSubs = uint32(pair.Val)
+			ci.NumSubs = uint32(sortValue)
 		case byPending:
-			ci.Pending = int(pair.Val)
+			ci.Pending = int(sortValue)
 		case byOutMsgs:
-			ci.OutMsgs = pair.Val
+			ci.OutMsgs = sortValue
 		case byInMsgs:
-			ci.InMsgs = pair.Val
+			ci.InMsgs = sortValue
 		case byOutBytes:
-			ci.OutBytes = pair.Val
+			ci.OutBytes = sortValue
 		case byInBytes:
-			ci.InBytes = pair.Val
+			ci.InBytes = sortValue
 		case byLast:
-			ci.LastActivity = time.Unix(0, pair.Val)
+			ci.LastActivity = time.Unix(0, sortValue)
 		case byIdle:
-			ci.Idle = myUptime(time.Duration(pair.Val))
+			ci.Idle = myUptime(time.Duration(sortValue))
 		}
 
 		// If the connection is gone, too bad, we won't set TLSVersion and TLSCipher.

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -473,6 +473,10 @@ func TestConnzWithOffsetAndLimit(t *testing.T) {
 		t.Fatalf("Expected conns of 1, got %v\n", len(c.Conns))
 	}
 
+	if c.NumConns != 1 {
+		t.Fatalf("Expected NumConns to be 1, got %v\n", c.NumConns)
+	}
+
 	resp, err = http.Get(url + "connz?offset=2&limit=1")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -503,6 +507,9 @@ func TestConnzWithOffsetAndLimit(t *testing.T) {
 		t.Fatalf("Expected conns of 0, got %v\n", len(c.Conns))
 	}
 
+	if c.NumConns != 0 {
+		t.Fatalf("Expected NumConns to be 0, got %v\n", c.NumConns)
+	}
 }
 
 func TestConnzDefaultSorted(t *testing.T) {


### PR DESCRIPTION
- Updating TestConnzWithOffsetAndLimit() to test for c.NumConns. This would have caught the issue that was fixed in my previous change.
- Use of variable sortValue set to pair.Val to help readability. No functional change.