### PR TITLE
Fix infinite server attempt to connect route to itself

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -965,6 +965,9 @@ func (c *client) closeConnection() {
 		if rid != "" && srv.remotes[rid] != nil {
 			Debugf("Not attempting reconnect for solicited route, already connected to \"%s\"", rid)
 			return
+		} else if c.route.remoteID == srv.info.ID {
+			Debugf("Detected route to self, ignoring \"%s\"", c.route.url)
+			return
 		} else if c.route.routeType != Implicit {
 			Debugf("Attempting reconnect for solicited route \"%s\"", c.route.url)
 			go srv.reConnectToRoute(c.route.url)

--- a/server/route.go
+++ b/server/route.go
@@ -89,8 +89,19 @@ func (c *client) processRouteInfo(info *Info) {
 		c.mu.Unlock()
 		return
 	}
-	// Copy over important information
+
+	// Need to set this for the detection of the route to self to work
+	// in closeConnection().
 	c.route.remoteID = info.ID
+
+	// Detect route to self.
+	if c.route.remoteID == c.srv.info.ID {
+		c.mu.Unlock()
+		c.closeConnection()
+		return
+	}
+
+	// Copy over important information.
 	c.route.authRequired = info.AuthRequired
 	c.route.tlsRequired = info.TLSRequired
 


### PR DESCRIPTION
Attempt to address issue #175.
Instead of trying to detect if route URL will point to route listen address, detects that the route remoteID is server's ID. If so, closes the connection and stop trying.