### PR TITLE
Return route's remote IP through INFO protocol

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -222,7 +222,7 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 
 			if r.nc != nil {
 				_, rport, err := net.SplitHostPort(r.route.url.Host)
-				if err != nil {
+				if err == nil {
 					// We will send the url but based on the route's ip address.
 					if ip, ok := r.nc.(*net.TCPConn); ok {
 						addr := ip.RemoteAddr().(*net.TCPAddr)


### PR DESCRIPTION
This helps in case where the original host in the route URL can resolve to different IPs or has different meaning depending on which host it is running. Returning the real IP should solve some issues.