### PR TITLE
Set IP and Port for monitoring connections using TLS in /connz

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -206,15 +206,17 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 			ci.TLSCipher = tlsCipher(cs.CipherSuite)
 		}
 
+		switch conn := client.nc.(type) {
+		case *net.TCPConn, *tls.Conn:
+			addr := conn.RemoteAddr().(*net.TCPAddr)
+			ci.Port = addr.Port
+			ci.IP = addr.IP.String()
+		}
+
 		if subs == 1 {
 			ci.Subs = castToSliceString(client.subs.All())
 		}
 
-		if ip, ok := client.nc.(*net.TCPConn); ok {
-			addr := ip.RemoteAddr().(*net.TCPAddr)
-			ci.Port = addr.Port
-			ci.IP = addr.IP.String()
-		}
 		client.mu.Unlock()
 		i++
 	}

--- a/test/configs/tls.conf
+++ b/test/configs/tls.conf
@@ -4,6 +4,8 @@
 port: 4443
 net: localhost
 
+https_port: 11522
+
 tls {
   # Server cert
   cert_file: "./configs/certs/server-cert.pem"


### PR DESCRIPTION
Currently they become the zero values if TLS is being used:

```js
{
  "now": "2016-02-14T19:12:39.523426391-08:00",
  "num_connections": 1,
  "offset": 0,
  "limit": 1024,
  "connections": [
    {
      "cid": 1,
      "ip": "",
      "port": 0,
      ...
      "tls_version": "1.2",
      "tls_cipher_suite": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
    }
  ]
}
```