### PR TITLE
Fix ports for cluster bcrypt auth config files in server package

### DIFF
--- a/server/configs/srv_a_bcrypt.conf
+++ b/server/configs/srv_a_bcrypt.conf
@@ -3,7 +3,7 @@
 # Cluster Server A
 
 host: '127.0.0.1'
-port: 4222
+port: 7222
 
 authorization {
   user: user
@@ -13,7 +13,7 @@ authorization {
 
 cluster {
   host: '127.0.0.1'
-  port: 4244
+  port: 7244
 
   authorization {
     user: ruser
@@ -27,6 +27,6 @@ cluster {
   # in their routes definitions from above.
 
   routes = [
-    nats-route://ruser:bar@127.0.0.1:4246
+    nats-route://ruser:bar@127.0.0.1:7246
   ]
 }

--- a/server/configs/srv_b_bcrypt.conf
+++ b/server/configs/srv_b_bcrypt.conf
@@ -3,7 +3,7 @@
 # Cluster Server B
 
 host: '127.0.0.1'
-port: 4224
+port: 7224
 
 authorization {
   user: user
@@ -13,7 +13,7 @@ authorization {
 
 cluster {
   host: '127.0.0.1'
-  port: 4246
+  port: 7246
 
   authorization {
     user: ruser
@@ -27,6 +27,6 @@ cluster {
   # in their routes definitions from above.
 
   routes = [
-    nats-route://ruser:bar@127.0.0.1:4244
+    nats-route://ruser:bar@127.0.0.1:7244
   ]
 }


### PR DESCRIPTION
The ports were conflicting with the 'test' package when running the test suite in parallel (go test -race -v ./...)