### PR TITLE
Fix cluster formation when servers connect quickly

### DIFF
--- a/server/configs/seed.conf
+++ b/server/configs/seed.conf
@@ -1,0 +1,13 @@
+# Copyright 2016 Apcera Inc. All rights reserved.
+
+# Cluster Seed Node
+
+port: 7222
+net: '127.0.0.1'
+
+http_port: 9222
+
+cluster {
+  host: '127.0.0.1'
+  port: 7248
+}

--- a/server/configs/seed_tls.conf
+++ b/server/configs/seed_tls.conf
@@ -1,0 +1,26 @@
+# Copyright 2016 Apcera Inc. All rights reserved.
+
+# Cluster Seed Node
+
+port: 7222
+net: '127.0.0.1'
+
+http_port: 9222
+
+cluster {
+  host: '127.0.0.1'
+  port: 7248
+  
+  tls {
+    # Route cert
+    cert_file: "../test/configs/certs/server-cert.pem"
+    # Private key
+    key_file:  "../test/configs/certs/server-key.pem"
+    # Specified time for handshake to complete
+    timeout: 2
+
+    # Optional certificate authority verifying connected routes
+    # Required when we have self-signed CA, etc.
+    ca_file:   "../test/configs/certs/ca.pem"
+  }  
+}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -132,3 +132,251 @@ func TestServerRoutesWithAuthAndBCrypt(t *testing.T) {
 		t.Fatal("Timeout waiting for message across route")
 	}
 }
+
+// Helper function to check that a cluster is formed
+func checkClusterFormed(t *testing.T, servers ...*Server) {
+	// Wait for the cluster to form
+	var err string
+	expectedNumRoutes := len(servers) - 1
+	maxTime := time.Now().Add(5 * time.Second)
+	for time.Now().Before(maxTime) {
+		err = ""
+		for _, s := range servers {
+			if numRoutes := s.NumRoutes(); numRoutes != expectedNumRoutes {
+				err = fmt.Sprintf("Expected %d routes for server %q, got %d", expectedNumRoutes, s.Id(), numRoutes)
+				break
+			}
+		}
+		if err != "" {
+			time.Sleep(100 * time.Millisecond)
+		} else {
+			break
+		}
+	}
+	if err != "" {
+		t.Fatalf("%s", err)
+	}
+}
+
+// Helper function to generate next opts to make sure no port conflicts etc.
+func nextServerOpts(opts *Options) *Options {
+	nopts := *opts
+	nopts.Port += 1
+	nopts.ClusterPort += 1
+	nopts.HTTPPort += 1
+	return &nopts
+}
+
+func TestSeedSolicitWorks(t *testing.T) {
+	optsSeed, _ := ProcessConfigFile("./configs/seed.conf")
+
+	optsSeed.NoSigs, optsSeed.NoLog = true, true
+
+	srvSeed := RunServer(optsSeed)
+	defer srvSeed.Shutdown()
+
+	optsA := nextServerOpts(optsSeed)
+	optsA.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsSeed.ClusterHost, optsSeed.ClusterPort))
+
+	srvA := RunServer(optsA)
+	defer srvA.Shutdown()
+
+	urlA := fmt.Sprintf("nats://%s:%d/", optsA.Host, optsA.Port)
+
+	nc1, err := nats.Connect(urlA)
+	if err != nil {
+		t.Fatalf("Error creating client: %v\n", err)
+	}
+	defer nc1.Close()
+
+	// Test that we are connected.
+	ch := make(chan bool)
+	nc1.Subscribe("foo", func(m *nats.Msg) { ch <- true })
+	nc1.Flush()
+
+	optsB := nextServerOpts(optsA)
+	optsB.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsSeed.ClusterHost, optsSeed.ClusterPort))
+
+	srvB := RunServer(optsB)
+	defer srvB.Shutdown()
+
+	urlB := fmt.Sprintf("nats://%s:%d/", optsB.Host, optsB.Port)
+
+	nc2, err := nats.Connect(urlB)
+	if err != nil {
+		t.Fatalf("Error creating client: %v\n", err)
+	}
+	defer nc2.Close()
+
+	checkClusterFormed(t, srvSeed, srvA, srvB)
+
+	nc2.Publish("foo", []byte("Hello"))
+
+	// Wait for message
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for message across route")
+	}
+}
+
+func TestTLSSeedSolicitWorks(t *testing.T) {
+	optsSeed, _ := ProcessConfigFile("./configs/seed_tls.conf")
+
+	optsSeed.NoSigs, optsSeed.NoLog = true, true
+
+	srvSeed := RunServer(optsSeed)
+	defer srvSeed.Shutdown()
+
+	optsA := nextServerOpts(optsSeed)
+	optsA.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsSeed.ClusterHost, optsSeed.ClusterPort))
+
+	srvA := RunServer(optsA)
+	defer srvA.Shutdown()
+
+	urlA := fmt.Sprintf("nats://%s:%d/", optsA.Host, optsA.Port)
+
+	nc1, err := nats.Connect(urlA)
+	if err != nil {
+		t.Fatalf("Error creating client: %v\n", err)
+	}
+	defer nc1.Close()
+
+	// Test that we are connected.
+	ch := make(chan bool)
+	nc1.Subscribe("foo", func(m *nats.Msg) { ch <- true })
+	nc1.Flush()
+
+	optsB := nextServerOpts(optsA)
+	optsB.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsSeed.ClusterHost, optsSeed.ClusterPort))
+
+	srvB := RunServer(optsB)
+	defer srvB.Shutdown()
+
+	urlB := fmt.Sprintf("nats://%s:%d/", optsB.Host, optsB.Port)
+
+	nc2, err := nats.Connect(urlB)
+	if err != nil {
+		t.Fatalf("Error creating client: %v\n", err)
+	}
+	defer nc2.Close()
+
+	checkClusterFormed(t, srvSeed, srvA, srvB)
+
+	nc2.Publish("foo", []byte("Hello"))
+
+	// Wait for message
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for message across route")
+	}
+}
+
+func TestChainedSolicitWorks(t *testing.T) {
+	optsSeed, _ := ProcessConfigFile("./configs/seed.conf")
+
+	optsSeed.NoSigs, optsSeed.NoLog = true, true
+
+	srvSeed := RunServer(optsSeed)
+	defer srvSeed.Shutdown()
+
+	optsA := nextServerOpts(optsSeed)
+	optsA.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsSeed.ClusterHost, optsSeed.ClusterPort))
+
+	srvA := RunServer(optsA)
+	defer srvA.Shutdown()
+
+	urlSeed := fmt.Sprintf("nats://%s:%d/", optsSeed.Host, optsSeed.Port)
+
+	nc1, err := nats.Connect(urlSeed)
+	if err != nil {
+		t.Fatalf("Error creating client: %v\n", err)
+	}
+	defer nc1.Close()
+
+	// Test that we are connected.
+	ch := make(chan bool)
+	nc1.Subscribe("foo", func(m *nats.Msg) { ch <- true })
+	nc1.Flush()
+
+	optsB := nextServerOpts(optsA)
+	// Server B connects to A
+	optsB.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsA.ClusterHost, optsA.ClusterPort))
+
+	srvB := RunServer(optsB)
+	defer srvB.Shutdown()
+
+	urlB := fmt.Sprintf("nats://%s:%d/", optsB.Host, optsB.Port)
+
+	nc2, err := nats.Connect(urlB)
+	if err != nil {
+		t.Fatalf("Error creating client: %v\n", err)
+	}
+	defer nc2.Close()
+
+	checkClusterFormed(t, srvSeed, srvA, srvB)
+
+	nc2.Publish("foo", []byte("Hello"))
+
+	// Wait for message
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for message across route")
+	}
+}
+
+func TestTLSChainedSolicitWorks(t *testing.T) {
+	optsSeed, _ := ProcessConfigFile("./configs/seed_tls.conf")
+
+	optsSeed.NoSigs, optsSeed.NoLog = true, true
+
+	srvSeed := RunServer(optsSeed)
+	defer srvSeed.Shutdown()
+
+	optsA := nextServerOpts(optsSeed)
+	optsA.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsSeed.ClusterHost, optsSeed.ClusterPort))
+
+	srvA := RunServer(optsA)
+	defer srvA.Shutdown()
+
+	urlSeed := fmt.Sprintf("nats://%s:%d/", optsSeed.Host, optsSeed.Port)
+
+	nc1, err := nats.Connect(urlSeed)
+	if err != nil {
+		t.Fatalf("Error creating client: %v\n", err)
+	}
+	defer nc1.Close()
+
+	// Test that we are connected.
+	ch := make(chan bool)
+	nc1.Subscribe("foo", func(m *nats.Msg) { ch <- true })
+	nc1.Flush()
+
+	optsB := nextServerOpts(optsA)
+	// Server B connects to A
+	optsB.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsA.ClusterHost, optsA.ClusterPort))
+
+	srvB := RunServer(optsB)
+	defer srvB.Shutdown()
+
+	urlB := fmt.Sprintf("nats://%s:%d/", optsB.Host, optsB.Port)
+
+	nc2, err := nats.Connect(urlB)
+	if err != nil {
+		t.Fatalf("Error creating client: %v\n", err)
+	}
+	defer nc2.Close()
+
+	checkClusterFormed(t, srvSeed, srvA, srvB)
+
+	nc2.Publish("foo", []byte("Hello"))
+
+	// Wait for message
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for message across route")
+	}
+}

--- a/test/client_cluster_test.go
+++ b/test/client_cluster_test.go
@@ -228,7 +228,7 @@ func TestServerRestartAndQueueSubs(t *testing.T) {
 
 	waitOnReconnect()
 
-	time.Sleep(50 * time.Millisecond)
+	checkClusterFormed(t, srvA, srvB)
 
 	// Now send another 10 messages, from each client..
 	sendAndCheckMsgs(10)

--- a/test/cluster_tls_test.go
+++ b/test/cluster_tls_test.go
@@ -4,7 +4,6 @@ package test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/nats-io/gnatsd/server"
 )
@@ -12,6 +11,7 @@ import (
 func runTLSServers(t *testing.T) (srvA, srvB *server.Server, optsA, optsB *server.Options) {
 	srvA, optsA = RunServerWithConfig("./configs/srv_a_tls.conf")
 	srvB, optsB = RunServerWithConfig("./configs/srv_b_tls.conf")
+	checkClusterFormed(t, srvA, srvB)
 	return
 }
 
@@ -19,25 +19,12 @@ func TestTLSClusterConfig(t *testing.T) {
 	srvA, srvB, _, _ := runTLSServers(t)
 	defer srvA.Shutdown()
 	defer srvB.Shutdown()
-
-	// Wait for the setup
-	time.Sleep(1 * time.Second)
-
-	if numRoutesA := srvA.NumRoutes(); numRoutesA != 1 {
-		t.Fatalf("Expected one route for srvA, got %d\n", numRoutesA)
-	}
-	if numRoutesB := srvB.NumRoutes(); numRoutesB != 1 {
-		t.Fatalf("Expected one route for srvB, got %d\n", numRoutesB)
-	}
 }
 
 func TestBasicTLSClusterPubSub(t *testing.T) {
 	srvA, srvB, optsA, optsB := runTLSServers(t)
 	defer srvA.Shutdown()
 	defer srvB.Shutdown()
-
-	// Wait for the setup
-	time.Sleep(500 * time.Millisecond)
 
 	clientA := createClientConn(t, optsA.Host, optsA.Port)
 	defer clientA.Close()

--- a/test/route_discovery_test.go
+++ b/test/route_discovery_test.go
@@ -4,6 +4,7 @@ package test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -40,8 +41,8 @@ func TestSeedFirstRouteInfo(t *testing.T) {
 		t.Fatalf("Could not unmarshal route info: %v", err)
 	}
 
-	if len(info.Routes) != 0 {
-		t.Fatalf("Expected len of []Routes to be zero vs %d\n", len(info.Routes))
+	if info.ID != s.Id() {
+		t.Fatalf("Expected seed's ID %q, got %q", s.Id(), info.ID)
 	}
 }
 
@@ -52,14 +53,12 @@ func TestSeedMultipleRouteInfo(t *testing.T) {
 	rc1 := createRouteConn(t, opts.ClusterHost, opts.ClusterPort)
 	defer rc1.Close()
 
-	routeSend1, route1Expect := setupRoute(t, rc1, opts)
-	route1Expect(infoRe)
-
 	rc1ID := "2222"
 	rc1Port := 22
 	rc1Host := "127.0.0.1"
 
-	hp1 := fmt.Sprintf("nats-route://%s/", net.JoinHostPort(rc1Host, strconv.Itoa(rc1Port)))
+	routeSend1, route1Expect := setupRouteEx(t, rc1, opts, rc1ID)
+	route1Expect(infoRe)
 
 	// register ourselves via INFO
 	r1Info := server.Info{ID: rc1ID, Host: rc1Host, Port: rc1Port}
@@ -72,13 +71,13 @@ func TestSeedMultipleRouteInfo(t *testing.T) {
 	rc2 := createRouteConn(t, opts.ClusterHost, opts.ClusterPort)
 	defer rc2.Close()
 
-	routeSend2, route2Expect := setupRoute(t, rc2, opts)
-
 	rc2ID := "2224"
 	rc2Port := 24
 	rc2Host := "127.0.0.1"
 
-	//	hp2 := net.JoinHostPort(rc2Host, strconv.Itoa(rc2Port))
+	routeSend2, route2Expect := setupRouteEx(t, rc2, opts, rc2ID)
+
+	hp2 := fmt.Sprintf("nats-route://%s/", net.JoinHostPort(rc2Host, strconv.Itoa(rc2Port)))
 
 	// register ourselves via INFO
 	r2Info := server.Info{ID: rc2ID, Host: rc2Host, Port: rc2Port}
@@ -86,29 +85,26 @@ func TestSeedMultipleRouteInfo(t *testing.T) {
 	infoJSON = fmt.Sprintf(server.InfoProto, b)
 	routeSend2(infoJSON)
 
-	// Now read back out the info from the seed route
-	buf := route2Expect(infoRe)
+	// Now read back the second INFO route1 should receive letting
+	// it know about route2
+	buf := route1Expect(infoRe)
 
 	info := server.Info{}
 	if err := json.Unmarshal(buf[4:], &info); err != nil {
 		t.Fatalf("Could not unmarshal route info: %v", err)
 	}
 
-	if len(info.Routes) != 1 {
-		t.Fatalf("Expected len of []Routes to be 1 vs %d\n", len(info.Routes))
+	if info.ID != rc2ID {
+		t.Fatalf("Expected info.ID to be %q, got %q", rc2ID, info.ID)
+	}
+	if info.IP == "" {
+		t.Fatalf("Expected a IP for the implicit route")
+	}
+	if info.IP != hp2 {
+		t.Fatalf("Expected IP Host of %s, got %s\n", hp2, info.IP)
 	}
 
-	route := info.Routes[0]
-	if route.RemoteID != rc1ID {
-		t.Fatalf("Expected RemoteID of \"22\", got %q\n", route.RemoteID)
-	}
-	if route.URL == "" {
-		t.Fatalf("Expected a URL for the implicit route")
-	}
-	if route.URL != hp1 {
-		t.Fatalf("Expected URL Host of %s, got %s\n", hp1, route.URL)
-	}
-
+	route2Expect(infoRe)
 	routeSend2("PING\r\n")
 	route2Expect(pongRe)
 
@@ -116,11 +112,11 @@ func TestSeedMultipleRouteInfo(t *testing.T) {
 	rc3 := createRouteConn(t, opts.ClusterHost, opts.ClusterPort)
 	defer rc3.Close()
 
-	routeSend3, route3Expect := setupRoute(t, rc3, opts)
-
 	rc3ID := "2226"
 	rc3Port := 26
 	rc3Host := "127.0.0.1"
+
+	routeSend3, _ := setupRouteEx(t, rc3, opts, rc3ID)
 
 	// register ourselves via INFO
 	r3Info := server.Info{ID: rc3ID, Host: rc3Host, Port: rc3Port}
@@ -129,14 +125,27 @@ func TestSeedMultipleRouteInfo(t *testing.T) {
 	routeSend3(infoJSON)
 
 	// Now read back out the info from the seed route
-	buf = route3Expect(infoRe)
+	buf = route1Expect(infoRe)
 
 	info = server.Info{}
 	if err := json.Unmarshal(buf[4:], &info); err != nil {
 		t.Fatalf("Could not unmarshal route info: %v", err)
 	}
-	if len(info.Routes) != 2 {
-		t.Fatalf("Expected len of []Routes to be 2 vs %d\n", len(info.Routes))
+
+	if info.ID != rc3ID {
+		t.Fatalf("Expected info.ID to be %q, got %q", rc3ID, info.ID)
+	}
+
+	// Now read back out the info from the seed route
+	buf = route2Expect(infoRe)
+
+	info = server.Info{}
+	if err := json.Unmarshal(buf[4:], &info); err != nil {
+		t.Fatalf("Could not unmarshal route info: %v", err)
+	}
+
+	if info.ID != rc3ID {
+		t.Fatalf("Expected info.ID to be %q, got %q", rc3ID, info.ID)
 	}
 }
 
@@ -192,6 +201,124 @@ func TestSeedSolicitWorks(t *testing.T) {
 	}
 	if ris[s2.Id()].IsConfigured == true {
 		t.Fatalf("Expected server not to be configured\n")
+	}
+}
+
+type serverInfo struct {
+	server *server.Server
+	opts   *server.Options
+}
+
+func checkConnected(t *testing.T, servers []serverInfo, current int, oneSeed bool) error {
+	s := servers[current]
+
+	// Grab Routez from monitor ports, make sure we are fully connected
+	url := fmt.Sprintf("http://%s:%d/", s.opts.Host, s.opts.HTTPPort)
+	rz := readHttpRoutez(t, url)
+	total := len(servers)
+	var ids []string
+	for i := 0; i < total; i++ {
+		if i == current {
+			continue
+		}
+		ids = append(ids, servers[i].server.Id())
+	}
+	ris, err := expectRidsNoFatal(t, true, rz, ids)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < total; i++ {
+		if i == current {
+			continue
+		}
+		s := servers[i]
+		if current == 0 || ((oneSeed && i > 0) || (!oneSeed && (i != current-1))) {
+			if ris[s.server.Id()].IsConfigured != false {
+				return errors.New(fmt.Sprintf("Expected server %s:%d not to be configured", s.opts.Host, s.opts.Port))
+			}
+		} else if oneSeed || (i == current-1) {
+			if ris[s.server.Id()].IsConfigured != true {
+				return errors.New(fmt.Sprintf("Expected server %s:%d to be configured", s.opts.Host, s.opts.Port))
+			}
+		}
+	}
+	return nil
+}
+
+func TestStressSeedSolicitWorks(t *testing.T) {
+	s1, opts := runSeedServer(t)
+	defer s1.Shutdown()
+
+	// Create the routes string for others to connect to the seed.
+	routesStr := fmt.Sprintf("nats-route://%s:%d/", opts.ClusterHost, opts.ClusterPort)
+
+	s2Opts := nextServerOpts(opts)
+	s2Opts.Routes = server.RoutesFromStr(routesStr)
+
+	s3Opts := nextServerOpts(s2Opts)
+	s4Opts := nextServerOpts(s3Opts)
+
+	for i := 0; i < 10; i++ {
+		func() {
+			// Run these servers manually, because we want them to start and
+			// connect to s1 as fast as possible.
+
+			s2 := server.New(s2Opts)
+			if s2 == nil {
+				panic("No NATS Server object returned.")
+			}
+			defer s2.Shutdown()
+			go s2.Start()
+
+			s3 := server.New(s3Opts)
+			if s3 == nil {
+				panic("No NATS Server object returned.")
+			}
+			defer s3.Shutdown()
+			go s3.Start()
+
+			s4 := server.New(s4Opts)
+			if s4 == nil {
+				panic("No NATS Server object returned.")
+			}
+			defer s4.Shutdown()
+			go s4.Start()
+
+			serversInfo := []serverInfo{{s1, opts}, {s2, s2Opts}, {s3, s3Opts}, {s4, s4Opts}}
+
+			var err error
+			maxTime := time.Now().Add(5 * time.Second)
+			for time.Now().Before(maxTime) {
+				resetPreviousHTTPConnections()
+
+				for j := 0; j < len(serversInfo); j++ {
+					err = checkConnected(t, serversInfo, j, true)
+					// If error, start this for loop from beginning
+					if err != nil {
+						// Sleep a bit before the next attempt
+						time.Sleep(100 * time.Millisecond)
+						break
+					}
+				}
+				// All servers checked ok, we are done, otherwise, try again
+				// until time is up
+				if err == nil {
+					break
+				}
+			}
+			// Report error
+			if err != nil {
+				t.Fatalf("Error: %v", err)
+			}
+		}()
+		maxTime := time.Now().Add(2 * time.Second)
+		for time.Now().Before(maxTime) {
+			if s1.NumRoutes() > 0 {
+				time.Sleep(10 * time.Millisecond)
+			} else {
+				break
+			}
+		}
 	}
 }
 
@@ -253,6 +380,89 @@ func TestChainedSolicitWorks(t *testing.T) {
 	}
 }
 
+func TestStressChainedSolicitWorks(t *testing.T) {
+	s1, opts := runSeedServer(t)
+	defer s1.Shutdown()
+
+	// Create the routes string for s2 to connect to the seed
+	routesStr := fmt.Sprintf("nats-route://%s:%d/", opts.ClusterHost, opts.ClusterPort)
+	s2Opts := nextServerOpts(opts)
+	s2Opts.Routes = server.RoutesFromStr(routesStr)
+
+	s3Opts := nextServerOpts(s2Opts)
+	// Create the routes string for s3 to connect to s2
+	routesStr = fmt.Sprintf("nats-route://%s:%d/", s2Opts.ClusterHost, s2Opts.ClusterPort)
+	s3Opts.Routes = server.RoutesFromStr(routesStr)
+
+	s4Opts := nextServerOpts(s3Opts)
+	// Create the routes string for s4 to connect to s3
+	routesStr = fmt.Sprintf("nats-route://%s:%d/", s3Opts.ClusterHost, s3Opts.ClusterPort)
+	s4Opts.Routes = server.RoutesFromStr(routesStr)
+
+	for i := 0; i < 10; i++ {
+		func() {
+			// Run these servers manually, because we want them to start and
+			// connect to s1 as fast as possible.
+
+			s2 := server.New(s2Opts)
+			if s2 == nil {
+				panic("No NATS Server object returned.")
+			}
+			defer s2.Shutdown()
+			go s2.Start()
+
+			s3 := server.New(s3Opts)
+			if s3 == nil {
+				panic("No NATS Server object returned.")
+			}
+			defer s3.Shutdown()
+			go s3.Start()
+
+			s4 := server.New(s4Opts)
+			if s4 == nil {
+				panic("No NATS Server object returned.")
+			}
+			defer s4.Shutdown()
+			go s4.Start()
+
+			serversInfo := []serverInfo{{s1, opts}, {s2, s2Opts}, {s3, s3Opts}, {s4, s4Opts}}
+
+			var err error
+			maxTime := time.Now().Add(5 * time.Second)
+			for time.Now().Before(maxTime) {
+				resetPreviousHTTPConnections()
+
+				for j := 0; j < len(serversInfo); j++ {
+					err = checkConnected(t, serversInfo, j, false)
+					// If error, start this for loop from beginning
+					if err != nil {
+						// Sleep a bit before the next attempt
+						time.Sleep(100 * time.Millisecond)
+						break
+					}
+				}
+				// All servers checked ok, we are done, otherwise, try again
+				// until time is up
+				if err == nil {
+					break
+				}
+			}
+			// Report error
+			if err != nil {
+				t.Fatalf("Error: %v", err)
+			}
+		}()
+		maxTime := time.Now().Add(2 * time.Second)
+		for time.Now().Before(maxTime) {
+			if s1.NumRoutes() > 0 {
+				time.Sleep(10 * time.Millisecond)
+			} else {
+				break
+			}
+		}
+	}
+}
+
 func TestAuthSeedSolicitWorks(t *testing.T) {
 	s1, opts := runAuthSeedServer(t)
 	defer s1.Shutdown()
@@ -310,9 +520,21 @@ func TestAuthSeedSolicitWorks(t *testing.T) {
 
 // Helper to check for correct route memberships
 func expectRids(t *testing.T, rz *server.Routez, rids []string) map[string]*server.RouteInfo {
+	ri, err := expectRidsNoFatal(t, false, rz, rids)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	return ri
+}
+
+func expectRidsNoFatal(t *testing.T, direct bool, rz *server.Routez, rids []string) (map[string]*server.RouteInfo, error) {
+	caller := 1
+	if !direct {
+		caller++
+	}
 	if len(rids) != rz.NumRoutes {
-		_, fn, line, _ := runtime.Caller(1)
-		t.Fatalf("[%s:%d] Expecting %d routes, got %d\n", fn, line, len(rids), rz.NumRoutes)
+		_, fn, line, _ := runtime.Caller(caller)
+		return nil, errors.New(fmt.Sprintf("[%s:%d] Expecting %d routes, got %d\n", fn, line, len(rids), rz.NumRoutes))
 	}
 	set := make(map[string]bool)
 	for _, v := range rids {
@@ -322,12 +544,12 @@ func expectRids(t *testing.T, rz *server.Routez, rids []string) map[string]*serv
 	ri := make(map[string]*server.RouteInfo)
 	for _, r := range rz.Routes {
 		if set[r.RemoteId] != true {
-			_, fn, line, _ := runtime.Caller(1)
-			t.Fatalf("[%s:%d] Route with rid %s unexpected, expected %+v\n", fn, line, r.RemoteId, rids)
+			_, fn, line, _ := runtime.Caller(caller)
+			return nil, errors.New(fmt.Sprintf("[%s:%d] Route with rid %s unexpected, expected %+v\n", fn, line, r.RemoteId, rids))
 		}
 		ri[r.RemoteId] = r
 	}
-	return ri
+	return ri, nil
 }
 
 // Helper to easily grab routez info.
@@ -355,19 +577,19 @@ func readHttpRoutez(t *testing.T, url string) *server.Routez {
 	return &r
 }
 
-func TestSeedReturnIPInsteadOfURL(t *testing.T) {
+func TestSeedReturnIPInInfo(t *testing.T) {
 	s, opts := runSeedServer(t)
 	defer s.Shutdown()
 
 	rc1 := createRouteConn(t, opts.ClusterHost, opts.ClusterPort)
 	defer rc1.Close()
 
-	routeSend1, route1Expect := setupRoute(t, rc1, opts)
-	route1Expect(infoRe)
-
 	rc1ID := "2222"
 	rc1Port := 22
 	rc1Host := "localhost"
+
+	routeSend1, route1Expect := setupRouteEx(t, rc1, opts, rc1ID)
+	route1Expect(infoRe)
 
 	// register ourselves via INFO
 	r1Info := server.Info{ID: rc1ID, Host: rc1Host, Port: rc1Port}
@@ -380,11 +602,11 @@ func TestSeedReturnIPInsteadOfURL(t *testing.T) {
 	rc2 := createRouteConn(t, opts.ClusterHost, opts.ClusterPort)
 	defer rc2.Close()
 
-	routeSend2, route2Expect := setupRoute(t, rc2, opts)
-
 	rc2ID := "2224"
 	rc2Port := 24
 	rc2Host := "localhost"
+
+	routeSend2, _ := setupRouteEx(t, rc2, opts, rc2ID)
 
 	// register ourselves via INFO
 	r2Info := server.Info{ID: rc2ID, Host: rc2Host, Port: rc2Port}
@@ -392,38 +614,28 @@ func TestSeedReturnIPInsteadOfURL(t *testing.T) {
 	infoJSON = fmt.Sprintf(server.InfoProto, b)
 	routeSend2(infoJSON)
 
-	// Now read back out the info from the seed route
-	buf := route2Expect(infoRe)
+	// Now read info that route1 should have received from the seed
+	buf := route1Expect(infoRe)
 
 	info := server.Info{}
 	if err := json.Unmarshal(buf[4:], &info); err != nil {
 		t.Fatalf("Could not unmarshal route info: %v", err)
 	}
 
-	if len(info.Routes) != 1 {
-		t.Fatalf("Expected len of []Routes to be 1 vs %d", len(info.Routes))
+	if info.IP == "" {
+		t.Fatal("Expected to have IP in INFO")
 	}
-
-	route := info.Routes[0]
-	if route.RemoteID != rc1ID {
-		t.Fatalf("Expected RemoteID of \"22\", got %q", route.RemoteID)
-	}
-	if route.URL == "" {
-		t.Fatal("Expected a URL for the implicit route")
-	}
-	rurl := strings.TrimPrefix(route.URL, "nats-route://")
-	rhost, _, err := net.SplitHostPort(rurl)
+	rip, _, err := net.SplitHostPort(strings.TrimPrefix(info.IP, "nats-route://"))
 	if err != nil {
-		t.Fatalf("Error getting host information from: %v, err=%v", route.URL, err)
-	}
-	if rhost == rc1Host {
-		t.Fatalf("Expected route url to include IP address, got %s", rhost)
+		t.Fatalf("Error parsing url: %v", err)
 	}
 	addr, ok := rc1.RemoteAddr().(*net.TCPAddr)
 	if !ok {
 		t.Fatal("Unable to get IP address from route")
 	}
-	if rhost != addr.IP.String() {
-		t.Fatalf("Expected IP %s, got %s", addr.IP.String(), rhost)
+	s1 := strings.ToLower(addr.IP.String())
+	s2 := strings.ToLower(rip)
+	if s1 != s2 {
+		t.Fatalf("Expected IP %s, got %s", s1, s2)
 	}
 }


### PR DESCRIPTION
Both seed and chained cases are now handled properly when servers
connect quickly and concurrently to one another.
When accepting a route, the server will forward the new route INFO
protocol to its known routes. In turn those routes will connect
to the new server (if not already connected).
A retry for implicit route was introduced to mitigate the issue
with two servers connecting to each other and electing the opposite
connection as the winner, resulting in both connections being dropped.
The server with smaller ID will try once to reconnect.
Some tests were fixed to handle possible extra INFO protocol.
New tests added.

Fix issue: https://github.com/nats-io/gnatsd/issues/206