### PR TITLE
Add ErrUnpromptedPong for clients sending `PONG`s without open `PING`s.

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -167,7 +167,7 @@ func (c *client) readLoop() {
 		}
 		if err := c.parse(b[:n]); err != nil {
 			// handled inline
-			if err != ErrMaxPayload && err != ErrAuthorization {
+			if err != ErrMaxPayload && err != ErrAuthorization && err != ErrUnpromptedPong {
 				c.Errorf("Error reading from client: %s", err.Error())
 				c.sendErr("Parser Error")
 				c.closeConnection()
@@ -306,6 +306,12 @@ func (c *client) maxPayloadViolation(sz int) {
 	c.closeConnection()
 }
 
+func (c *client) unpromptedPong() {
+	c.Errorf(ErrUnpromptedPong.Error())
+	c.sendErr("Received PONG without a pending PING")
+	c.closeConnection()
+}
+
 // Assume the lock is held upon entry.
 func (c *client) sendInfo(info []byte) {
 	c.bw.Write(info)
@@ -347,11 +353,18 @@ func (c *client) processPing() {
 	c.mu.Unlock()
 }
 
-func (c *client) processPong() {
+func (c *client) processPong() error {
 	c.traceInOp("PONG", nil)
 	c.mu.Lock()
-	c.pout -= 1
+	if c.pout > 0 {
+		c.pout -= 1
+	} else {
+		c.mu.Unlock()
+		c.unpromptedPong()
+		return ErrUnpromptedPong
+	}
 	c.mu.Unlock()
+	return nil
 }
 
 func (c *client) processMsgArgs(arg []byte) error {

--- a/server/errors.go
+++ b/server/errors.go
@@ -16,4 +16,7 @@ var (
 
 	// ErrMaxPayload represents error condition when the payload is too big.
 	ErrMaxPayload = errors.New("Maximum Payload Exceeded")
+
+	// ErrUnpromptedPong represents error condition when a PONG is received without a pending PING.
+	ErrUnpromptedPong = errors.New("Unprompted Pong")
 )

--- a/server/parser.go
+++ b/server/parser.go
@@ -377,7 +377,9 @@ func (c *client) parse(buf []byte) error {
 		case OP_PONG:
 			switch b {
 			case '\n':
-				c.processPong()
+				if err := c.processPong(); err != nil {
+					return err
+				}
 				c.drop, c.state = 0, OP_START
 			}
 		case OP_C:


### PR DESCRIPTION
Resolves Issue #168 

The tests don't run on my machine (even for master), so I didn't add a test here. If I can get the tests running, I will update this PR with a test for the unprompted PONG behaviour.
I suspect it would look something like this appended to `test/ping_test.go`.

```go

func TestUnpromptedPong(t *testing.T) {
	s := runPingServer()
	defer s.Shutdown()

	c:=createClientConn(t, "localhost", PING_TEST_PORT)
	defer c.Close()

	doConnect(t, c, false, false, false)

	expect := expectCommand(t, c)

	c.Write([]byte("PONG\r\n"))
	expect(errRe)
}
```

An accompanying documentation update has been submitted as a PR for nats-docs.

And of course, an even simpler solution would be to just silently guard decrementing `c.mu.pout` so that it doesn't go below zero; though this client behaviour is categorically poor and I figure it makes sense to disconnect for it.

_I'm a Go amateur, so please feel free to rip this PR to shreds with scathing review._