### PR TITLE
Fixed code and tests to run on Windows

### DIFF
--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -382,6 +383,12 @@ func TestConnzLastActivity(t *testing.T) {
 		t.Fatalf("Expected LastActivity to be valid\n")
 	}
 
+	// On Windows, looks like the precision is too low, and if we
+	// don't wait, first and last would be equal.
+	if runtime.GOOS == "windows" {
+		time.Sleep(100 * time.Millisecond)
+	}
+
 	// Sub should trigger update.
 	nc.Subscribe("hello.world", func(m *nats.Msg) {})
 	nc.Flush()
@@ -390,6 +397,13 @@ func TestConnzLastActivity(t *testing.T) {
 	if firstLast.Equal(subLast) {
 		t.Fatalf("Subscribe should have triggered update to LastActivity\n")
 	}
+
+	// On Windows, looks like the precision is too low, and if we
+	// don't wait, first and last would be equal.
+	if runtime.GOOS == "windows" {
+		time.Sleep(100 * time.Millisecond)
+	}
+
 	// Pub should trigger as well
 	nc.Publish("foo", []byte("Hello"))
 	nc.Flush()
@@ -398,6 +412,13 @@ func TestConnzLastActivity(t *testing.T) {
 	if subLast.Equal(pubLast) {
 		t.Fatalf("Publish should have triggered update to LastActivity\n")
 	}
+
+	// On Windows, looks like the precision is too low, and if we
+	// don't wait, first and last would be equal.
+	if runtime.GOOS == "windows" {
+		time.Sleep(100 * time.Millisecond)
+	}
+
 	// Message delivery should trigger as well
 	nc2.Publish("foo", []byte("Hello"))
 	nc2.Flush()

--- a/server/pse_test.go
+++ b/server/pse_test.go
@@ -6,10 +6,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"testing"
 )
 
 func TestPSEmulation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skipf("Skipping this test on Windows")
+	}
 	var rss, vss, psRss, psVss int64
 	var pcpu, psPcpu float64
 

--- a/server/route.go
+++ b/server/route.go
@@ -429,6 +429,10 @@ func (s *Server) addRoute(c *client, info *Info) (bool, bool) {
 	sendInfo := false
 
 	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return false, false
+	}
 	remote, exists := s.remotes[id]
 	if !exists {
 		s.routes[c.cid] = c

--- a/server/server.go
+++ b/server/server.go
@@ -711,8 +711,8 @@ func (s *Server) Addr() net.Addr {
 }
 
 // GetListenEndpoint will return a string of the form host:port suitable for
-// a connect. Will return nil if the server is not ready to accept client
-// connections.
+// a connect. Will return empty string if the server is not ready to accept
+// client connections.
 func (s *Server) GetListenEndpoint() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -732,6 +732,29 @@ func (s *Server) GetListenEndpoint() string {
 	// Return the opts's Host and Port. Note that the Port may be set
 	// when the listener is started, due to the use of RANDOM_PORT
 	return net.JoinHostPort(host, strconv.Itoa(s.opts.Port))
+}
+
+// GetRouteListenEndpoint will return a string of the form host:port suitable
+// for a connect. Will return empty string if the server is not configured for
+// routing or not ready to accept route connections.
+func (s *Server) GetRouteListenEndpoint() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.routeListener == nil {
+		return ""
+	}
+
+	host := s.opts.ClusterHost
+
+	// On windows, a connect with host "0.0.0.0" (or "::") will fail.
+	// We replace it with "localhost" when that's the case.
+	if host == "0.0.0.0" || host == "::" || host == "[::]" {
+		host = "localhost"
+	}
+
+	// Return the cluster's Host and Port.
+	return net.JoinHostPort(host, strconv.Itoa(s.opts.ClusterPort))
 }
 
 // Server's ID

--- a/test/client_cluster_test.go
+++ b/test/client_cluster_test.go
@@ -39,6 +39,8 @@ func TestServerRestartReSliceIssue(t *testing.T) {
 		reconnectsDone <- true
 	}
 
+	clients := make([]*nats.Conn, numClients)
+
 	// Create 20 random clients.
 	// Half connected to A and half to B..
 	for i := 0; i < numClients; i++ {
@@ -47,6 +49,7 @@ func TestServerRestartReSliceIssue(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create connection: %v\n", err)
 		}
+		clients[i] = nc
 		defer nc.Close()
 
 		// Create 10 subscriptions each..
@@ -79,11 +82,26 @@ func TestServerRestartReSliceIssue(t *testing.T) {
 	srvB = RunServer(optsB)
 	defer srvB.Shutdown()
 
-	select {
-	case <-reconnectsDone:
-		break
-	case <-time.After(3 * time.Second):
-		t.Fatalf("Expected %d reconnects, got %d\n", numClients/2, reconnects)
+	// Check that all expected clients have reconnected
+	for i := 0; i < numClients/2; i++ {
+		select {
+		case <-reconnectsDone:
+			break
+		case <-time.After(3 * time.Second):
+			t.Fatalf("Expected %d reconnects, got %d\n", numClients/2, reconnects)
+		}
+	}
+
+	// Since srvB was restarted, its defer Shutdown() was last, so will
+	// exectue first, which would cause clients that have reconnected to
+	// it to try to reconnect (causing delays on Windows). So let's
+	// explicitly close them here.
+	// NOTE: With fix of NATS GO client (reconnect loop yields to Close()),
+	//       this change would not be required, however, it still speeeds up
+	//       the test, from more than 7s to less than one.
+	for i := 0; i < numClients; i++ {
+		nc := clients[i]
+		nc.Close()
 	}
 }
 
@@ -211,6 +229,11 @@ func TestServerRestartAndQueueSubs(t *testing.T) {
 	// Base Test
 	////////////////////////////////////////////////////////////////////////////
 
+	// Make sure subscriptions are propagated in the cluster
+	if err := checkExpectedSubs(4, srvA, srvB); err != nil {
+		t.Fatalf("%v", err)
+	}
+
 	// Now send 10 messages, from each client..
 	sendAndCheckMsgs(10)
 
@@ -228,10 +251,23 @@ func TestServerRestartAndQueueSubs(t *testing.T) {
 
 	waitOnReconnect()
 
+	// Make sure the cluster is reformed
 	checkClusterFormed(t, srvA, srvB)
+
+	// Make sure subscriptions are propagated in the cluster
+	if err := checkExpectedSubs(4, srvA, srvB); err != nil {
+		t.Fatalf("%v", err)
+	}
 
 	// Now send another 10 messages, from each client..
 	sendAndCheckMsgs(10)
+
+	// Since servers are restarted after all client's close defer calls,
+	// their defer Shutdown() are last, and so will be executed first,
+	// which would cause clients to try to reconnect on exit, causing
+	// delays on Windows. So let's explicitly close them here.
+	c1.Close()
+	c2.Close()
 }
 
 // This will test request semantics across a route

--- a/test/maxpayload_test.go
+++ b/test/maxpayload_test.go
@@ -5,8 +5,10 @@ package test
 import (
 	"fmt"
 	"net"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nats-io/nats"
 )
@@ -34,6 +36,7 @@ func TestMaxPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not make a raw connection to the server: %v", err)
 	}
+	defer conn.Close()
 	info := make([]byte, 512)
 	_, err = conn.Read(info)
 	if err != nil {
@@ -65,7 +68,21 @@ func TestMaxPayload(t *testing.T) {
 	// publishing the bytes following what is suggested by server
 	// in the info message has its connection closed.
 	_, err = conn.Write(big)
-	if err == nil {
+	if err == nil && runtime.GOOS != "windows" {
 		t.Errorf("Expected error due to maximum payload transgression.")
+	}
+
+	// On windows, the previous write will not fail because the connection
+	// is not fully closed at this stage.
+	if runtime.GOOS == "windows" {
+		// Issuing a PING and not expecting the PONG.
+		_, err = conn.Write([]byte("PING\r\n"))
+		if err == nil {
+			conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+			_, err = conn.Read(big)
+			if err == nil {
+				t.Errorf("Expected closed connection due to maximum payload transgression.")
+			}
+		}
 	}
 }

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -151,7 +151,7 @@ func stressConnect(t *testing.T, wg *sync.WaitGroup, errCh chan error, url strin
 
 	subName := fmt.Sprintf("foo.%d", index)
 
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 33; i++ {
 		nc, err := nats.Connect(url, nats.RootCAs("./configs/certs/ca.pem"))
 		if err != nil {
 			errCh <- fmt.Errorf("Unable to create TLS connection: %v\n", err)


### PR DESCRIPTION
Mainly tests, but also a fix in route.go to reject a route when the server is being shutdown.