### PR TITLE
Queue subscriber performance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,6 @@
 - [ ] Signal based reload of configuration
 - [ ] Dynamic socket buffer sizes
 - [ ] brew, apt-get, rpm, chocately (windows)
-- [ ] Sublist better at high concurrency, cache uses writelock always currently
 - [ ] Buffer pools/sync pools?
 - [ ] IOVec pools and writev for high fanout?
 - [ ] Add ability to reload config on signal
@@ -19,9 +18,10 @@
 - [ ] Modify cluster support for single message across routes between pub/sub and d-queue
 - [ ] Memory limits/warnings?
 - [ ] Limit number of subscriptions a client can have, total memory usage etc.
-- [ ] Info updates contain other implicit route servers
-- [ ] Pedantic state
 - [ ] Multi-tenant accounts with isolation of subject space
+- [ ] Pedantic state
+- [X] Info updates contain other implicit route servers
+- [X] Sublist better at high concurrency, cache uses writelock always currently
 - [X] Switch to 1.4/1.5 and use maps vs hashmaps in sublist
 - [X] NewSource on Rand to lower lock contention on QueueSubs, or redesign!
 - [X] Default sort by cid on connz

--- a/server/split_test.go
+++ b/server/split_test.go
@@ -33,10 +33,10 @@ func TestSplitBufferSubOp(t *testing.T) {
 		t.Fatalf("Expected OP_START state vs %d\n", c.state)
 	}
 	r := s.sl.Match("foo")
-	if r == nil || len(r) != 1 {
+	if r == nil || len(r.psubs) != 1 {
 		t.Fatalf("Did not match subscription properly: %+v\n", r)
 	}
-	sub := r[0]
+	sub := r.psubs[0]
 	if !bytes.Equal(sub.subject, []byte("foo")) {
 		t.Fatalf("Subject did not match expected 'foo' : '%s'\n", sub.subject)
 	}
@@ -77,7 +77,7 @@ func TestSplitBufferUnsubOp(t *testing.T) {
 		t.Fatalf("Expected OP_START state vs %d\n", c.state)
 	}
 	r := s.sl.Match("foo")
-	if r != nil && len(r) != 0 {
+	if r != nil && len(r.psubs) != 0 {
 		t.Fatalf("Should be no subscriptions in results: %+v\n", r)
 	}
 }

--- a/test/client_cluster_test.go
+++ b/test/client_cluster_test.go
@@ -183,7 +183,7 @@ func TestServerRestartAndQueueSubs(t *testing.T) {
 
 		for i := 0; i < numSent; i++ {
 			if results[i] != ExpectedMsgCount {
-				t.Fatalf("Received incorrect number of messages, [%d] for seq: %d\n", results[i], i)
+				t.Fatalf("Received incorrect number of messages, [%d] vs [%d] for seq: %d\n", results[i], ExpectedMsgCount, i)
 			}
 		}
 


### PR DESCRIPTION
Reworked sublist to sort out normal subscribers from queue subscribers into
a result set that can be cached and easily iterated over.