### PR TITLE
Remove an unnecessary string allocation

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -787,20 +787,19 @@ func (c *client) processMsg(msg []byte) {
 	var r *SublistResult
 	var ok bool
 
-	subject := string(c.pa.subject)
-
 	if srv != nil {
 		genid = atomic.LoadUint64(&srv.sl.genid)
 	}
 
 	if genid == c.cache.genid && c.cache.results != nil {
-		r, ok = c.cache.results[subject]
+		r, ok = c.cache.results[string(c.pa.subject)]
 	} else {
 		// reset
 		c.cache.results = make(map[string]*SublistResult)
 		c.cache.genid = genid
 	}
 	if !ok {
+		subject := string(c.pa.subject)
 		r = srv.sl.Match(subject)
 		c.cache.results[subject] = r
 	}


### PR DESCRIPTION
This removes an potentially unneeded allocation when processing messages. Previous to this change, the processMsg function always converted the subject from a []byte to a string, thus allocating, and used it to lookup or set a cache entry.

By moving the conversion for the cache lookup into the map access, we can use an optimization introduced in Go 1.3 that avoids allocating the string for the map lookup.

In case where we insert into the cache we still need to allocate, because we need a string for the Match function and also because setting the map key still needs to allocate, if the key isn't already in the map (if I remember correctly).

These are the results from the publish benchmarks from github.com/nats-io/nats/test:

```
benchmark                          old ns/op     new ns/op     delta
BenchmarkPublishSpeed-4            394           339           -13.96%
BenchmarkPublishSpeedViaChan-4     2005          2013          +0.40%

benchmark                          old allocs     new allocs     delta
BenchmarkPublishSpeed-4            1              0              -100.00%
BenchmarkPublishSpeedViaChan-4     4              3              -25.00%

benchmark                          old bytes     new bytes     delta
BenchmarkPublishSpeed-4            3             0             -100.00%
BenchmarkPublishSpeedViaChan-4     169           167           -1.18%
```

Both old and new number are the best of 3 runs. The slow down in BenchmarkPublishSpeedViaChan is just noise and fluctuates between + and - on the machine I used to test.