### PR TITLE
Remove allocation when inserting into sublist

### DIFF
--- a/server/sublist.go
+++ b/server/sublist.go
@@ -83,7 +83,7 @@ func NewSublist() *Sublist {
 // Insert adds a subscription into the sublist
 func (s *Sublist) Insert(sub *subscription) error {
 	// copy the subject since we hold this and this might be part of a large byte slice.
-	subject := string(append([]byte(nil), sub.subject...))
+	subject := string(sub.subject)
 	tsa := [32]string{}
 	tokens := tsa[:0]
 	start := 0


### PR DESCRIPTION
The Insert function on \*Sublist converts the subject of the given subscription to a string.

Before this change, the conversion was done in 2 steps:
1. Appending the subject to a nil byte-slice, causing a new byte slice to be allocated.
2. Converting the new byte-slice to a string.

This is done so that the code doesn't (potentially) hold on to the original byte-slice, which might be a part of a larger slice (thus preventing it from being deallocated).

But step 1 is unnecessary, as step 2 always allocates a new string with the exact length and capacity needed.

This change removes step 1 an relies on step 2 only.

Benchmark results:

```
name                                    old time/op    new time/op    delta
______________________SublistInsert-4      971ns ± 0%     766ns ± 4%   ~             (p=0.100 n=3+3)
____________SublistMatchSingleToken-4     54.8ns ± 0%    54.8ns ± 0%   ~             (p=1.000 n=3+3)
______________SublistMatchTwoTokens-4     58.1ns ± 1%    58.3ns ± 1%   ~             (p=1.000 n=3+3)
____________SublistMatchThreeTokens-4     61.3ns ± 0%    61.1ns ± 0%   ~             (p=0.700 n=3+3)
_____________SublistMatchFourTokens-4     65.6ns ± 0%    64.6ns ± 1%   ~             (p=0.100 n=3+3)
_SublistMatchFourTokensSingleResult-4     65.7ns ± 1%    64.4ns ± 1%   ~             (p=0.100 n=3+3)
_SublistMatchFourTokensMultiResults-4     69.2ns ± 0%    68.4ns ± 1%   ~             (p=0.100 n=3+3)
_______SublistMissOnLastTokenOfFive-4     72.5ns ± 0%    71.6ns ± 0%   ~             (p=0.100 n=3+3)
_____________Sublist10XMultipleReads-4    1.93µs ± 3%    1.63µs ±32%   ~             (p=0.400 n=3+3)
____________Sublist100XMultipleReads-4    14.2µs ±48%    13.5µs ±28%   ~             (p=1.000 n=3+3)
ParseInt-4                                53.0ns ± 0%    53.6ns ± 1%   ~             (p=0.100 n=3+3)
ParseSize-4                               20.2ns ± 0%    20.3ns ± 1%   ~             (p=1.000 n=3+3)
DeferMutex-4                               162ns ± 2%     162ns ± 1%   ~             (p=1.000 n=3+3)
NoDeferMutex-4                            27.8ns ± 1%    28.6ns ± 0%   ~             (p=0.100 n=3+3)
ArrayRand-4                               65.4ns ± 0%    67.3ns ± 6%   ~             (p=1.000 n=3+3)
MapRange-4                                66.8ns ± 1%    66.6ns ± 1%   ~             (p=0.600 n=3+3)

name                                    old alloc/op   new alloc/op   delta
______________________SublistInsert-4      98.0B ± 0%     60.0B ± 0%   ~             (p=0.100 n=3+3)
____________SublistMatchSingleToken-4     0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
______________SublistMatchTwoTokens-4     0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
____________SublistMatchThreeTokens-4     0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
_____________SublistMatchFourTokens-4     0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
_SublistMatchFourTokensSingleResult-4     0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
_SublistMatchFourTokensMultiResults-4     0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
_______SublistMissOnLastTokenOfFive-4     0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
_____________Sublist10XMultipleReads-4    0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
____________Sublist100XMultipleReads-4    0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
ParseInt-4                                0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
ParseSize-4                               0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
DeferMutex-4                              0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
NoDeferMutex-4                            0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
ArrayRand-4                               0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
MapRange-4                                0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)

name                                    old allocs/op  new allocs/op  delta
______________________SublistInsert-4       2.00 ± 0%      1.00 ± 0%   ~             (p=0.100 n=3+3)
____________SublistMatchSingleToken-4      0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
______________SublistMatchTwoTokens-4      0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
____________SublistMatchThreeTokens-4      0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
_____________SublistMatchFourTokens-4      0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
_SublistMatchFourTokensSingleResult-4      0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
_SublistMatchFourTokensMultiResults-4      0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
_______SublistMissOnLastTokenOfFive-4      0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
_____________Sublist10XMultipleReads-4     0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
____________Sublist100XMultipleReads-4     0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
ParseInt-4                                 0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
ParseSize-4                                0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
DeferMutex-4                               0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
NoDeferMutex-4                             0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
ArrayRand-4                                0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
MapRange-4                                 0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
```

Numbers are the average of 3 runs with and without the change. This machine is somewhat noisy and results fluctuate (only CPU, not allocs), but the numbers show the SublistInsert benchmark go down from 971ns to 766ns, the allocs per operation go down from 2 to 1 and the number of bytes per operation go down from 98 to 60.

I also also checked that the allocation from step 2 really is still there and works as inteded. Here is the result from pprof:

```
    698119     698119 (flat, cum)   100% of Total
         .          .     81:}
         .          .     82:
         .          .     83:// Insert adds a subscription into the sublist
         .          .     84:func (s *Sublist) Insert(sub *subscription) error {
         .          .     85:   // copy the subject since we hold this and this might be part of a large byte slice.
    310039     310039     86:   subject := string(sub.subject)
         .          .     87:   tsa := [32]string{}
         .          .     88:   tokens := tsa[:0]
         .          .     89:   start := 0
         .          .     90:   for i := 0; i < len(subject); i++ {
         .          .     91:           if subject[i] == btsep {
         .          .     92:                   tokens = append(tokens, subject[start:i])
         .          .     93:                   start = i + 1
         .          .     94:           }
         .          .     95:   }
         .          .     96:   tokens = append(tokens, subject[start:])
```

Being a bit paranoid about it, I also verified it manually, by looking at the generated assembly with go build -gcflags="-S" and by reading the code of the function that converts the []byte to string in the Go runtime.

Go version: go version go1.6 windows/amd64
OS: Windows 8.1