### PR TITLE
Make sure that the we copy the subject when converting

### DIFF
--- a/server/sublist.go
+++ b/server/sublist.go
@@ -83,7 +83,7 @@ func NewSublist() *Sublist {
 // Insert adds a subscription into the sublist
 func (s *Sublist) Insert(sub *subscription) error {
 	// copy the subject since we hold this and this might be part of a large byte slice.
-	subject := string(sub.subject)
+	subject := (" " + string(sub.subject))[1:]
 	tsa := [32]string{}
 	tokens := tsa[:0]
 	start := 0


### PR DESCRIPTION
[As noted](https://github.com/nats-io/gnatsd/pull/239#discussion_r58732109) in PR #239 we should make sure, that the string really gets allocated and does not reuse the memory of sub.subject.

By appending to the string and then reslicing, we force the compiler to make an allocation.
I tried a few other things, but this should be enough.

This slightly increases the number of bytes allocated, but doesn't increase the number of allocations in Insert.