### PR TITLE
Dynamic writes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,7 @@
 - [ ] Limit number of subscriptions a client can have, total memory usage etc.
 - [ ] Multi-tenant accounts with isolation of subject space
 - [ ] Pedantic state
-- [ ] Write dynamic socket buffer sizes
+- [X] Write dynamic socket buffer sizes
 - [X] Read dynamic socket buffer sizes
 - [X] Info updates contain other implicit route servers
 - [X] Sublist better at high concurrency, cache uses writelock always currently

--- a/gnatsd.go
+++ b/gnatsd.go
@@ -67,10 +67,6 @@ func main() {
 	flag.StringVar(&opts.TLSKey, "tlskey", "", "Private key for server certificate.")
 	flag.StringVar(&opts.TLSCaCert, "tlscacert", "", "Client certificate CA for verification.")
 
-	// Not public per se, will be replaced with dynamic system, but can be used to lower memory footprint when
-	// lots of connections present.
-	flag.IntVar(&opts.BufSize, "bs", 0, "Read/Write buffer size per client connection.")
-
 	flag.Usage = server.Usage
 
 	flag.Parse()

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -52,7 +52,7 @@ var defaultServerOptions = Options{
 
 func rawSetup(serverOptions Options) (*Server, *client, *bufio.Reader, string) {
 	cli, srv := net.Pipe()
-	cr := bufio.NewReaderSize(cli, DEFAULT_BUF_SIZE)
+	cr := bufio.NewReaderSize(cli, maxBufSize)
 	s := New(&serverOptions)
 	if serverOptions.Authorization != "" {
 		s.SetClientAuthMethod(&mockAuth{})

--- a/server/const.go
+++ b/server/const.go
@@ -82,8 +82,4 @@ const (
 
 	// MAX_PUB_ARGS Maximum possible number of arguments from PUB proto.
 	MAX_PUB_ARGS = 3
-
-	// DEFAULT_BUF_SIZE is the default buffer size for reads and writes per connection.
-	// It will be replaced by a dynamic system in the long run.
-	DEFAULT_BUF_SIZE = 32768
 )

--- a/server/opts.go
+++ b/server/opts.go
@@ -53,7 +53,6 @@ type Options struct {
 	RemoteSyslog       string        `json:"-"`
 	Routes             []*url.URL    `json:"-"`
 	RoutesStr          string        `json:"-"`
-	BufSize            int           `json:"-"`
 	TLSTimeout         float64       `json:"tls_timeout"`
 	TLS                bool          `json:"-"`
 	TLSVerify          bool          `json:"-"`
@@ -571,8 +570,5 @@ func processOptions(opts *Options) {
 	}
 	if opts.MaxPending == 0 {
 		opts.MaxPending = MAX_PENDING_SIZE
-	}
-	if opts.BufSize == 0 {
-		opts.BufSize = DEFAULT_BUF_SIZE
 	}
 }

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -24,7 +24,6 @@ func TestDefaultOptions(t *testing.T) {
 		MaxPending:         MAX_PENDING_SIZE,
 		ClusterAuthTimeout: float64(AUTH_TIMEOUT) / float64(time.Second),
 		ClusterTLSTimeout:  float64(TLS_TIMEOUT) / float64(time.Second),
-		BufSize:            DEFAULT_BUF_SIZE,
 	}
 
 	opts := &Options{}

--- a/server/route.go
+++ b/server/route.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2015 Apcera Inc. All rights reserved.
+// Copyright 2013-2016 Apcera Inc. All rights reserved.
 
 package server
 
@@ -331,7 +331,7 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 		}
 
 		// Rewrap bw
-		c.bw = bufio.NewWriterSize(c.nc, s.opts.BufSize)
+		c.bw = bufio.NewWriterSize(c.nc, startBufSize)
 
 		// Do final client initialization
 

--- a/server/server.go
+++ b/server/server.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2015 Apcera Inc. All rights reserved.
+// Copyright 2012-2016 Apcera Inc. All rights reserved.
 
 package server
 
@@ -530,7 +530,7 @@ func (s *Server) createClient(conn net.Conn) *client {
 		c.mu.Lock()
 
 		// Rewrap bw
-		c.bw = bufio.NewWriterSize(c.nc, s.opts.BufSize)
+		c.bw = bufio.NewWriterSize(c.nc, startBufSize)
 
 		// Do final client initialization
 


### PR DESCRIPTION
This allows outbound buffers to clients to dynamically resize. Helps memory footprint with lots of connections and pairs with the read buffer work.

/cc @kozlovic