### PR TITLE
Fix data race

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -310,23 +310,28 @@ func (c *client) processConnect(arg []byte) error {
 	c.mu.Lock()
 	c.clearAuthTimer()
 	c.last = time.Now()
+	typ := c.typ
+	r := c.route
+	srv := c.srv
 	c.mu.Unlock()
 
 	if err := json.Unmarshal(arg, &c.opts); err != nil {
 		return err
 	}
 
-	if c.srv != nil {
+	if srv != nil {
 		// Check for Auth
-		if ok := c.srv.checkAuth(c); !ok {
+		if ok := srv.checkAuth(c); !ok {
 			c.authViolation()
 			return ErrAuthorization
 		}
 	}
 
 	// Grab connection name of remote route.
-	if c.typ == ROUTER && c.route != nil {
+	if typ == ROUTER && r != nil {
+		c.mu.Lock()
 		c.route.remoteID = c.opts.Name
+		c.mu.Unlock()
 	}
 
 	if c.opts.Verbose {

--- a/server/server.go
+++ b/server/server.go
@@ -690,10 +690,14 @@ func (s *Server) checkAuth(c *client) bool {
 
 // Remove a client or route from our internal accounting.
 func (s *Server) removeClient(c *client) {
+	var rID string
 	c.mu.Lock()
 	cid := c.cid
 	typ := c.typ
 	r := c.route
+	if r != nil {
+		rID = r.remoteID
+	}
 	c.mu.Unlock()
 
 	s.mu.Lock()
@@ -703,10 +707,10 @@ func (s *Server) removeClient(c *client) {
 	case ROUTER:
 		delete(s.routes, cid)
 		if r != nil {
-			rc, ok := s.remotes[r.remoteID]
+			rc, ok := s.remotes[rID]
 			// Only delete it if it is us..
 			if ok && c == rc {
-				delete(s.remotes, r.remoteID)
+				delete(s.remotes, rID)
 			}
 		}
 	}


### PR DESCRIPTION
When processing a connect request, there was a risk of race condition
when the server was being shutdown. Capture fields that are checked
under lock and lock when setting the route's remote ID.

Resolves #255