### PR TITLE
Add a live connection count to connz monitoring.

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -92,6 +92,7 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 	// number total of clients. The resulting ConnInfo array
 	// may be smaller if pagination is used.
 	totalClients := len(s.clients)
+	c.TotalLive = len(s.clients)
 
 	i := 0
 	pairs := make(Pairs, totalClients)
@@ -147,7 +148,6 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 	// Now we have the real number of ConnInfo objects, we can set c.NumConns
 	// and allocate the array
 	c.NumConns = len(pairs)
-	c.TotalLive = len(s.clients)
 	c.Conns = make([]ConnInfo, c.NumConns)
 
 	i = 0

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -26,11 +26,12 @@ func init() {
 
 // Connz represents detailed information on current client connections.
 type Connz struct {
-	Now      time.Time  `json:"now"`
-	NumConns int        `json:"num_connections"`
-	Offset   int        `json:"offset"`
-	Limit    int        `json:"limit"`
-	Conns    []ConnInfo `json:"connections"`
+	Now       time.Time  `json:"now"`
+	NumConns  int        `json:"num_connections"`
+	TotalLive int        `json:"total_live"`
+	Offset    int        `json:"offset"`
+	Limit     int        `json:"limit"`
+	Conns     []ConnInfo `json:"connections"`
 }
 
 // ConnInfo has detailed information on a per connection basis.
@@ -146,6 +147,7 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 	// Now we have the real number of ConnInfo objects, we can set c.NumConns
 	// and allocate the array
 	c.NumConns = len(pairs)
+	c.TotalLive = len(s.clients)
 	c.Conns = make([]ConnInfo, c.NumConns)
 
 	i = 0

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -26,12 +26,12 @@ func init() {
 
 // Connz represents detailed information on current client connections.
 type Connz struct {
-	Now       time.Time  `json:"now"`
-	NumConns  int        `json:"num_connections"`
-	TotalLive int        `json:"total_live"`
-	Offset    int        `json:"offset"`
-	Limit     int        `json:"limit"`
-	Conns     []ConnInfo `json:"connections"`
+	Now      time.Time  `json:"now"`
+	NumConns int        `json:"num_connections"`
+	Total    int        `json:"total"`
+	Offset   int        `json:"offset"`
+	Limit    int        `json:"limit"`
+	Conns    []ConnInfo `json:"connections"`
 }
 
 // ConnInfo has detailed information on a per connection basis.
@@ -92,7 +92,7 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 	// number total of clients. The resulting ConnInfo array
 	// may be smaller if pagination is used.
 	totalClients := len(s.clients)
-	c.TotalLive = len(s.clients)
+	c.Total = totalClients
 
 	i := 0
 	pairs := make(Pairs, totalClients)

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -211,6 +211,9 @@ func TestConnz(t *testing.T) {
 	if c.NumConns != 0 {
 		t.Fatalf("Expected 0 connections, got %d\n", c.NumConns)
 	}
+	if c.TotalLive != 0 {
+		t.Fatalf("Expected 0 live connections, got %d\n", c.TotalLive)
+	}
 	if c.Conns == nil || len(c.Conns) != 0 {
 		t.Fatalf("Expected 0 connections in array, got %p\n", c.Conns)
 	}
@@ -237,10 +240,13 @@ func TestConnz(t *testing.T) {
 	}
 
 	if c.NumConns != 1 {
-		t.Fatalf("Expected 1 connections, got %d\n", c.NumConns)
+		t.Fatalf("Expected 1 connection, got %d\n", c.NumConns)
+	}
+	if c.TotalLive != 1 {
+		t.Fatalf("Expected 1 live connection, got %d\n", c.TotalLive)
 	}
 	if c.Conns == nil || len(c.Conns) != 1 {
-		t.Fatalf("Expected 1 connections in array, got %d\n", len(c.Conns))
+		t.Fatalf("Expected 1 connection in array, got %d\n", len(c.Conns))
 	}
 
 	if c.Limit != DefaultConnListSize {

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -211,8 +211,8 @@ func TestConnz(t *testing.T) {
 	if c.NumConns != 0 {
 		t.Fatalf("Expected 0 connections, got %d\n", c.NumConns)
 	}
-	if c.TotalLive != 0 {
-		t.Fatalf("Expected 0 live connections, got %d\n", c.TotalLive)
+	if c.Total != 0 {
+		t.Fatalf("Expected 0 live connections, got %d\n", c.Total)
 	}
 	if c.Conns == nil || len(c.Conns) != 0 {
 		t.Fatalf("Expected 0 connections in array, got %p\n", c.Conns)
@@ -242,8 +242,8 @@ func TestConnz(t *testing.T) {
 	if c.NumConns != 1 {
 		t.Fatalf("Expected 1 connection, got %d\n", c.NumConns)
 	}
-	if c.TotalLive != 1 {
-		t.Fatalf("Expected 1 live connection, got %d\n", c.TotalLive)
+	if c.Total != 1 {
+		t.Fatalf("Expected 1 live connection, got %d\n", c.Total)
 	}
 	if c.Conns == nil || len(c.Conns) != 1 {
 		t.Fatalf("Expected 1 connection in array, got %d\n", len(c.Conns))

--- a/test/monitor_test.go
+++ b/test/monitor_test.go
@@ -152,8 +152,8 @@ func TestConnz(t *testing.T) {
 	if c.NumConns != 0 {
 		t.Fatalf("Expected 0 connections, got %d\n", c.NumConns)
 	}
-	if c.TotalLive != 0 {
-		t.Fatalf("Expected 0 live connections, got %d\n", c.TotalLive)
+	if c.Total != 0 {
+		t.Fatalf("Expected 0 live connections, got %d\n", c.Total)
 	}
 	if c.Conns == nil || len(c.Conns) != 0 {
 		t.Fatalf("Expected 0 connections in array, got %p\n", c.Conns)
@@ -181,8 +181,8 @@ func TestConnz(t *testing.T) {
 	if c.NumConns != 1 {
 		t.Fatalf("Expected 1 connection, got %d\n", c.NumConns)
 	}
-	if c.TotalLive != 1 {
-		t.Fatalf("Expected 1 live connection, got %d\n", c.TotalLive)
+	if c.Total != 1 {
+		t.Fatalf("Expected 1 live connection, got %d\n", c.Total)
 	}
 	if c.Conns == nil || len(c.Conns) != 1 {
 		t.Fatalf("Expected 1 connection in array, got %p\n", c.Conns)
@@ -289,8 +289,8 @@ func TestTLSConnz(t *testing.T) {
 	if c.NumConns != 1 {
 		t.Fatalf("Expected 1 connection, got %d\n", c.NumConns)
 	}
-	if c.TotalLive != 1 {
-		t.Fatalf("Expected 1 live connection, got %d\n", c.TotalLive)
+	if c.Total != 1 {
+		t.Fatalf("Expected 1 live connection, got %d\n", c.Total)
 	}
 	if c.Conns == nil || len(c.Conns) != 1 {
 		t.Fatalf("Expected 1 connection in array, got %d\n", len(c.Conns))

--- a/test/monitor_test.go
+++ b/test/monitor_test.go
@@ -152,6 +152,9 @@ func TestConnz(t *testing.T) {
 	if c.NumConns != 0 {
 		t.Fatalf("Expected 0 connections, got %d\n", c.NumConns)
 	}
+	if c.TotalLive != 0 {
+		t.Fatalf("Expected 0 live connections, got %d\n", c.TotalLive)
+	}
 	if c.Conns == nil || len(c.Conns) != 0 {
 		t.Fatalf("Expected 0 connections in array, got %p\n", c.Conns)
 	}
@@ -176,10 +179,13 @@ func TestConnz(t *testing.T) {
 	}
 
 	if c.NumConns != 1 {
-		t.Fatalf("Expected 1 connections, got %d\n", c.NumConns)
+		t.Fatalf("Expected 1 connection, got %d\n", c.NumConns)
+	}
+	if c.TotalLive != 1 {
+		t.Fatalf("Expected 1 live connection, got %d\n", c.TotalLive)
 	}
 	if c.Conns == nil || len(c.Conns) != 1 {
-		t.Fatalf("Expected 1 connections in array, got %p\n", c.Conns)
+		t.Fatalf("Expected 1 connection in array, got %p\n", c.Conns)
 	}
 
 	if c.Limit != server.DefaultConnListSize {
@@ -281,10 +287,13 @@ func TestTLSConnz(t *testing.T) {
 	}
 
 	if c.NumConns != 1 {
-		t.Fatalf("Expected 1 connections, got %d\n", c.NumConns)
+		t.Fatalf("Expected 1 connection, got %d\n", c.NumConns)
+	}
+	if c.TotalLive != 1 {
+		t.Fatalf("Expected 1 live connection, got %d\n", c.TotalLive)
 	}
 	if c.Conns == nil || len(c.Conns) != 1 {
-		t.Fatalf("Expected 1 connections in array, got %d\n", len(c.Conns))
+		t.Fatalf("Expected 1 connection in array, got %d\n", len(c.Conns))
 	}
 
 	// Test inside details of each connection


### PR DESCRIPTION
Adds a new field, `total_live` to the `/connz` generated json, representing the number of live connections at the moment.