### PR TITLE
Update the Windows PSE Test

### DIFF
--- a/server/pse/pse_windows_test.go
+++ b/server/pse/pse_windows_test.go
@@ -1,5 +1,5 @@
 // Copyright 2016 Apcera Inc. All rights reserved.
-// +build win
+// +build windows
 
 package pse
 
@@ -93,13 +93,13 @@ func TestPSEmulationWin(t *testing.T) {
 	}
 	tRss = int64(fval)
 
-	if err = procUsage(&pcpu, &rss, &vss); err != nil {
+	if err = ProcUsage(&pcpu, &rss, &vss); err != nil {
 		t.Fatal("Error:  %v", err)
 	}
 	checkValues(t, pcpu, tPcpu, rss, tRss)
 
 	// Again to test image name caching
-	if err = procUsage(&pcpu, &rss, &vss); err != nil {
+	if err = ProcUsage(&pcpu, &rss, &vss); err != nil {
 		t.Fatal("Error:  %v", err)
 	}
 	checkValues(t, pcpu, tPcpu, rss, tRss)


### PR DESCRIPTION
While locally tested before committing, this test was inadvertently being skipped in the suite.
* Use the proper build flag
* Call ProcUsage (versus procUsage), as test has been moved.