### PR TITLE
Divide by # of processors to reflect what Task Manager displays.

### DIFF
--- a/server/pse/pse_windows.go
+++ b/server/pse/pse_windows.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -255,7 +256,12 @@ func ProcUsage(pcpu *float64, rss, vss *int64) error {
 		return fmt.Errorf("could not find pid in performance counter results")
 	}
 	// assign values from the performance counters
-	*pcpu = cpuAry[idx]
+	cpu := cpuAry[idx]
+	if cpu > 0.0 {
+		cpu /= float64(runtime.NumCPU())
+	}
+
+	*pcpu = cpu
 	*rss = int64(rssAry[idx])
 	*vss = int64(vssAry[idx])
 

--- a/server/pse/pse_windows.go
+++ b/server/pse/pse_windows.go
@@ -35,6 +35,7 @@ var (
 	processPid                                     int
 	pcQueryLock                                    sync.Mutex
 	initialSample                                  = true
+	numCPUs                                        int
 )
 
 // maxQuerySize is the number of values to return from a query.
@@ -157,6 +158,10 @@ func getProcessImageName() (name string) {
 func initCounters() (err error) {
 
 	processPid = os.Getpid()
+	numCPUs = runtime.NumCPU()
+	if numCPUs <= 0 {
+		numCPUs = 1
+	}
 	// require an addressible nil pointer
 	var source uint16
 	if err := pdhOpenQuery(&source, 0, &pcHandle); err != nil {
@@ -256,12 +261,7 @@ func ProcUsage(pcpu *float64, rss, vss *int64) error {
 		return fmt.Errorf("could not find pid in performance counter results")
 	}
 	// assign values from the performance counters
-	cpu := cpuAry[idx]
-	if cpu > 0.0 {
-		cpu /= float64(runtime.NumCPU())
-	}
-
-	*pcpu = cpu
+	*pcpu = cpuAry[idx] / float64(numCPUs)
 	*rss = int64(rssAry[idx])
 	*vss = int64(vssAry[idx])
 


### PR DESCRIPTION
When looking at performance counters directly, CPU percentage reflects the sum of % used across CPUs.  Divide by the number of processors to mirror what Task Manager reports when the NATS server process is using more than one processor (typically under a very high load).