### PR TITLE
Enable listen address parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,9 @@ Common Options:
 
 ```
 
-port: 4242      # port to listen for client connections
-net: apcera.me  # net interface to listen
+listen: localhost:4242 # host/port to listen for client connections
 
-http_port: 8222 # HTTP monitoring port
+http: localhost:8222 # HTTP monitoring port
 
 # Authorization for client connections
 authorization {
@@ -111,8 +110,7 @@ authorization {
 
 cluster {
 
-  host: '127.0.0.1'  # host/net interface
-  port: 4244         # port for inbound route connections
+  listen: localhost:4244 # host/port for inbound route connections
 
   # Authorization for route connections
   authorization {
@@ -179,14 +177,11 @@ Alternatively, you could use a configuration file, let's call it `seed.conf`, wi
 ```
 # Cluster Seed Node
 
-port: 4222
-net: 127.0.0.1
-
-http_port: 8222
+listen: 127.0.0.1:4222
+http: 8222
 
 cluster {
-  host: 127.0.0.1
-  port: 4248
+  listen: 127.0.0.1:4248
 }
 ```
 and start the server like this:
@@ -196,8 +191,8 @@ gnatsd -config ./seed.conf -D
 
 This will produce an output similar to:
 ```
-[75653] 2016/04/26 15:14:47.339321 [INF] Listening for route connections on localhost:4248
-[75653] 2016/04/26 15:14:47.340787 [INF] Listening for client connections on 0.0.0.0:4222
+[75653] 2016/04/26 15:14:47.339321 [INF] Listening for route connections on 127.0.0.1:4248
+[75653] 2016/04/26 15:14:47.340787 [INF] Listening for client connections on 127.0.0.1:4222
 [75653] 2016/04/26 15:14:47.340822 [DBG] server id is xZfu3u7usAPWkuThomoGzM
 [75653] 2016/04/26 15:14:47.340825 [INF] server is ready
 ```
@@ -307,8 +302,7 @@ with a CA authority to verify the client certificates.
 ```
 # Simple TLS config file
 
-net:  127.0.0.1
-port: 4443
+listen: 127.0.0.1:4443
 
 tls {
   cert_file:  "./configs/certs/server-cert.pem"
@@ -339,8 +333,7 @@ both directions. Certificates can be configured only for the server's cluster id
 
 ```
 cluster {
-  host: '127.0.0.1'
-  port: 4244
+  listen: 127.0.0.1:4244
 
   tls {
     # Route cert

--- a/server/configs/listen.conf
+++ b/server/configs/listen.conf
@@ -1,0 +1,12 @@
+# Copyright 2016 Apcera Inc. All rights reserved.
+
+# Test all permutations of listen address parsing, client, cluster and http.
+
+listen: 10.0.1.22:4422
+
+http: 127.0.0.1:8422
+https: 127.0.0.1:9443
+
+cluster {
+  listen: 127.0.0.1:4244
+}

--- a/server/configs/listen_port.conf
+++ b/server/configs/listen_port.conf
@@ -1,0 +1,3 @@
+# Copyright 2016 Apcera Inc. All rights reserved.
+
+listen: 8922

--- a/server/configs/listen_port_with_colon.conf
+++ b/server/configs/listen_port_with_colon.conf
@@ -1,0 +1,3 @@
+# Copyright 2016 Apcera Inc. All rights reserved.
+
+listen: :8922

--- a/server/configs/seed.conf
+++ b/server/configs/seed.conf
@@ -2,12 +2,10 @@
 
 # Cluster Seed Node
 
-port: 7222
-net: 127.0.0.1
+listen: 127.0.0.1:7222
 
-http_port: 9222
+http: 127.0.0.1:9222
 
 cluster {
-  host: 127.0.0.1
-  port: 7248
+  listen: 127.0.0.1:7248
 }

--- a/server/configs/seed_tls.conf
+++ b/server/configs/seed_tls.conf
@@ -2,14 +2,12 @@
 
 # Cluster Seed Node
 
-port: 7222
-net: 127.0.0.1
+listen: 127.0.0.1:7222
 
-http_port: 9222
+http: 127.0.0.1:9222
 
 cluster {
-  host: 127.0.0.1
-  port: 7248
+  listen: 127.0.0.1:7248
 
   tls {
     # Route cert

--- a/server/configs/srv_a.conf
+++ b/server/configs/srv_a.conf
@@ -2,12 +2,10 @@
 
 # Cluster Server A
 
-port: 7222
-net: 127.0.0.1
+listen: 127.0.0.1:7222
 
 cluster {
-  host: 127.0.0.1
-  port: 7244
+  listen: 127.0.0.1:7244
 
   authorization {
     user: ruser

--- a/server/configs/srv_a_bcrypt.conf
+++ b/server/configs/srv_a_bcrypt.conf
@@ -2,8 +2,7 @@
 
 # Cluster Server A
 
-host: 127.0.0.1
-port: 7222
+listen: 127.0.0.1:7222
 
 authorization {
   user: user
@@ -12,8 +11,7 @@ authorization {
 }
 
 cluster {
-  host: 127.0.0.1
-  port: 7244
+  listen: 127.0.0.1:7244
 
   authorization {
     user: ruser

--- a/server/configs/srv_b.conf
+++ b/server/configs/srv_b.conf
@@ -2,12 +2,10 @@
 
 # Cluster Server B
 
-port: 7224
-net: 127.0.0.1
+listen: 127.0.0.1:7224
 
 cluster {
-  host: 127.0.0.1
-  port: 7246
+  listen: 127.0.0.1:7246
 
   authorization {
     user: ruser

--- a/server/configs/srv_b_bcrypt.conf
+++ b/server/configs/srv_b_bcrypt.conf
@@ -2,8 +2,7 @@
 
 # Cluster Server B
 
-host: 127.0.0.1
-port: 7224
+listen: 127.0.0.1:7224
 
 authorization {
   user: user
@@ -12,8 +11,7 @@ authorization {
 }
 
 cluster {
-  host: 127.0.0.1
-  port: 7246
+  listen: 127.0.0.1:7246
 
   authorization {
     user: ruser

--- a/server/configs/test.conf
+++ b/server/configs/test.conf
@@ -1,10 +1,9 @@
 
 # Simple config file
 
-port: 4242
-net: localhost
+listen: localhost:4242
 
-http_port: 8222
+http: 8222
 
 authorization {
   user:     derek

--- a/server/configs/tls.conf
+++ b/server/configs/tls.conf
@@ -1,8 +1,7 @@
 
 # Simple TLS config file
 
-port: 4443
-net: localhost
+listen: localhost:4443
 
 tls {
   cert_file:  "./configs/certs/server.pem"

--- a/server/configs/tls_bad_cipher.conf
+++ b/server/configs/tls_bad_cipher.conf
@@ -1,8 +1,7 @@
 
 # Simple TLS config file
 
-port: 4443
-net: localhost
+listen: localhost:4443
 
 tls {
   cert_file:  "./configs/certs/server.pem"

--- a/server/configs/tls_ciphers.conf
+++ b/server/configs/tls_ciphers.conf
@@ -1,8 +1,7 @@
 
 # Simple TLS config file
 
-port: 4443
-net: localhost
+listen: localhost:4443
 
 tls {
   cert_file:  "./configs/certs/server.pem"

--- a/server/configs/tls_empty_cipher.conf
+++ b/server/configs/tls_empty_cipher.conf
@@ -1,8 +1,7 @@
 
 # Simple TLS config file
 
-port: 4443
-net: localhost
+listen: localhost:4443
 
 tls {
   cert_file:  "./configs/certs/server.pem"

--- a/server/configs/tls_test.conf
+++ b/server/configs/tls_test.conf
@@ -1,8 +1,7 @@
 
 # Simple TLS config file
 
-port: 4443
-net: localhost # net interface
+listen: localhost:4443
 
 tls {
   cert_file:  "./configs/certs/server.pem"

--- a/server/configs/tls_test.conf
+++ b/server/configs/tls_test.conf
@@ -1,0 +1,10 @@
+
+# Simple TLS config file
+
+port: 4443
+net: localhost # net interface
+
+tls {
+  cert_file:  "./configs/certs/server.pem"
+  key_file:   "./configs/certs/key.pem"
+}

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -23,6 +23,7 @@ const CLUSTER_PORT = 12444
 var DefaultMonitorOptions = Options{
 	Host:        "localhost",
 	Port:        CLIENT_PORT,
+	HTTPHost:    "127.0.0.1",
 	HTTPPort:    MONITOR_PORT,
 	ClusterHost: "localhost",
 	ClusterPort: CLUSTER_PORT,

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2015 Apcera Inc. All rights reserved.
+// Copyright 2013-2016 Apcera Inc. All rights reserved.
 
 package server
 
@@ -306,5 +306,86 @@ func TestRouteFlagOverrideWithMultiple(t *testing.T) {
 	if !reflect.DeepEqual(golden, merged) {
 		t.Fatalf("Options are incorrect.\nexpected: %+v\ngot: %+v",
 			golden, merged)
+	}
+}
+
+func TestListenConfig(t *testing.T) {
+	opts, err := ProcessConfigFile("./configs/listen.conf")
+	if err != nil {
+		t.Fatalf("Received an error reading config file: %v\n", err)
+	}
+	processOptions(opts)
+
+	// Normal clients
+	host := "10.0.1.22"
+	port := 4422
+
+	if opts.Host != host {
+		t.Fatalf("Received incorrect host %q, expected %q\n", opts.Host, host)
+	}
+	if opts.Port != port {
+		t.Fatalf("Received incorrect port %v, expected %v\n", opts.Port, port)
+	}
+
+	// Clustering
+	clusterHost := "127.0.0.1"
+	clusterPort := 4244
+
+	if opts.ClusterHost != clusterHost {
+		t.Fatalf("Received incorrect cluster host %q, expected %q\n", opts.ClusterHost, clusterHost)
+	}
+	if opts.ClusterPort != clusterPort {
+		t.Fatalf("Received incorrect cluster port %v, expected %v\n", opts.ClusterPort, clusterPort)
+	}
+
+	// HTTP
+	httpHost := "127.0.0.1"
+	httpPort := 8422
+
+	if opts.HTTPHost != httpHost {
+		t.Fatalf("Received incorrect http host %q, expected %q\n", opts.HTTPHost, httpHost)
+	}
+	if opts.HTTPPort != httpPort {
+		t.Fatalf("Received incorrect http port %v, expected %v\n", opts.HTTPPort, httpPort)
+	}
+
+	// HTTPS
+	httpsPort := 9443
+	if opts.HTTPSPort != httpsPort {
+		t.Fatalf("Received incorrect https port %v, expected %v\n", opts.HTTPSPort, httpsPort)
+	}
+}
+
+func TestListenPortOnlyConfig(t *testing.T) {
+	opts, err := ProcessConfigFile("./configs/listen_port.conf")
+	if err != nil {
+		t.Fatalf("Received an error reading config file: %v\n", err)
+	}
+	processOptions(opts)
+
+	port := 8922
+
+	if opts.Host != DEFAULT_HOST {
+		t.Fatalf("Received incorrect host %q, expected %q\n", opts.Host, DEFAULT_HOST)
+	}
+	if opts.Port != port {
+		t.Fatalf("Received incorrect port %v, expected %v\n", opts.Port, port)
+	}
+}
+
+func TestListenPortWithColonConfig(t *testing.T) {
+	opts, err := ProcessConfigFile("./configs/listen_port_with_colon.conf")
+	if err != nil {
+		t.Fatalf("Received an error reading config file: %v\n", err)
+	}
+	processOptions(opts)
+
+	port := 8922
+
+	if opts.Host != DEFAULT_HOST {
+		t.Fatalf("Received incorrect host %q, expected %q\n", opts.Host, DEFAULT_HOST)
+	}
+	if opts.Port != port {
+		t.Fatalf("Received incorrect port %v, expected %v\n", opts.Port, port)
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -445,14 +445,14 @@ func (s *Server) startMonitoring(secure bool) {
 	var err error
 
 	if secure {
-		hp = net.JoinHostPort(s.opts.Host, strconv.Itoa(s.opts.HTTPSPort))
+		hp = net.JoinHostPort(s.opts.HTTPHost, strconv.Itoa(s.opts.HTTPSPort))
 		Noticef("Starting https monitor on %s", hp)
 		config := *s.opts.TLSConfig
 		config.ClientAuth = tls.NoClientCert
 		s.http, err = tls.Listen("tcp", hp, &config)
 
 	} else {
-		hp = net.JoinHostPort(s.opts.Host, strconv.Itoa(s.opts.HTTPPort))
+		hp = net.JoinHostPort(s.opts.HTTPHost, strconv.Itoa(s.opts.HTTPPort))
 		Noticef("Starting http monitor on %s", hp)
 		s.http, err = net.Listen("tcp", hp)
 	}

--- a/test/configs/auth_seed.conf
+++ b/test/configs/auth_seed.conf
@@ -4,7 +4,7 @@
 
 listen: 127.0.0.1:4222
 
-http_port: 8222
+http: 8222
 
 cluster {
   listen: 127.0.0.1:4248

--- a/test/configs/auth_seed.conf
+++ b/test/configs/auth_seed.conf
@@ -2,14 +2,12 @@
 
 # Cluster Seed Node
 
-port: 4222
-net: 127.0.0.1
+listen: 127.0.0.1:4222
 
 http_port: 8222
 
 cluster {
-  host: '127.0.0.1'
-  port: 4248
+  listen: 127.0.0.1:4248
 
   authorization {
     user: ruser

--- a/test/configs/cluster.conf
+++ b/test/configs/cluster.conf
@@ -2,12 +2,10 @@
 
 # Cluster config file
 
-host: 127.0.0.1
-port: 4242
+listen: 127.0.0.1:4242
 
 cluster {
-  host: '127.0.0.1'
-  port: 4244
+  listen: 127.0.0.1:4244
 
   authorization {
     user: route_user

--- a/test/configs/override.conf
+++ b/test/configs/override.conf
@@ -2,8 +2,7 @@
 
 # Config file to test overrides to client
 
-host: 127.0.0.1
-port: 4224
+listen: 127.0.0.1:4224
 
 # maximum payload
 max_payload: 2222

--- a/test/configs/seed.conf
+++ b/test/configs/seed.conf
@@ -2,12 +2,10 @@
 
 # Cluster Seed Node
 
-port: 4222
-net: 127.0.0.1
+listen: 127.0.0.1:4222
 
 http_port: 8222
 
 cluster {
-  host: 127.0.0.1
-  port: 4248
+  listen: 127.0.0.1:4248
 }

--- a/test/configs/seed.conf
+++ b/test/configs/seed.conf
@@ -4,7 +4,7 @@
 
 listen: 127.0.0.1:4222
 
-http_port: 8222
+http: 8222
 
 cluster {
   listen: 127.0.0.1:4248

--- a/test/configs/srv_a.conf
+++ b/test/configs/srv_a.conf
@@ -2,12 +2,10 @@
 
 # Cluster Server A
 
-port: 4222
-net: 127.0.0.1
+listen: 127.0.0.1:4222
 
 cluster {
-  host: '127.0.0.1'
-  port: 4244
+  listen: 127.0.0.1:4244
 
   authorization {
     user: ruser

--- a/test/configs/srv_a_tls.conf
+++ b/test/configs/srv_a_tls.conf
@@ -2,12 +2,10 @@
 
 # Cluster Server A
 
-host: 127.0.0.1
-port: 4222
+listen: 127.0.0.1:4222
 
 cluster {
-  host: 127.0.0.1
-  port: 4244
+  listen: 127.0.0.1:4244
 
   tls {
     # Route cert

--- a/test/configs/srv_b.conf
+++ b/test/configs/srv_b.conf
@@ -2,12 +2,10 @@
 
 # Cluster Server B
 
-port: 4224
-net: 127.0.0.1
+listen: 127.0.0.1:4224
 
 cluster {
-  host: 127.0.0.1
-  port: 4246
+  listen: 127.0.0.1:4246
 
   authorization {
     user: ruser

--- a/test/configs/srv_b_tls.conf
+++ b/test/configs/srv_b_tls.conf
@@ -2,12 +2,10 @@
 
 # Cluster Server B
 
-host: 127.0.0.1
-port: 4224
+listen: 127.0.0.1:4224
 
 cluster {
-  host: 127.0.0.1
-  port: 4246
+  listen: 127.0.0.1:4246
 
   tls {
     # Route cert

--- a/test/configs/tls.conf
+++ b/test/configs/tls.conf
@@ -1,8 +1,7 @@
 
 # Simple TLS config file
 
-port: 4443
-net: localhost
+listen: localhost:4443
 
 https_port: 11522
 

--- a/test/configs/tls.conf
+++ b/test/configs/tls.conf
@@ -3,7 +3,7 @@
 
 listen: localhost:4443
 
-https_port: 11522
+https: 11522
 
 tls {
   # Server cert

--- a/test/configs/tlsverify.conf
+++ b/test/configs/tlsverify.conf
@@ -1,8 +1,7 @@
 
 # Simple TLS config file
 
-port: 4443
-net: localhost
+listen: localhost:4443
 
 tls {
   # Server cert

--- a/test/opts_test.go
+++ b/test/opts_test.go
@@ -1,10 +1,8 @@
-// Copyright 2015 Apcera Inc. All rights reserved.
+// Copyright 2015-2016 Apcera Inc. All rights reserved.
 
 package test
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestServerConfig(t *testing.T) {
 	srv, opts := RunServerWithConfig("./configs/override.conf")


### PR DESCRIPTION
Move away from addr and port to single (or array) or address strings under listen.

Also separate and enforce http host.