### PR TITLE
Concurrent map access in server/route.go

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -423,7 +423,10 @@ func (s *Server) routeSidQueueSubscriber(rsid []byte) (*subscription, bool) {
 	}
 	sid := matches[RSID_SID_INDEX]
 
-	if sub, ok := client.subs[string(sid)]; ok {
+	client.mu.Lock()
+	sub, ok := client.subs[string(sid)]
+	client.mu.Unlock()
+	if ok {
 		return sub, true
 	}
 	return nil, true


### PR DESCRIPTION
Hi there, 

We got the following trace today testing nats 8.

```
goroutine 59 [running]:
runtime.throw(0x947620, 0x21)
	/usr/local/go/src/runtime/panic.go:547 +0x90 fp=0xc8200f3710 sp=0xc8200f36f8
runtime.mapaccess2_faststr(0x792fc0, 0xc8203149f0, 0xc82050c57b, 0x3, 0x3, 0x3)
	/usr/local/go/src/runtime/hashmap_fast.go:307 +0x5b fp=0xc8200f3770 sp=0xc8200f3710
github.com/nats-io/gnatsd/server.(*Server).routeSidQueueSubscriber(0xc82009d200, 0xc82050c573, 0xb, 0x3a8d, 0xc820245180, 0x39)
	/go/src/github.com/nats-io/gnatsd/server/route.go:426 +0x2a6 fp=0xc8200f3838 sp=0xc8200f3770
github.com/nats-io/gnatsd/server.(*client).processMsg(0xc8200aed00, 0xc82050c584, 0x25a, 0x3a7c)
	/go/src/github.com/nats-io/gnatsd/server/client.go:848 +0x5b2 fp=0xc8200f3ad0 sp=0xc8200f3838
github.com/nats-io/gnatsd/server.(*client).parse(0xc8200aed00, 0xc82050c000, 0x4000, 0x4000, 0x0, 0x0)
	/go/src/github.com/nats-io/gnatsd/server/parser.go:221 +0x1c94 fp=0xc8200f3d50 sp=0xc8200f3ad0
github.com/nats-io/gnatsd/server.(*client).readLoop(0xc8200aed00)
	/go/src/github.com/nats-io/gnatsd/server/client.go:178 +0x247 fp=0xc8200f3f80 sp=0xc8200f3d50
github.com/nats-io/gnatsd/server.(*Server).createRoute.func2()
	/go/src/github.com/nats-io/gnatsd/server/route.go:353 +0x20 fp=0xc8200f3f90 sp=0xc8200f3f80
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1998 +0x1 fp=0xc8200f3f98 sp=0xc8200f3f90
created by github.com/nats-io/gnatsd/server.(*Server).startGoRoutine
	/go/src/github.com/nats-io/gnatsd/server/server.go:821 +0x80
```
