### PR TITLE
Configuration Variables

### DIFF
--- a/conf/lex_test.go
+++ b/conf/lex_test.go
@@ -20,6 +20,15 @@ func expect(t *testing.T, lx *lexer, items []item) {
 	}
 }
 
+func TestPlainValue(t *testing.T) {
+	expectedItems := []item{
+		{itemKey, "foo", 1},
+		{itemEOF, "", 1},
+	}
+	lx := lex("foo")
+	expect(t, lx, expectedItems)
+}
+
 func TestSimpleKeyStringValues(t *testing.T) {
 	expectedItems := []item{
 		{itemKey, "foo", 1},
@@ -189,6 +198,20 @@ func TestDateValues(t *testing.T) {
 	}
 
 	lx := lex("foo = 2016-05-04T18:53:41Z")
+	expect(t, lx, expectedItems)
+}
+
+func TestVariableValues(t *testing.T) {
+	expectedItems := []item{
+		{itemKey, "foo", 1},
+		{itemVariable, "bar", 1},
+		{itemEOF, "", 1},
+	}
+	lx := lex("foo = $bar")
+	expect(t, lx, expectedItems)
+	lx = lex("foo =$bar")
+	expect(t, lx, expectedItems)
+	lx = lex("foo $bar")
 	expect(t, lx, expectedItems)
 }
 

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -89,6 +89,13 @@ func TestEnvVariable(t *testing.T) {
 	test(t, fmt.Sprintf("foo = $%s", evar), ex)
 }
 
+func TestBcryptVariable(t *testing.T) {
+	ex := map[string]interface{}{
+		"password": "$2a$11$ooo",
+	}
+	test(t, "password: $2a$11$ooo", ex)
+}
+
 var sample1 = `
 foo  {
   host {


### PR DESCRIPTION
PR to land first pass at configuration language supporting variable references. These will be block scoped from the parse state and can also come from the environment variables as well.