### PR TITLE
Add /stacksz to monitoring

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -61,6 +61,8 @@ type ConnInfo struct {
 // DefaultConnListSize is the default size of the connection list.
 const DefaultConnListSize = 1024
 
+const defaultStackBufSize = 10000
+
 // HandleConnz process HTTP requests for connection information.
 func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 	sortOpt := SortOpt(r.URL.Query().Get("sort"))
@@ -356,17 +358,17 @@ func (s *Server) HandleSubsz(w http.ResponseWriter, r *http.Request) {
 func (s *Server) HandleStacksz(w http.ResponseWriter, r *http.Request) {
 	// Do not get any lock here that would prevent getting the stacks
 	// if we were to have a deadlock somewhere.
-	var buf []byte
-	size := 10000
+	var defaultBuf [defaultStackBufSize]byte
+	size := defaultStackBufSize
+	buf := defaultBuf[:size]
 	n := 0
 	for {
-		buf = make([]byte, size)
 		n = runtime.Stack(buf, true)
 		if n < size {
 			break
 		}
-
 		size *= 2
+		buf = make([]byte, size)
 	}
 	// Handle response
 	ResponseHandler(w, r, buf[:n])

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -352,6 +352,26 @@ func (s *Server) HandleSubsz(w http.ResponseWriter, r *http.Request) {
 	ResponseHandler(w, r, b)
 }
 
+// HandleStacksz processes HTTP requests for getting stacks
+func (s *Server) HandleStacksz(w http.ResponseWriter, r *http.Request) {
+	// Do not get any lock here that would prevent gettign the stacks
+	// if we were to have a deadlock somewhere.
+	var buf []byte
+	size := 10000
+	n := 0
+	for {
+		buf = make([]byte, size)
+		n = runtime.Stack(buf, true)
+		if n < size {
+			break
+		}
+
+		size = 2 * size
+	}
+	// Handle response
+	ResponseHandler(w, r, buf[:n])
+}
+
 // Varz will output server information on the monitoring port at /varz.
 type Varz struct {
 	*Info

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -354,7 +354,7 @@ func (s *Server) HandleSubsz(w http.ResponseWriter, r *http.Request) {
 
 // HandleStacksz processes HTTP requests for getting stacks
 func (s *Server) HandleStacksz(w http.ResponseWriter, r *http.Request) {
-	// Do not get any lock here that would prevent gettign the stacks
+	// Do not get any lock here that would prevent getting the stacks
 	// if we were to have a deadlock somewhere.
 	var buf []byte
 	size := 10000
@@ -366,7 +366,7 @@ func (s *Server) HandleStacksz(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 
-		size = 2 * size
+		size *= 2
 	}
 	// Handle response
 	ResponseHandler(w, r, buf[:n])

--- a/server/server.go
+++ b/server/server.go
@@ -422,11 +422,12 @@ func (s *Server) StartHTTPSMonitoring() {
 
 // HTTP endpoints
 const (
-	RootPath   = "/"
-	VarzPath   = "/varz"
-	ConnzPath  = "/connz"
-	RoutezPath = "/routez"
-	SubszPath  = "/subsz"
+	RootPath    = "/"
+	VarzPath    = "/varz"
+	ConnzPath   = "/connz"
+	RoutezPath  = "/routez"
+	SubszPath   = "/subsz"
+	StackszPath = "/stacksz"
 )
 
 // Start the monitoring server
@@ -476,6 +477,8 @@ func (s *Server) startMonitoring(secure bool) {
 	mux.HandleFunc(SubszPath, s.HandleSubsz)
 	// Subz alias for backwards compatibility
 	mux.HandleFunc("/subscriptionsz", s.HandleSubsz)
+	// Stacksz
+	mux.HandleFunc(StackszPath, s.HandleStacksz)
 
 	srv := &http.Server{
 		Addr:           hp,


### PR DESCRIPTION
Allows to get the server's stacks from the monitoring interface.