### PR TITLE
Fix possible blocking on sock write or connection close (when using TLS)

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"crypto/tls"
 	"github.com/nats-io/nats"
 )
 
@@ -608,4 +609,92 @@ func TestUnsubRace(t *testing.T) {
 	sub.Unsubscribe()
 
 	wg.Wait()
+}
+
+func TestTLSCloseClientConnection(t *testing.T) {
+	opts, err := ProcessConfigFile("./configs/tls.conf")
+	if err != nil {
+		t.Fatalf("Error processign config file: %v", err)
+	}
+	opts.Authorization = ""
+	opts.TLSTimeout = 100
+	s := New(opts)
+	if s == nil {
+		panic("No NATS Server object returned.")
+	}
+	// Run server in Go routine.
+	go s.Start()
+	defer s.Shutdown()
+
+	endpoint := fmt.Sprintf("%s:%d", opts.Host, opts.Port)
+	conn, err := net.DialTimeout("tcp", endpoint, 2*time.Second)
+	if err != nil {
+		t.Fatalf("Unexpected error on dial: %v", err)
+	}
+	defer conn.Close()
+	br := bufio.NewReaderSize(conn, 100)
+	if _, err := br.ReadString('\n'); err != nil {
+		t.Fatalf("Unexpected error reading INFO: %v", err)
+	}
+
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	defer tlsConn.Close()
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("Unexpected error during handshake: %v", err)
+	}
+	br = bufio.NewReaderSize(tlsConn, 100)
+	connectOp := []byte("CONNECT {\"verbose\":false,\"pedantic\":false,\"tls_required\":true}\r\n")
+	if _, err := tlsConn.Write(connectOp); err != nil {
+		t.Fatalf("Unexpected error writing CONNECT: %v", err)
+	}
+	if _, err := tlsConn.Write([]byte("PING\r\n")); err != nil {
+		t.Fatalf("Unexpected error writing PING: %v", err)
+	}
+	if _, err := br.ReadString('\n'); err != nil {
+		t.Fatalf("Unexpected error reading PONG: %v", err)
+	}
+
+	getClient := func() *client {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		for _, c := range s.clients {
+			return c
+		}
+		return nil
+	}
+	// Wait for client to be registered.
+	timeout := time.Now().Add(5 * time.Second)
+	var cli *client
+	for time.Now().Before(timeout) {
+		cli = getClient()
+		if cli != nil {
+			break
+		}
+	}
+	if cli == nil {
+		t.Fatal("Did not register client on time")
+	}
+	// Fill the buffer. Need to send 1 byte at a time so that we timeout here
+	// the nc.Close() would block due to a write that can not complete.
+	done := false
+	for !done {
+		cli.nc.SetWriteDeadline(time.Now().Add(time.Second))
+		if _, err := cli.nc.Write([]byte("a")); err != nil {
+			done = true
+		}
+		cli.nc.SetWriteDeadline(time.Time{})
+	}
+	ch := make(chan bool)
+	go func() {
+		select {
+		case <-ch:
+			return
+		case <-time.After(3 * time.Second):
+			fmt.Println("!!!! closeConnection is blocked, test will hang !!!")
+			return
+		}
+	}()
+	// Close the client
+	cli.closeConnection()
+	ch <- true
 }

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -618,12 +618,7 @@ func TestTLSCloseClientConnection(t *testing.T) {
 	}
 	opts.Authorization = ""
 	opts.TLSTimeout = 100
-	s := New(opts)
-	if s == nil {
-		panic("No NATS Server object returned.")
-	}
-	// Run server in Go routine.
-	go s.Start()
+	s := RunServer(opts)
 	defer s.Shutdown()
 
 	endpoint := fmt.Sprintf("%s:%d", opts.Host, opts.Port)


### PR DESCRIPTION
Ensure that all socket writes are protected with deadlines.
For connection Close(), also use deadlines since in case of TLS,
the Close() will send an alert (do a write) if the handshake was
completed. If the peer is not reading, this would cause the Close()
to hang.