### PR TITLE
Simplify processMsg

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -797,12 +797,6 @@ func (c *client) processMsg(msg []byte) {
 	// Snapshot server.
 	srv := c.srv
 
-	// Create cache subs map if needed.
-	if c.cache.results == nil && srv != nil {
-		c.cache.results = make(map[string]*SublistResult)
-		c.cache.genid = atomic.LoadUint64(&srv.sl.genid)
-	}
-
 	// Update statistics
 	// The msg includes the CR_LF, so pull back out for accounting.
 	c.cache.inMsgs += 1
@@ -818,13 +812,10 @@ func (c *client) processMsg(msg []byte) {
 		return
 	}
 
-	var genid uint64
 	var r *SublistResult
 	var ok bool
 
-	if srv != nil {
-		genid = atomic.LoadUint64(&srv.sl.genid)
-	}
+	genid := atomic.LoadUint64(&srv.sl.genid)
 
 	if genid == c.cache.genid && c.cache.results != nil {
 		r, ok = c.cache.results[string(c.pa.subject)]
@@ -841,7 +832,7 @@ func (c *client) processMsg(msg []byte) {
 	}
 
 	// Check for no interest, short circuit if so.
-	if len(r.psubs) <= 0 && len(r.qsubs) <= 0 {
+	if len(r.psubs) == 0 && len(r.qsubs) == 0 {
 		return
 	}
 


### PR DESCRIPTION
This commit has 3 changes:

- Remove duplicate logic for creating cache results map.
- Move code out of an if that will always be true and remove the if.
- Use == 0 instead of <= 0 for comparing the return value of len(X) as the value can never be < 0.