### PR TITLE
rumprun unikernel support

### DIFF
--- a/server/pse/pse_rumprun.go
+++ b/server/pse/pse_rumprun.go
@@ -1,0 +1,12 @@
+// Copyright 2015-2016 Apcera Inc. All rights reserved.
+
+package pse
+
+// This is a placeholder for now.
+func ProcUsage(pcpu *float64, rss, vss *int64) error {
+	*pcpu = 0.0
+	*rss = 0
+	*vss = 0
+
+	return nil
+}

--- a/server/pse/pse_rumprun.go
+++ b/server/pse/pse_rumprun.go
@@ -1,4 +1,5 @@
 // Copyright 2015-2016 Apcera Inc. All rights reserved.
+// +build rumprun
 
 package pse
 


### PR DESCRIPTION
This is a stub to allow nats to run as a rumprun unikernel.