### PR TITLE
[ADDED] Server sends INFO with cluster URLs to clients with support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,7 @@
 
 # General
 
+- [ ] Auth for queue groups?
 - [ ] Blacklist or ERR escalation to close connection for auth/permissions
 - [ ] Protocol updates, MAP, MPUB, etc
 - [ ] Multiple listen endpoints

--- a/server/client.go
+++ b/server/client.go
@@ -110,6 +110,7 @@ type client struct {
 	parseState
 
 	route *route
+	debug bool
 	trace bool
 
 	flags clientFlag // Compact booleans into a single field. Size will be increased when needed.
@@ -179,6 +180,7 @@ func (c *client) initClient() {
 	c.cid = atomic.AddUint64(&s.gcid, 1)
 	c.bw = bufio.NewWriterSize(c.nc, startBufSize)
 	c.subs = make(map[string]*subscription)
+	c.debug = (atomic.LoadInt32(&debug) != 0)
 	c.trace = (atomic.LoadInt32(&trace) != 0)
 
 	// This is a scratch buffer used for processMsg()

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"crypto/tls"
+
 	"github.com/nats-io/nats"
 )
 
@@ -164,6 +165,49 @@ func TestClientConnect(t *testing.T) {
 
 	if !reflect.DeepEqual(c.opts, clientOpts{Verbose: true, Pedantic: true, Authorization: "YZZ222", Name: "router"}) {
 		t.Fatalf("Did not parse connect options correctly: %+v\n", c.opts)
+	}
+}
+
+func TestClientConnectProto(t *testing.T) {
+	_, c, _ := setupClient()
+
+	// Basic Connect setting flags, proto should be zero (original proto)
+	connectOp := []byte("CONNECT {\"verbose\":true,\"pedantic\":true,\"ssl_required\":false}\r\n")
+	err := c.parse(connectOp)
+	if err != nil {
+		t.Fatalf("Received error: %v\n", err)
+	}
+	if c.state != OP_START {
+		t.Fatalf("Expected state of OP_START vs %d\n", c.state)
+	}
+	if !reflect.DeepEqual(c.opts, clientOpts{Verbose: true, Pedantic: true, Protocol: ClientProtoZero}) {
+		t.Fatalf("Did not parse connect options correctly: %+v\n", c.opts)
+	}
+
+	// ProtoInfo
+	connectOp = []byte(fmt.Sprintf("CONNECT {\"verbose\":true,\"pedantic\":true,\"ssl_required\":false,\"protocol\":%d}\r\n", ClientProtoInfo))
+	err = c.parse(connectOp)
+	if err != nil {
+		t.Fatalf("Received error: %v\n", err)
+	}
+	if c.state != OP_START {
+		t.Fatalf("Expected state of OP_START vs %d\n", c.state)
+	}
+	if !reflect.DeepEqual(c.opts, clientOpts{Verbose: true, Pedantic: true, Protocol: ClientProtoInfo}) {
+		t.Fatalf("Did not parse connect options correctly: %+v\n", c.opts)
+	}
+	if c.opts.Protocol != ClientProtoInfo {
+		t.Fatalf("Protocol should have been set to %v, but is set to %v", ClientProtoInfo, c.opts.Protocol)
+	}
+
+	// Illegal Option
+	connectOp = []byte("CONNECT {\"protocol\":22}\r\n")
+	err = c.parse(connectOp)
+	if err == nil {
+		t.Fatalf("Expected to receive an error\n")
+	}
+	if err != ErrBadClientProtocol {
+		t.Fatalf("Expected err of %q, got  %q\n", ErrBadClientProtocol, err)
 	}
 }
 

--- a/server/errors.go
+++ b/server/errors.go
@@ -22,4 +22,7 @@ var (
 
 	// ErrReservedPublishSubject represents an error condition when sending to a reserved subject, e.g. _SYS.>
 	ErrReservedPublishSubject = errors.New("Reserved Internal Subject")
+
+	// ErrBadClientProtocol signals a client requested an invalud client protocol.
+	ErrBadClientProtocol = errors.New("Invalid Client Protocol")
 )

--- a/server/server.go
+++ b/server/server.go
@@ -341,7 +341,7 @@ func (s *Server) Shutdown() {
 }
 
 // AcceptLoop is exported for easier testing.
-func (s *Server) AcceptLoop(clientListenReady chan struct{}) {
+func (s *Server) AcceptLoop(clr chan struct{}) {
 	hp := net.JoinHostPort(s.opts.Host, strconv.Itoa(s.opts.Port))
 	Noticef("Listening for client connections on %s", hp)
 	l, e := net.Listen("tcp", hp)
@@ -383,7 +383,7 @@ func (s *Server) AcceptLoop(clientListenReady chan struct{}) {
 	s.mu.Unlock()
 
 	// Let the caller know that we are ready
-	close(clientListenReady)
+	close(clr)
 
 	tmpDelay := ACCEPT_MIN_SLEEP
 

--- a/server/server.go
+++ b/server/server.go
@@ -24,17 +24,21 @@ import (
 // Info is the information sent to clients to help them understand information
 // about this server.
 type Info struct {
-	ID           string `json:"server_id"`
-	Version      string `json:"version"`
-	GoVersion    string `json:"go"`
-	Host         string `json:"host"`
-	Port         int    `json:"port"`
-	AuthRequired bool   `json:"auth_required"`
-	SSLRequired  bool   `json:"ssl_required"` // DEPRECATED: ssl json used for older clients
-	TLSRequired  bool   `json:"tls_required"`
-	TLSVerify    bool   `json:"tls_verify"`
-	MaxPayload   int    `json:"max_payload"`
-	IP           string `json:"ip,omitempty"`
+	ID                string   `json:"server_id"`
+	Version           string   `json:"version"`
+	GoVersion         string   `json:"go"`
+	Host              string   `json:"host"`
+	Port              int      `json:"port"`
+	AuthRequired      bool     `json:"auth_required"`
+	SSLRequired       bool     `json:"ssl_required"` // DEPRECATED: ssl json used for older clients
+	TLSRequired       bool     `json:"tls_required"`
+	TLSVerify         bool     `json:"tls_verify"`
+	MaxPayload        int      `json:"max_payload"`
+	IP                string   `json:"ip,omitempty"`
+	ClientConnectURLs []string `json:"connect_urls,omitempty"` // Contains URLs a client can connect to.
+
+	// Used internally for quick look-ups.
+	clientConnectURLs map[string]struct{}
 }
 
 // Server is our main struct.
@@ -69,6 +73,7 @@ type Server struct {
 	grTmpClients  map[uint64]*client
 	grRunning     bool
 	grWG          sync.WaitGroup // to wait on various go routines
+	cproto        int64          // number of clients supporting async INFO
 }
 
 // Make sure all are 64bits for atomic use
@@ -89,16 +94,17 @@ func New(opts *Options) *Server {
 	verify := (tlsReq && opts.TLSConfig.ClientAuth == tls.RequireAnyClientCert)
 
 	info := Info{
-		ID:           genID(),
-		Version:      VERSION,
-		GoVersion:    runtime.Version(),
-		Host:         opts.Host,
-		Port:         opts.Port,
-		AuthRequired: false,
-		TLSRequired:  tlsReq,
-		SSLRequired:  tlsReq,
-		TLSVerify:    verify,
-		MaxPayload:   opts.MaxPayload,
+		ID:                genID(),
+		Version:           VERSION,
+		GoVersion:         runtime.Version(),
+		Host:              opts.Host,
+		Port:              opts.Port,
+		AuthRequired:      false,
+		TLSRequired:       tlsReq,
+		SSLRequired:       tlsReq,
+		TLSVerify:         verify,
+		MaxPayload:        opts.MaxPayload,
+		clientConnectURLs: make(map[string]struct{}),
 	}
 
 	s := &Server{
@@ -236,9 +242,15 @@ func (s *Server) Start() {
 		s.StartHTTPSMonitoring()
 	}
 
+	// The Routing routine needs to wait for the client listen
+	// port to be opened and potential ephemeral port selected.
+	clientListenReady := make(chan struct{})
+
 	// Start up routing as well if needed.
 	if s.opts.ClusterPort != 0 {
-		s.StartRouting()
+		s.startGoRoutine(func() {
+			s.StartRouting(clientListenReady)
+		})
 	}
 
 	// Pprof http endpoint for the profiler.
@@ -247,7 +259,7 @@ func (s *Server) Start() {
 	}
 
 	// Wait for clients.
-	s.AcceptLoop()
+	s.AcceptLoop(clientListenReady)
 }
 
 // Shutdown will shutdown the server instance by kicking out the AcceptLoop
@@ -329,7 +341,7 @@ func (s *Server) Shutdown() {
 }
 
 // AcceptLoop is exported for easier testing.
-func (s *Server) AcceptLoop() {
+func (s *Server) AcceptLoop(clientListenReady chan struct{}) {
 	hp := net.JoinHostPort(s.opts.Host, strconv.Itoa(s.opts.Port))
 	Noticef("Listening for client connections on %s", hp)
 	l, e := net.Listen("tcp", hp)
@@ -369,6 +381,9 @@ func (s *Server) AcceptLoop() {
 		s.opts.Port = portNum
 	}
 	s.mu.Unlock()
+
+	// Let the caller know that we are ready
+	close(clientListenReady)
 
 	tmpDelay := ACCEPT_MIN_SLEEP
 
@@ -597,6 +612,30 @@ func (s *Server) createClient(conn net.Conn) *client {
 	return c
 }
 
+// updateServerINFO updates the server's Info object with the given
+// array of URLs and re-generate the infoJSON byte array, only if the
+// given URLs were not already recorded.
+// Returns a boolean indicating if server's Info was updated.
+func (s *Server) updateServerINFO(urls []string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Will be set to true if we alter the server's Info object.
+	wasUpdated := false
+	for _, url := range urls {
+		if _, present := s.info.clientConnectURLs[url]; !present {
+
+			s.info.clientConnectURLs[url] = struct{}{}
+			s.info.ClientConnectURLs = append(s.info.ClientConnectURLs, url)
+			wasUpdated = true
+		}
+	}
+	if wasUpdated {
+		s.generateServerInfoJSON()
+	}
+	return wasUpdated
+}
+
 // Handle closing down a connection when the handshake has timedout.
 func tlsTimeout(c *client, conn *tls.Conn) {
 	c.mu.Lock()
@@ -700,12 +739,19 @@ func (s *Server) removeClient(c *client) {
 	if r != nil {
 		rID = r.remoteID
 	}
+	updateProtoInfoCount := false
+	if typ == CLIENT && c.opts.Protocol >= ClientProtoInfo {
+		updateProtoInfoCount = true
+	}
 	c.mu.Unlock()
 
 	s.mu.Lock()
 	switch typ {
 	case CLIENT:
 		delete(s.clients, cid)
+		if updateProtoInfoCount {
+			s.cproto--
+		}
 	case ROUTER:
 		delete(s.routes, cid)
 		if r != nil {
@@ -823,4 +869,46 @@ func (s *Server) startGoRoutine(f func()) {
 		go f()
 	}
 	s.grMu.Unlock()
+}
+
+// getClientConnectURLs returns suitable URLs for clients to connect to the listen
+// port based on the server options' Host and Port. If the Host corresponds to
+// "any" interfaces, this call returns the list of resolved IP addresses.
+func (s *Server) getClientConnectURLs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sPort := strconv.Itoa(s.opts.Port)
+	urls := make([]string, 0, 1)
+
+	ipAddr, err := net.ResolveIPAddr("ip", s.opts.Host)
+	// If the host is "any" (0.0.0.0 or ::), get specific IPs from available
+	// interfaces.
+	if err == nil && ipAddr.IP.IsUnspecified() {
+		var ip net.IP
+		ifaces, _ := net.Interfaces()
+		for _, i := range ifaces {
+			addrs, _ := i.Addrs()
+			for _, addr := range addrs {
+				switch v := addr.(type) {
+				case *net.IPNet:
+					ip = v.IP
+				case *net.IPAddr:
+					ip = v.IP
+				}
+				// Skip loopback/localhost
+				if ip.IsLoopback() {
+					ip = nil
+					continue
+				}
+				urls = append(urls, net.JoinHostPort(ip.String(), sPort))
+			}
+		}
+	}
+	if err != nil || len(urls) == 0 {
+		// We are here if s.opts.Host is not "0.0.0.0" nor "::", or if for some
+		// reason we could not add any URL in the loop above.
+		urls = append(urls, net.JoinHostPort(s.opts.Host, sPort))
+	}
+	return urls
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Apcera Inc. All rights reserved.
+// Copyright 2015-2016 Apcera Inc. All rights reserved.
 
 package server
 
@@ -136,5 +136,38 @@ func TestTlsCipher(t *testing.T) {
 	}
 	if !strings.Contains(tlsCipher(0x9999), "Unknown") {
 		t.Fatalf("Expected an unknown cipher.")
+	}
+}
+
+func TestGetConnectURLs(t *testing.T) {
+	opts := DefaultOptions
+	opts.Host = "0.0.0.0"
+	opts.Port = 4222
+	s := New(&opts)
+	defer s.Shutdown()
+
+	urls := s.getClientConnectURLs()
+	if len(urls) == 0 {
+		t.Fatal("Expected to get a list of urls, got none")
+	}
+	for _, u := range urls {
+		if strings.HasPrefix(u, opts.Host) {
+			t.Fatalf("This URL looks wrong: %v", u)
+		}
+	}
+	s.Shutdown()
+
+	opts.Host = "localhost"
+	opts.Port = 4222
+	s = New(&opts)
+	defer s.Shutdown()
+
+	expectedURL := "localhost:4222"
+	urls = s.getClientConnectURLs()
+	if len(urls) == 0 {
+		t.Fatal("Expected to get a list of urls, got none")
+	}
+	if urls[0] != expectedURL {
+		t.Fatalf("Expected to get %v, got %v", expectedURL, urls[0])
 	}
 }

--- a/test/test.go
+++ b/test/test.go
@@ -244,6 +244,13 @@ func setupConn(t tLogger, c net.Conn) (sendFun, expectFun) {
 	return sendCommand(t, c), expectCommand(t, c)
 }
 
+func setupConnWithProto(t tLogger, c net.Conn, proto int) (sendFun, expectFun) {
+	checkInfoMsg(t, c)
+	cs := fmt.Sprintf("CONNECT {\"verbose\":%v,\"pedantic\":%v,\"ssl_required\":%v,\"protocol\":%d}\r\n", false, false, false, proto)
+	sendProto(t, c, cs)
+	return sendCommand(t, c), expectCommand(t, c)
+}
+
 type sendFun func(string)
 type expectFun func(*regexp.Regexp) []byte
 


### PR DESCRIPTION
Clients that will be at the ClientProtoInfo protocol level (or above)
will now receive an asynchronous INFO protocol when the server
they connect to adds a *new* route. This means that when the cluster
adds a new server, all clients in the cluster should now be notified
of this new addition.