### PR TITLE
[IMPROVED] Route performance for larger messages

### DIFF
--- a/server/parser.go
+++ b/server/parser.go
@@ -503,6 +503,11 @@ func (c *client) parse(buf []byte) error {
 					return err
 				}
 				c.drop, c.as, c.state = 0, i+1, MSG_PAYLOAD
+
+				// jump ahead with the index. If this overruns
+				// what is left we fall out and process split
+				// buffer.
+				i = c.as + c.pa.size - 1
 			default:
 				if c.argBuf != nil {
 					c.argBuf = append(c.argBuf, b)
@@ -661,6 +666,7 @@ func (c *client) parse(buf []byte) error {
 		// We need to clone the pubArg if it is still referencing the
 		// read buffer and we are not able to process the msg.
 		if c.argBuf == nil {
+			// Works also for MSG_ARG, when message comes from ROUTE.
 			c.clonePubArg()
 		}
 

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -340,8 +340,6 @@ func TestParseMsgSpace(t *testing.T) {
 }
 
 func TestShouldFail(t *testing.T) {
-	c := dummyClient()
-
 	wrongProtos := []string{
 		"xxx",
 		"Px", "PIx", "PINx", " PING",
@@ -359,17 +357,17 @@ func TestShouldFail(t *testing.T) {
 		"Ix", "INx", "INFx", "INFO  \r\n",
 	}
 	for _, proto := range wrongProtos {
-		c.state = OP_START
+		c := dummyClient()
 		if err := c.parse([]byte(proto)); err == nil {
 			t.Fatalf("Should have received a parse error for: %v", proto)
 		}
 	}
 
 	// Special case for MSG, type needs to not be client.
-	c.typ = ROUTER
 	wrongProtos = []string{"Mx", "MSx", "MSGx", "MSG  \r\n"}
 	for _, proto := range wrongProtos {
-		c.state = OP_START
+		c := dummyClient()
+		c.typ = ROUTER
 		if err := c.parse([]byte(proto)); err == nil {
 			t.Fatalf("Should have received a parse error for: %v", proto)
 		}


### PR DESCRIPTION
Similar improvement that we got in the client's parser.

The PR includes benchmarks for routes. Here would be the results with/without the changes.
```
Original:
Benchmark_RoutePubSub_NoPayload-8	 3000000	       590 ns/op
Benchmark_RoutePubSub_1K-8       	  500000	      3119 ns/op
Benchmark_RoutePubSub_100K-8     	   10000	    128411 ns/op

Change in parser:
Benchmark_RoutePubSub_NoPayload-8	 3000000	       584 ns/op
Benchmark_RoutePubSub_1K-8       	 1000000	      1181 ns/op (2.64x faster)
Benchmark_RoutePubSub_100K-8     	   20000	     76809 ns/op (1.67x faster)
```

/cc @derekcollison 