### PR TITLE
[FIXED] Route/Cluster override

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -637,6 +637,9 @@ func MergeOptions(fileOpts, flagOpts *Options) *Options {
 	if flagOpts.ProfPort != 0 {
 		opts.ProfPort = flagOpts.ProfPort
 	}
+	if flagOpts.ClusterListenStr != "" {
+		opts.ClusterListenStr = flagOpts.ClusterListenStr
+	}
 	if flagOpts.RoutesStr != "" {
 		mergeRoutes(&opts, flagOpts)
 	}


### PR DESCRIPTION
If the server was started with a cluster section in a configuration
file and one would want to override the routes (using `-routes`) the
server would complain that you need to use `-cluster`. Adding
an override of cluster would not work, server would still complain.
Trying to override simply the cluster listen info (without override
of routes) would also not work.