### PR TITLE
[FIXED] Cluster's listener with IPv6

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -584,11 +584,13 @@ func (s *Server) broadcastUnSubscribe(sub *subscription) {
 }
 
 func (s *Server) routeAcceptLoop(ch chan struct{}) {
-	hp := fmt.Sprintf("%s:%d", s.opts.ClusterHost, s.opts.ClusterPort)
+	hp := net.JoinHostPort(s.opts.ClusterHost, strconv.Itoa(s.opts.ClusterPort))
 	Noticef("Listening for route connections on %s", hp)
 	l, e := net.Listen("tcp", hp)
 	if e != nil {
-		Fatalf("Error listening on router port: %d - %v", s.opts.Port, e)
+		// We need to close this channel to avoid a deadlock
+		close(ch)
+		Fatalf("Error listening on router port: %d - %v", s.opts.ClusterPort, e)
 		return
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -171,3 +171,18 @@ func TestGetConnectURLs(t *testing.T) {
 		t.Fatalf("Expected to get %v, got %v", expectedURL, urls[0])
 	}
 }
+
+func TestNoDeadlockOnStartFailure(t *testing.T) {
+	opts := DefaultOptions
+	opts.Host = "x.x.x.x" // bad host
+	opts.Port = 4222
+	opts.ClusterHost = "localhost"
+	opts.ClusterPort = 6222
+
+	s := New(&opts)
+	// This should return since it should fail to start a listener
+	// on x.x.x.x:4222
+	s.Start()
+	// We should be able to shutdown
+	s.Shutdown()
+}


### PR DESCRIPTION
Trying to use IPv6 address for the cluster host would fail.
Also, there were some unclosed channels in case of accept loop
setup failures.

Resolves #323