### PR TITLE
[FIXED] When server listens to any interface, return only global IPs

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -896,8 +896,8 @@ func (s *Server) getClientConnectURLs() []string {
 				case *net.IPAddr:
 					ip = v.IP
 				}
-				// Skip loopback/localhost
-				if ip.IsLoopback() {
+				// Skip non global unicast addresses
+				if !ip.IsGlobalUnicast() {
 					ip = nil
 					continue
 				}


### PR DESCRIPTION
The server was returning all resolved IP addresses, including link
local addresses, which did not make sense for remote clients.

Note that if server listens to localhost, it still returns that so that clusters running on single host (most likely test) will work. To avoid servers to advertise `localhost` as an URL you should start the server with a global IP address instead.

Resolves #321