### PR TITLE
Check that 0.0.0.0 or [::] is not returned as a client connect URL

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -916,7 +916,7 @@ func (s *Server) getClientConnectURLs() []string {
 					ip = v.IP
 				}
 				// Skip non global unicast addresses
-				if !ip.IsGlobalUnicast() {
+				if !ip.IsGlobalUnicast() || ip.IsUnspecified() {
 					ip = nil
 					continue
 				}
@@ -927,7 +927,15 @@ func (s *Server) getClientConnectURLs() []string {
 	if err != nil || len(urls) == 0 {
 		// We are here if s.opts.Host is not "0.0.0.0" nor "::", or if for some
 		// reason we could not add any URL in the loop above.
-		urls = append(urls, net.JoinHostPort(s.opts.Host, sPort))
+		// We had a case where a Windows VM was hosed and would have err == nil
+		// and not add any address in the array in the loop above, and we
+		// ended-up returning 0.0.0.0, which is problematic for Windows clients.
+		// Check for 0.0.0.0 or :: specifically, and ignore if that's the case.
+		if s.opts.Host == "0.0.0.0" || s.opts.Host == "::" {
+			Errorf("Address %q can not be resolved properly", s.opts.Host)
+		} else {
+			urls = append(urls, net.JoinHostPort(s.opts.Host, sPort))
+		}
 	}
 	return urls
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -162,6 +162,13 @@ func TestGetConnectURLs(t *testing.T) {
 			if !ip.IsGlobalUnicast() {
 				t.Fatalf("IP %v is not global", ip.String())
 			}
+			if ip.IsUnspecified() {
+				t.Fatalf("IP %v is unspecified", ip.String())
+			}
+			addr := strings.TrimSuffix(u, ":4222")
+			if addr == opts.Host {
+				t.Fatalf("Returned url is not right: %v", u)
+			}
 			if globalIP == nil {
 				globalIP = ip
 			}


### PR DESCRIPTION
We saw a case where a Windows VM would return 0.0.0.0 in the INFO
protocol. After debugging, it appeared that the VM had an issue
and a reboot solved it, but while in bad mode, the resolution of
the IP address would not return an error, but nothing was added
to the array and we ended-up adding at the last resort the 0.0.0.0
IP. This is a problem for Windows clients since they can't use
that IP to connect. In that situation, the server will now log an error
message and not return a client connect URL, which is fine.
