### PR TITLE
Enables using the same listen from server for monitoring endpoint via `-a`

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -758,6 +758,10 @@ func processOptions(opts *Options) {
 	if opts.Host == "" {
 		opts.Host = DEFAULT_HOST
 	}
+	if opts.HTTPHost == "" {
+		// Default to same bind from server if left undefined
+		opts.HTTPHost = opts.Host
+	}
 	if opts.Port == 0 {
 		opts.Port = DEFAULT_PORT
 	} else if opts.Port == RANDOM_PORT {

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -15,6 +15,7 @@ func TestDefaultOptions(t *testing.T) {
 		Host:               DEFAULT_HOST,
 		Port:               DEFAULT_PORT,
 		MaxConn:            DEFAULT_MAX_CONNECTIONS,
+		HTTPHost:           DEFAULT_HOST,
 		PingInterval:       DEFAULT_PING_INTERVAL,
 		MaxPingsOut:        DEFAULT_PING_MAX_OUT,
 		TLSTimeout:         float64(TLS_TIMEOUT) / float64(time.Second),
@@ -360,9 +361,12 @@ func TestListenConfig(t *testing.T) {
 	// Normal clients
 	host := "10.0.1.22"
 	port := 4422
-
+	monHost := "127.0.0.1"
 	if opts.Host != host {
 		t.Fatalf("Received incorrect host %q, expected %q\n", opts.Host, host)
+	}
+	if opts.HTTPHost != monHost {
+		t.Fatalf("Received incorrect host %q, expected %q\n", opts.HTTPHost, monHost)
 	}
 	if opts.Port != port {
 		t.Fatalf("Received incorrect port %v, expected %v\n", opts.Port, port)
@@ -409,6 +413,9 @@ func TestListenPortOnlyConfig(t *testing.T) {
 	if opts.Host != DEFAULT_HOST {
 		t.Fatalf("Received incorrect host %q, expected %q\n", opts.Host, DEFAULT_HOST)
 	}
+	if opts.HTTPHost != DEFAULT_HOST {
+		t.Fatalf("Received incorrect host %q, expected %q\n", opts.Host, DEFAULT_HOST)
+	}
 	if opts.Port != port {
 		t.Fatalf("Received incorrect port %v, expected %v\n", opts.Port, port)
 	}
@@ -426,8 +433,29 @@ func TestListenPortWithColonConfig(t *testing.T) {
 	if opts.Host != DEFAULT_HOST {
 		t.Fatalf("Received incorrect host %q, expected %q\n", opts.Host, DEFAULT_HOST)
 	}
+	if opts.HTTPHost != DEFAULT_HOST {
+		t.Fatalf("Received incorrect host %q, expected %q\n", opts.Host, DEFAULT_HOST)
+	}
 	if opts.Port != port {
 		t.Fatalf("Received incorrect port %v, expected %v\n", opts.Port, port)
+	}
+}
+
+func TestListenMonitoringDefault(t *testing.T) {
+	opts := &Options{
+		Host: "10.0.1.22",
+	}
+	processOptions(opts)
+
+	host := "10.0.1.22"
+	if opts.Host != host {
+		t.Fatalf("Received incorrect host %q, expected %q\n", opts.Host, host)
+	}
+	if opts.HTTPHost != host {
+		t.Fatalf("Received incorrect host %q, expected %q\n", opts.Host, host)
+	}
+	if opts.Port != DEFAULT_PORT {
+		t.Fatalf("Received incorrect port %v, expected %v\n", opts.Port, DEFAULT_PORT)
 	}
 }
 


### PR DESCRIPTION
Enables using the same listen from server as was specified via `--addr`, for the monitoring server:

```sh
# Sets both server and monitoring endpoint to listen on 127.0.0.1
$ gnatsd -a 127.0.0.1 -p 4222 -m 8222 --cluster nats://127.0.1.1:6222 --routes nats://127.0.0.1:6222,nats://127.0.1.2:6222
[22861] 2016/08/17 22:54:58.080511 [INF] Starting nats-server version 0.9.2
[22861] 2016/08/17 22:54:58.080594 [INF] Starting http monitor on 127.0.0.1:8222
[22861] 2016/08/17 22:54:58.080703 [INF] Listening for client connections on 127.0.0.1:4222
[22861] 2016/08/17 22:54:58.080739 [INF] Server is ready
[22861] 2016/08/17 22:54:58.080918 [INF] Listening for route connections on 127.0.1.1:6222
^C[22861] 2016/08/17 22:55:01.973635 [INF] Server Exiting..

# Default listen set for both
$ gnatsd -p 4222 -m 8222 --cluster nats://127.0.1.1:6222 --routes nats://127.0.0.1:6222,nats://127.0.1.2:6222
[22880] 2016/08/17 22:55:07.735592 [INF] Starting nats-server version 0.9.2
[22880] 2016/08/17 22:55:07.735672 [INF] Starting http monitor on 0.0.0.0:8222
[22880] 2016/08/17 22:55:07.735771 [INF] Listening for client connections on 0.0.0.0:4222
[22880] 2016/08/17 22:55:07.735813 [INF] Server is ready
[22880] 2016/08/17 22:55:07.736113 [INF] Listening for route connections on 127.0.1.1:6222
^C[22880] 2016/08/17 22:56:02.022849 [INF] Server Exiting..

# Monitoring endpoint disabled by default
$ gnatsd -p 4222 --cluster nats://127.0.1.1:6222 --routes nats://127.0.0.1:6222,nats://127.0.1.2:6222
[22901] 2016/08/17 22:56:07.948709 [INF] Starting nats-server version 0.9.2
[22901] 2016/08/17 22:56:07.948789 [INF] Listening for client connections on 0.0.0.0:4222
[22901] 2016/08/17 22:56:07.948873 [INF] Server is ready
[22901] 2016/08/17 22:56:07.949162 [INF] Listening for route connections on 127.0.1.1:6222
^C[22901] 2016/08/17 22:56:21.290168 [INF] Server Exiting..
```

before (not possible to customize listen for monitoring endpoint, only possible via config file):
```sh
$ gnatsd -a 127.0.0.1 -p 4222 -m 8222 --cluster nats://127.0.1.1:6222 --routes nats://127.0.0.1:6222,nats://127.0.1.2:6222
[23005] 2016/08/17 23:06:56.966082 [INF] Starting nats-server version 0.9.2
[23005] 2016/08/17 23:06:56.966214 [INF] Starting http monitor on :8222
[23005] 2016/08/17 23:06:56.966326 [INF] Listening for client connections on 127.0.0.1:4222
[23005] 2016/08/17 23:06:56.966355 [INF] Server is ready
[23005] 2016/08/17 23:06:56.966448 [INF] Listening for route connections on 127.0.1.1:6222

$ gnatsd -p 4222 -m 8222 --cluster nats://127.0.1.1:6222 --routes nats://127.0.0.1:6222,nats://127.0.1.2:6222
[22930] 2016/08/17 23:05:08.658069 [INF] Starting nats-server version 0.9.2
[22930] 2016/08/17 23:05:08.658193 [INF] Starting http monitor on :8222
[22930] 2016/08/17 23:05:08.658272 [INF] Listening for client connections on 0.0.0.0:4222
[22930] 2016/08/17 23:05:08.658296 [INF] Server is ready
[22930] 2016/08/17 23:05:08.658602 [INF] Listening for route connections on 127.0.1.1:6222
```
