### PR TITLE
[FIXED] Client certificate verification when `verify` is true.

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -309,7 +309,7 @@ func parseCluster(cm map[string]interface{}, opts *Options) error {
 			// as both client and server, so will mirror the rootCA to the
 			// clientCA pool.
 			opts.ClusterTLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
-			opts.ClusterTLSConfig.ClientCAs = opts.ClusterTLSConfig.RootCAs
+			opts.ClusterTLSConfig.RootCAs = opts.ClusterTLSConfig.ClientCAs
 			opts.ClusterTLSTimeout = tc.Timeout
 		case "no_advertise":
 			opts.ClusterNoAdvertise = mv.(bool)
@@ -573,7 +573,7 @@ func GenTLSConfig(tc *TLSConfigOpts) (*tls.Config, error) {
 
 	// Require client certificates as needed
 	if tc.Verify {
-		config.ClientAuth = tls.RequireAnyClientCert
+		config.ClientAuth = tls.RequireAndVerifyClientCert
 	}
 	// Add in CAs if applicable.
 	if tc.CaFile != "" {
@@ -586,7 +586,7 @@ func GenTLSConfig(tc *TLSConfigOpts) (*tls.Config, error) {
 		if !ok {
 			return nil, fmt.Errorf("failed to parse root ca certificate")
 		}
-		config.RootCAs = pool
+		config.ClientCAs = pool
 	}
 
 	return &config, nil

--- a/server/server.go
+++ b/server/server.go
@@ -91,7 +91,7 @@ func New(opts *Options) *Server {
 
 	// Process TLS options, including whether we require client certificates.
 	tlsReq := opts.TLSConfig != nil
-	verify := (tlsReq && opts.TLSConfig.ClientAuth == tls.RequireAnyClientCert)
+	verify := (tlsReq && opts.TLSConfig.ClientAuth == tls.RequireAndVerifyClientCert)
 
 	info := Info{
 		ID:                genID(),

--- a/test/configs/tlsverify_noca.conf
+++ b/test/configs/tlsverify_noca.conf
@@ -1,0 +1,18 @@
+
+# Simple TLS config file
+
+listen: localhost:4443
+
+tls {
+  # Server cert
+  cert_file: "./configs/certs/server-cert.pem"
+  # Server private key
+  key_file:  "./configs/certs/server-key.pem"
+  # Specified time for handshake to complete
+  timeout: 2
+  # Require a client certificate
+  verify:    true
+  # Omit the client CA, this is to verify that
+  # the server is really trying to verify the 
+  # client certificate.
+}


### PR DESCRIPTION
When `verify` was set to true in the configuration, the 
server was requiring a client certificate, but unfortunately
not verifying it.

Resolves #336