### PR TITLE
Fix non-ASCII quotes in HTML

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -442,7 +442,7 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
    <head>
     <link rel="shortcut icon" href="http://nats.io/img/favicon.ico">
     <style type="text/css">
-      body { font-family: “Century Gothic”, CenturyGothic, AppleGothic, sans-serif; font-size: 22; }
+      body { font-family: "Century Gothic", CenturyGothic, AppleGothic, sans-serif; font-size: 22; }
       a { margin-left: 32px; }
     </style>
   </head>

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/nats-io/nats"
 	"sync"
@@ -1167,6 +1168,17 @@ func TestHandleRoot(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Fatalf("Expected a 200 response, got %d\n", resp.StatusCode)
 	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Expected no error reading body: Got %v\n", err)
+	}
+	for _, b := range body {
+		if b > unicode.MaxASCII {
+			t.Fatalf("Expected body to contain only ASCII characters, but got %v\n", b)
+		}
+	}
+
 	ct := resp.Header.Get("Content-Type")
 	if !strings.Contains(ct, "text/html") {
 		t.Fatalf("Expected text/html response, got %s\n", ct)


### PR DESCRIPTION
Fixes #304 

Changes the non-ASCII curly quotes in the HTML to use the regular ASCII double quotes. Also adds a test to check for the existence of non-ASCII characters in that same HTML.