### PR TITLE
Create gnatsd user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ MAINTAINER Derek Collison <derek@apcera.com>
 COPY . /go/src/github.com/nats-io/gnatsd
 WORKDIR /go/src/github.com/nats-io/gnatsd
 
-RUN CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/gnatsd/version.GITCOMMIT=`git rev-parse --short HEAD`"
+RUN adduser --system --group --no-create-home --shell /bin/false gnatsd \
+    && CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/gnatsd/version.GITCOMMIT=`git rev-parse --short HEAD`"
 
 EXPOSE 4222 8222
 ENTRYPOINT ["gnatsd"]


### PR DESCRIPTION
Gnatsd runs as root in a container by default. This MR adds the `gnatsd` user (and group) to the docker container, which maybe used with `docker run -u` or docker compose to run the gnatsd process under that user.