### PR TITLE
[FIXED] SetLogger to be able to set debug/trace to 0

### DIFF
--- a/server/log.go
+++ b/server/log.go
@@ -37,17 +37,16 @@ type Logger interface {
 
 // SetLogger sets the logger of the server
 func (s *Server) SetLogger(logger Logger, debugFlag, traceFlag bool) {
-	debugVal := 0
 	if debugFlag {
-		debugVal = 1
+		atomic.StoreInt32(&debug, 1)
+	} else {
+		atomic.StoreInt32(&debug, 0)
 	}
-	atomic.StoreInt32(&debug, int32(debugVal))
-
-	traceVal := 0
 	if traceFlag {
-		traceVal = 1
+		atomic.StoreInt32(&trace, 1)
+	} else {
+		atomic.StoreInt32(&trace, 0)
 	}
-	atomic.StoreInt32(&trace, int32(traceVal))
 
 	log.Lock()
 	log.logger = logger

--- a/server/log.go
+++ b/server/log.go
@@ -37,13 +37,17 @@ type Logger interface {
 
 // SetLogger sets the logger of the server
 func (s *Server) SetLogger(logger Logger, debugFlag, traceFlag bool) {
+	debugVal := 0
 	if debugFlag {
-		atomic.StoreInt32(&debug, 1)
+		debugVal = 1
 	}
+	atomic.StoreInt32(&debug, int32(debugVal))
 
+	traceVal := 0
 	if traceFlag {
-		atomic.StoreInt32(&trace, 1)
+		traceVal = 1
 	}
+	atomic.StoreInt32(&trace, int32(traceVal))
 
 	log.Lock()
 	log.logger = logger

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -8,7 +8,8 @@ import (
 
 func TestSetLogger(t *testing.T) {
 	server := &Server{}
-	server.SetLogger(&DummyLogger{}, true, true)
+	dl := &DummyLogger{}
+	server.SetLogger(dl, true, true)
 
 	// We assert that the logger has change to the DummyLogger
 	_ = log.logger.(*DummyLogger)
@@ -19,6 +20,15 @@ func TestSetLogger(t *testing.T) {
 
 	if trace != 1 {
 		t.Fatalf("Expected trace 1, received value %d\n", trace)
+	}
+
+	// Make sure that we can reset to fal
+	server.SetLogger(dl, false, false)
+	if debug != 0 {
+		t.Fatalf("Expected debug 0, got %v", debug)
+	}
+	if trace != 0 {
+		t.Fatalf("Expected trace 0, got %v", trace)
 	}
 }
 


### PR DESCRIPTION
In NATS Streaming, we have a test - started early on - that was testing
logging and called SetLogger(l, true, true), then reset by calling
SetLogger(l, false, false) to reset the values. That obviously had not
the expected effect.
During profiling, I noticed that there were tons of allocated
objects due to NATS server debug/trace statements caused by that.