### PR TITLE
Generate syslog tags based on the name of the executable or link.

### DIFF
--- a/logger/syslog.go
+++ b/logger/syslog.go
@@ -9,6 +9,8 @@ import (
 	"log"
 	"log/syslog"
 	"net/url"
+	"os"
+	"strings"
 )
 
 // SysLogger provides a system logger facility
@@ -18,9 +20,24 @@ type SysLogger struct {
 	trace  bool
 }
 
+// GetSysLoggerTag generates the tag name for use in syslog statements. If
+// the executable is linked, the name of the link will be used as the tag,
+// otherwise, the name of the executable is used.  "gnatsd" is the default
+// for the NATS server.
+func GetSysLoggerTag() string {
+	procName := os.Args[0]
+	if strings.ContainsRune(procName, os.PathSeparator) {
+		parts := strings.FieldsFunc(procName, func(c rune) bool {
+			return c == os.PathSeparator
+		})
+		procName = parts[len(parts)-1]
+	}
+	return procName
+}
+
 // NewSysLogger creates a new system logger
 func NewSysLogger(debug, trace bool) *SysLogger {
-	w, err := syslog.New(syslog.LOG_DAEMON|syslog.LOG_NOTICE, "gnatsd")
+	w, err := syslog.New(syslog.LOG_DAEMON|syslog.LOG_NOTICE, GetSysLoggerTag())
 	if err != nil {
 		log.Fatalf("error connecting to syslog: %q", err.Error())
 	}
@@ -35,7 +52,7 @@ func NewSysLogger(debug, trace bool) *SysLogger {
 // NewRemoteSysLogger creates a new remote system logger
 func NewRemoteSysLogger(fqn string, debug, trace bool) *SysLogger {
 	network, addr := getNetworkAndAddr(fqn)
-	w, err := syslog.Dial(network, addr, syslog.LOG_DEBUG, "gnatsd")
+	w, err := syslog.Dial(network, addr, syslog.LOG_DEBUG, GetSysLoggerTag())
 	if err != nil {
 		log.Fatalf("error connecting to syslog: %q", err.Error())
 	}


### PR DESCRIPTION
When running multiple NATS servers on a machine and directing output to syslog, we need a way to differentiate the servers beyond process ID.  One way to do this is to use the link or executable name used to launch the process.  Users can then identify individual servers in the syslog output if they link to, or copy the NATS server.  Current behavior will be maintained when using the default NATS server executable.

Given files `gnatsd`, a copy of `gnatsd` (`gnatsd.1`) and a link `gnatsd-link`:

```
-rwxr-xr-x  1 colinsullivan  staff  9084636 Oct 18 11:35 gnatsd
lrwxr-xr-x  1 colinsullivan  staff       10 Oct 18 11:38 gnatsd-link -> ./gnatsd
-rwxr-xr-x  1 colinsullivan  staff  9084636 Oct 18 11:36 gnatsd.1
```

The NATS server will generate syslog statements based on the link or executable name stripped of the path, demonstrated below.  The command used is paired with a corresponding syslog statement.

`# ../tmp/gnatsd -s udp://localhost:512`
`Oct 18 11:50:15 machinename gnatsd[92147] <Notice>: Starting nats-server version 0.9.4`

`# ./gnatsd.1 -s udp://localhost:512`
`Oct 18 11:50:38 machinename gnatsd.1[92173] <Notice>: Starting nats-server version 0.9.4`

`# ./gnatsd-link -s udp://localhost:512`
`Oct 18 11:51:28 machinename gnatsd-link[92188] <Notice>: Starting nats-server version 0.9.4`

`# gnatsd -s udp://localhost:512`
`Oct 18 11:52:26 machinename gnatsd[92296] <Notice>: Starting nats-server version 0.9.4`

_Note:  An alternative is a command line parameter / server option._