### PR TITLE
Use 2 files for CloneTLSConfig instead of reflection

### DIFF
--- a/util/tls.go
+++ b/util/tls.go
@@ -1,46 +1,37 @@
 // Copyright 2016 Apcera Inc. All rights reserved.
+// +build go1.7
 
 package util
 
 import (
 	"crypto/tls"
-	"reflect"
 )
 
 // CloneTLSConfig returns a copy of c. Only the exported fields are copied.
 // This is temporary, until this is provided by the language.
 // https://go-review.googlesource.com/#/c/28075/
 func CloneTLSConfig(c *tls.Config) *tls.Config {
-	newConfig := &tls.Config{
-		Rand:                     c.Rand,
-		Time:                     c.Time,
-		Certificates:             c.Certificates,
-		NameToCertificate:        c.NameToCertificate,
-		GetCertificate:           c.GetCertificate,
-		RootCAs:                  c.RootCAs,
-		NextProtos:               c.NextProtos,
-		ServerName:               c.ServerName,
-		ClientAuth:               c.ClientAuth,
-		ClientCAs:                c.ClientCAs,
-		InsecureSkipVerify:       c.InsecureSkipVerify,
-		CipherSuites:             c.CipherSuites,
-		PreferServerCipherSuites: c.PreferServerCipherSuites,
-		SessionTicketsDisabled:   c.SessionTicketsDisabled,
-		SessionTicketKey:         c.SessionTicketKey,
-		ClientSessionCache:       c.ClientSessionCache,
-		MinVersion:               c.MinVersion,
-		MaxVersion:               c.MaxVersion,
-		CurvePreferences:         c.CurvePreferences,
+	return &tls.Config{
+		Rand:                        c.Rand,
+		Time:                        c.Time,
+		Certificates:                c.Certificates,
+		NameToCertificate:           c.NameToCertificate,
+		GetCertificate:              c.GetCertificate,
+		RootCAs:                     c.RootCAs,
+		NextProtos:                  c.NextProtos,
+		ServerName:                  c.ServerName,
+		ClientAuth:                  c.ClientAuth,
+		ClientCAs:                   c.ClientCAs,
+		InsecureSkipVerify:          c.InsecureSkipVerify,
+		CipherSuites:                c.CipherSuites,
+		PreferServerCipherSuites:    c.PreferServerCipherSuites,
+		SessionTicketsDisabled:      c.SessionTicketsDisabled,
+		SessionTicketKey:            c.SessionTicketKey,
+		ClientSessionCache:          c.ClientSessionCache,
+		MinVersion:                  c.MinVersion,
+		MaxVersion:                  c.MaxVersion,
+		CurvePreferences:            c.CurvePreferences,
+		DynamicRecordSizingDisabled: c.DynamicRecordSizingDisabled,
+		Renegotiation:               c.Renegotiation,
 	}
-	fieldName := "DynamicRecordSizingDisabled"
-	if cField := reflect.ValueOf(c).Elem().FieldByName(fieldName); cField.IsValid() {
-		newField := reflect.ValueOf(newConfig).Elem().FieldByName(fieldName)
-		newField.SetBool(cField.Bool())
-
-		fieldName = "Renegotiation"
-		cField = reflect.ValueOf(c).Elem().FieldByName(fieldName)
-		newField = reflect.ValueOf(newConfig).Elem().FieldByName(fieldName)
-		newField.SetInt(cField.Int())
-	}
-	return newConfig
 }

--- a/util/tls_pre17.go
+++ b/util/tls_pre17.go
@@ -1,0 +1,35 @@
+// Copyright 2016 Apcera Inc. All rights reserved.
+// +build go1.5,!go1.7
+
+package util
+
+import (
+	"crypto/tls"
+)
+
+// CloneTLSConfig returns a copy of c. Only the exported fields are copied.
+// This is temporary, until this is provided by the language.
+// https://go-review.googlesource.com/#/c/28075/
+func CloneTLSConfig(c *tls.Config) *tls.Config {
+	return &tls.Config{
+		Rand:                     c.Rand,
+		Time:                     c.Time,
+		Certificates:             c.Certificates,
+		NameToCertificate:        c.NameToCertificate,
+		GetCertificate:           c.GetCertificate,
+		RootCAs:                  c.RootCAs,
+		NextProtos:               c.NextProtos,
+		ServerName:               c.ServerName,
+		ClientAuth:               c.ClientAuth,
+		ClientCAs:                c.ClientCAs,
+		InsecureSkipVerify:       c.InsecureSkipVerify,
+		CipherSuites:             c.CipherSuites,
+		PreferServerCipherSuites: c.PreferServerCipherSuites,
+		SessionTicketsDisabled:   c.SessionTicketsDisabled,
+		SessionTicketKey:         c.SessionTicketKey,
+		ClientSessionCache:       c.ClientSessionCache,
+		MinVersion:               c.MinVersion,
+		MaxVersion:               c.MaxVersion,
+		CurvePreferences:         c.CurvePreferences,
+	}
+}


### PR DESCRIPTION
Use build directives to solve the problem of new fields in tls.Config
in go 1.7

Related to #231