### PR TITLE
Differentiate signal handling for windows

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -11,11 +11,9 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/signal"
 	"runtime"
 	"strconv"
 	"sync"
-	"syscall"
 	"time"
 
 	// Allow dynamic profiling.
@@ -180,30 +178,6 @@ func PrintAndDie(msg string) {
 func PrintServerAndExit() {
 	fmt.Printf("nats-server version %s\n", VERSION)
 	os.Exit(0)
-}
-
-// Signal Handling
-func (s *Server) handleSignals() {
-	if s.opts.NoSigs {
-		return
-	}
-	c := make(chan os.Signal, 1)
-
-	signal.Notify(c, syscall.SIGINT, syscall.SIGUSR1)
-
-	go func() {
-		for sig := range c {
-			Debugf("Trapped %q signal", sig)
-			switch sig {
-			case syscall.SIGINT:
-				Noticef("Server Exiting..")
-				os.Exit(0)
-			case syscall.SIGUSR1:
-				// File log re-open for rotating file logs.
-				s.ReOpenLogFile()
-			}
-		}
-	}()
 }
 
 // Protected check on running state

--- a/server/signal.go
+++ b/server/signal.go
@@ -1,0 +1,34 @@
+// +build !windows
+// Copyright 2012-2016 Apcera Inc. All rights reserved.
+
+package server
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// Signal Handling
+func (s *Server) handleSignals() {
+	if s.opts.NoSigs {
+		return
+	}
+	c := make(chan os.Signal, 1)
+
+	signal.Notify(c, syscall.SIGINT, syscall.SIGUSR1)
+
+	go func() {
+		for sig := range c {
+			Debugf("Trapped %q signal", sig)
+			switch sig {
+			case syscall.SIGINT:
+				Noticef("Server Exiting..")
+				os.Exit(0)
+			case syscall.SIGUSR1:
+				// File log re-open for rotating file logs.
+				s.ReOpenLogFile()
+			}
+		}
+	}()
+}

--- a/server/signal_windows.go
+++ b/server/signal_windows.go
@@ -1,0 +1,30 @@
+// Copyright 2012-2016 Apcera Inc. All rights reserved.
+
+package server
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// Signal Handling
+func (s *Server) handleSignals() {
+	if s.opts.NoSigs {
+		return
+	}
+	c := make(chan os.Signal, 1)
+
+	signal.Notify(c, syscall.SIGINT)
+
+	go func() {
+		for sig := range c {
+			Debugf("Trapped %q signal", sig)
+			switch sig {
+			case syscall.SIGINT:
+				Noticef("Server Exiting..")
+				os.Exit(0)
+			}
+		}
+	}()
+}

--- a/server/signal_windows.go
+++ b/server/signal_windows.go
@@ -5,7 +5,6 @@ package server
 import (
 	"os"
 	"os/signal"
-	"syscall"
 )
 
 // Signal Handling
@@ -15,16 +14,13 @@ func (s *Server) handleSignals() {
 	}
 	c := make(chan os.Signal, 1)
 
-	signal.Notify(c, syscall.SIGINT)
+	signal.Notify(c, os.Interrupt)
 
 	go func() {
 		for sig := range c {
 			Debugf("Trapped %q signal", sig)
-			switch sig {
-			case syscall.SIGINT:
-				Noticef("Server Exiting..")
-				os.Exit(0)
-			}
+			Noticef("Server Exiting..")
+			os.Exit(0)
 		}
 	}()
 }


### PR DESCRIPTION
Windows has limited support for signals, and does not define `syscall.SIGUSR1`.  Log rotation will be handled differently in windows.

* Add signal.go for all non-windows builds
* Add signal_windows.go for windows builds.

Today, windows looks to be the only platform that does not have `syscall.SIGUSR1` defined.

Resolves #381 