### PR TITLE
Remove "max_pending_size" option

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -29,9 +29,6 @@ const (
 	// something different if > 1MB payloads are needed.
 	MAX_PAYLOAD_SIZE = (1024 * 1024)
 
-	// MAX_PENDING_SIZE is the maximum outbound size (in bytes) per client.
-	MAX_PENDING_SIZE = (10 * 1024 * 1024)
-
 	// DEFAULT_MAX_CONNECTIONS is the default maximum connections allowed.
 	DEFAULT_MAX_CONNECTIONS = (64 * 1024)
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -53,7 +53,6 @@ type Options struct {
 	AuthTimeout        float64       `json:"auth_timeout"`
 	MaxControlLine     int           `json:"max_control_line"`
 	MaxPayload         int           `json:"max_payload"`
-	MaxPending         int           `json:"max_pending_size"`
 	ClusterHost        string        `json:"addr"`
 	ClusterPort        int           `json:"cluster_port"`
 	ClusterUsername    string        `json:"-"`
@@ -207,8 +206,6 @@ func ProcessConfigFile(configFile string) (*Options, error) {
 			opts.MaxControlLine = int(v.(int64))
 		case "max_payload":
 			opts.MaxPayload = int(v.(int64))
-		case "max_pending_size", "max_pending":
-			opts.MaxPending = int(v.(int64))
 		case "max_connections", "max_conn":
 			opts.MaxConn = int(v.(int64))
 		case "ping_interval":
@@ -796,8 +793,5 @@ func processOptions(opts *Options) {
 	}
 	if opts.MaxPayload == 0 {
 		opts.MaxPayload = MAX_PAYLOAD_SIZE
-	}
-	if opts.MaxPending == 0 {
-		opts.MaxPending = MAX_PENDING_SIZE
 	}
 }

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -22,7 +22,6 @@ func TestDefaultOptions(t *testing.T) {
 		AuthTimeout:        float64(AUTH_TIMEOUT) / float64(time.Second),
 		MaxControlLine:     MAX_CONTROL_LINE_SIZE,
 		MaxPayload:         MAX_PAYLOAD_SIZE,
-		MaxPending:         MAX_PENDING_SIZE,
 		ClusterHost:        DEFAULT_HOST,
 		ClusterAuthTimeout: float64(AUTH_TIMEOUT) / float64(time.Second),
 		ClusterTLSTimeout:  float64(TLS_TIMEOUT) / float64(time.Second),
@@ -66,7 +65,6 @@ func TestConfigFile(t *testing.T) {
 		MaxControlLine: 2048,
 		MaxPayload:     65536,
 		MaxConn:        100,
-		MaxPending:     10000000,
 		PingInterval:   60 * time.Second,
 		MaxPingsOut:    3,
 	}
@@ -188,7 +186,6 @@ func TestMergeOverrides(t *testing.T) {
 		MaxControlLine:     2048,
 		MaxPayload:         65536,
 		MaxConn:            100,
-		MaxPending:         10000000,
 		PingInterval:       60 * time.Second,
 		MaxPingsOut:        3,
 		ClusterNoAdvertise: true,


### PR DESCRIPTION
Previous implementations of the server checked the pending data size being currently buffered for a client to detect slow consumers, though this does not apply to latest version of the server, so removing
it as a config option for now to avoid confusion since not implemented.
