### PR TITLE
Add TLS infos to ClientAuth interface

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -2,6 +2,10 @@
 
 package server
 
+import (
+	"crypto/tls"
+)
+
 // Auth is an interface for implementing authentication
 type Auth interface {
 	// Check if a client is authorized to connect
@@ -12,6 +16,8 @@ type Auth interface {
 type ClientAuth interface {
 	// Get options associated with a client
 	GetOpts() *clientOpts
+	// If TLS is enabled, TLS ConnectionState, nil otherwise
+	GetTLSConnectionState() *tls.ConnectionState
 	// Optionally map a user after auth.
 	RegisterUser(*User)
 }

--- a/server/client.go
+++ b/server/client.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"bufio"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -144,6 +145,15 @@ func (c *client) String() (id string) {
 
 func (c *client) GetOpts() *clientOpts {
 	return &c.opts
+}
+
+func (c *client) GetTLSConnectionState() *tls.ConnectionState {
+	tc, ok := c.nc.(*tls.Conn)
+	if !ok {
+		return nil
+	}
+	state := tc.ConnectionState()
+	return &state
 }
 
 type subscription struct {

--- a/server/client.go
+++ b/server/client.go
@@ -147,6 +147,8 @@ func (c *client) GetOpts() *clientOpts {
 	return &c.opts
 }
 
+// GetTLSConnectionState returns the TLS ConnectionState if TLS is enabled, nil
+// otherwise. Implements the ClientAuth interface.
 func (c *client) GetTLSConnectionState() *tls.ConnectionState {
 	tc, ok := c.nc.(*tls.Conn)
 	if !ok {

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -107,6 +107,14 @@ func TestClientCreateAndInfo(t *testing.T) {
 	}
 }
 
+func TestNonTLSConnectionState(t *testing.T) {
+	_, c, _ := setupClient()
+	state := c.GetTLSConnectionState()
+	if state != nil {
+		t.Error("GetTLSConnectionState() returned non-nil")
+	}
+}
+
 func TestClientConnect(t *testing.T) {
 	_, c, _ := setupClient()
 
@@ -712,6 +720,11 @@ func TestTLSCloseClientConnection(t *testing.T) {
 	}
 	if cli == nil {
 		t.Fatal("Did not register client on time")
+	}
+	// Test GetTLSConnectionState
+	state := cli.GetTLSConnectionState()
+	if state == nil {
+		t.Error("GetTLSConnectionState() returned nil")
 	}
 	// Fill the buffer. Need to send 1 byte at a time so that we timeout here
 	// the nc.Close() would block due to a write that can not complete.


### PR DESCRIPTION
It makes it possible to implement a Auth that uses client TLS certificates
to identify them.