### PR TITLE
Remove non needed test for ErrTooManyConnections in client's readLoop

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -270,7 +270,7 @@ func (c *client) readLoop() {
 
 		if err := c.parse(b[:n]); err != nil {
 			// handled inline
-			if err != ErrMaxPayload && err != ErrAuthorization && err != ErrTooManyConnections {
+			if err != ErrMaxPayload && err != ErrAuthorization {
 				c.Errorf("Error reading from client: %s", err.Error())
 				c.sendErr("Parser Error")
 				c.closeConnection()


### PR DESCRIPTION
Since we now return an error before setting up the client's readLoop,
testing for this error in readLoop in not needed.