### PR TITLE
Prevent unrecognized sub commands in cmd line

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"strings"
 
 	"github.com/nats-io/gnatsd/auth"
 	"github.com/nats-io/gnatsd/logger"
@@ -138,16 +137,13 @@ func main() {
 
 	// Process args looking for non-flag options,
 	// 'version' and 'help' only for now
-	if len(flag.Args()) > 0 {
-		switch strings.ToLower(flag.Args()[0]) {
-		case "version":
-			server.PrintServerAndExit()
-		case "help":
-			usage()
-		default:
-			// Unrecognized command
-			usage()
-		}
+	showVersion, showHelp, err := server.ProcessCommandLineArgs(flag.CommandLine)
+	if err != nil {
+		server.PrintAndDie(err.Error() + usageStr)
+	} else if showVersion {
+		server.PrintServerAndExit()
+	} else if showHelp {
+		usage()
 	}
 
 	// Parse config if given

--- a/main.go
+++ b/main.go
@@ -138,11 +138,14 @@ func main() {
 
 	// Process args looking for non-flag options,
 	// 'version' and 'help' only for now
-	for _, arg := range flag.Args() {
-		switch strings.ToLower(arg) {
+	if len(flag.Args()) > 0 {
+		switch strings.ToLower(flag.Args()[0]) {
 		case "version":
 			server.PrintServerAndExit()
 		case "help":
+			usage()
+		default:
+			// Unrecognized command
 			usage()
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"crypto/tls"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -13,6 +14,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -178,6 +180,25 @@ func PrintAndDie(msg string) {
 func PrintServerAndExit() {
 	fmt.Printf("nats-server version %s\n", VERSION)
 	os.Exit(0)
+}
+
+// ProcessCommandLineArgs takes the command line arguments
+// validating and setting flags for handling in case any
+// sub command was present.
+func ProcessCommandLineArgs(cmd *flag.FlagSet) (showVersion bool, showHelp bool, err error) {
+	if len(cmd.Args()) > 0 {
+		arg := cmd.Args()[0]
+		switch strings.ToLower(arg) {
+		case "version":
+			return true, false, nil
+		case "help":
+			return false, true, nil
+		default:
+			return false, false, fmt.Errorf("Unrecognized command: %q\n", arg)
+		}
+	}
+
+	return false, false, nil
 }
 
 // Protected check on running state


### PR DESCRIPTION
Currently we allow `version` and `help` as subcommands and ignoring others, though this conflicts with command line options as it ignores the rest of the options and uses default parameters. Instead now we change to bail on unrecognized command to prevent misconfigurations which may arise from this.

Examples which now show usage of the binary instead:

```
gnatsd -p 4223 foo 
gnatsd foo -p 4223
gnatsd bar
```

Subcommands allowed are only `version` and `help`:
```
gnatsd version -p 4223 -DV
nats-server version 0.9.5
gnatsd help
```

Using only option flags works as they were previously
```
gnatsd -p 4223 -DV
[10452] 2016/12/01 14:48:27.641548 [INF] Starting nats-server version 0.9.5
[10452] 2016/12/01 14:48:27.641630 [DBG] Go build version go1.7
[10452] 2016/12/01 14:48:27.641635 [INF] Listening for client connections on 0.0.0.0:4223
...
```

Fixes #392