### PR TITLE
Replace GetListenEndpoint() with ReadyForConnections()

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -598,13 +598,13 @@ func (s *Server) routeAcceptLoop(ch chan struct{}) {
 		return
 	}
 
-	// Let them know we are up
-	close(ch)
-
 	// Setup state that can enable shutdown
 	s.mu.Lock()
 	s.routeListener = l
 	s.mu.Unlock()
+
+	// Let them know we are up
+	close(ch)
 
 	tmpDelay := ACCEPT_MIN_SLEEP
 

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -455,9 +455,19 @@ func TestRouteUseIPv6(t *testing.T) {
 	routeUp := false
 	timeout := time.Now().Add(5 * time.Second)
 	for time.Now().Before(timeout) && !routeUp {
-		if s.GetRouteListenEndpoint() == "" {
-			time.Sleep(time.Second)
-			continue
+		// We know that the server is local and listening to
+		// all IPv6 interfaces. Try connect using IPv6 loopback.
+		if conn, err := net.Dial("tcp", "[::1]:6222"); err != nil {
+			// Travis seem to have the server actually listening to 0.0.0.0,
+			// so try with 127.0.0.1
+			if conn, err := net.Dial("tcp", "127.0.0.1:6222"); err != nil {
+				time.Sleep(time.Second)
+				continue
+			} else {
+				conn.Close()
+			}
+		} else {
+			conn.Close()
 		}
 		routeUp = true
 	}

--- a/test/test.go
+++ b/test/test.go
@@ -97,28 +97,11 @@ func RunServerWithAuth(opts *server.Options, auth server.Auth) *server.Server {
 	// Run server in Go routine.
 	go s.Start()
 
-	end := time.Now().Add(10 * time.Second)
-	for time.Now().Before(end) {
-		addr := s.GetListenEndpoint()
-		if addr == "" {
-			time.Sleep(50 * time.Millisecond)
-			// Retry. We might take a little while to open a connection.
-			continue
-		}
-		conn, err := net.Dial("tcp", addr)
-		if err != nil {
-			// Retry after 50ms
-			time.Sleep(50 * time.Millisecond)
-			continue
-		}
-		conn.Close()
-		// Wait a bit to give a chance to the server to remove this
-		// "client" from its state, which may otherwise interfere with
-		// some tests.
-		time.Sleep(25 * time.Millisecond)
-		return s
+	// Wait for accept loop(s) to be started
+	if !s.ReadyForConnections(10 * time.Second) {
+		panic("Unable to start NATS Server in Go Routine")
 	}
-	panic("Unable to start NATS Server in Go Routine")
+	return s
 }
 
 func stackFatalf(t tLogger, f string, args ...interface{}) {


### PR DESCRIPTION
The RunServer() function (and the various variants)
call Server.Start() in a go-routine, but do not return until
it has verified that the server is ready to accept connections.
To do so, it use GetListenEndpoint() to get a suitable connect
address (replacing "0.0.0.0" or "::" with localhost - important
on Windows). It then creates a raw TCP connection to ensure the
server is started, repeating the process in case of failure up
to 10 seconds.

This PR replaces this with a function that checks that client
listener, and route listener if configured, are set. This removes
the need to get a connect address and create test tcp connections.

The reason for this change is that NATS Streaming when starting
the NATS Server (unless configured to connect to a remote one)
calls RunServerWithAuth(), which when getting "localhost" from
GetListenEndpoint(), would fail trying to resolve it. This happened
for the NATS Streaming Docker image built with Go 1.7+.