### PR TITLE
Change coverage/cross compile trigger for travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ script:
 - go test -v -race $EXCLUDE_VENDOR
 - staticcheck -ignore "$(cat staticcheck.ignore)" $EXCLUDE_VENDOR
 after_success:
-- if [ "$TRAVIS_GO_VERSION" \> "1.7." ]; then ./scripts/cov.sh TRAVIS; fi
-- if [ "$TRAVIS_GO_VERSION" \> "1.7." ] && [ "$TRAVIS_TAG" != "" ]; then ./scripts/cross_compile.sh $TRAVIS_TAG; ghr --owner nats-io --token $GITHUB_TOKEN --draft --replace $TRAVIS_TAG pkg/; fi
+- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]]; then ./scripts/cov.sh TRAVIS; fi
+- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]] && [ "$TRAVIS_TAG" != "" ]; then ./scripts/cross_compile.sh $TRAVIS_TAG; ghr --owner nats-io --token $GITHUB_TOKEN --draft --replace $TRAVIS_TAG pkg/; fi


### PR DESCRIPTION
Doing code coverage/cross compile for a single Go release. As of now,
if we were to introduce Go 1.8 in the matrix, we would do code
coverage (which may be ok) and create release (which would not be
ok) for 2 Go releases since were were using >= comparison.
This change ensures that we do for only 1.7.x for now.