### PR TITLE
Implement windows event logging

### DIFF
--- a/logger/syslog_windows.go
+++ b/logger/syslog_windows.go
@@ -1,20 +1,38 @@
-// Copyright 2012-2014 Apcera Inc. All rights reserved.
+// Copyright 2012-2016 Apcera Inc. All rights reserved.
+
+// Package logger logs to the windows event log
 package logger
 
 import (
 	"fmt"
-	"log"
+	"golang.org/x/sys/windows/svc/eventlog"
 	"os"
+	"strings"
 )
 
+const (
+	natsEventSource = "NATS-Server"
+)
+
+// SysLogger logs to the windows event logger
 type SysLogger struct {
-	writer *log.Logger
+	writer *eventlog.Log
 	debug  bool
 	trace  bool
 }
 
+// NewSysLogger creates a log using the windows event logger
 func NewSysLogger(debug, trace bool) *SysLogger {
-	w := log.New(os.Stdout, "gnatsd", log.LstdFlags)
+	if err := eventlog.InstallAsEventCreate(natsEventSource, eventlog.Info|eventlog.Error|eventlog.Warning); err != nil {
+		if !strings.Contains(err.Error(), "registry key already exists") {
+			panic(fmt.Sprintf("could not access event log: %v", err))
+		}
+	}
+
+	w, err := eventlog.Open(natsEventSource)
+	if err != nil {
+		panic(fmt.Sprintf("could not open event log: %v", err))
+	}
 
 	return &SysLogger{
 		writer: w,
@@ -23,30 +41,52 @@ func NewSysLogger(debug, trace bool) *SysLogger {
 	}
 }
 
+// NewRemoteSysLogger creates a remote event logger
 func NewRemoteSysLogger(fqn string, debug, trace bool) *SysLogger {
-	return NewSysLogger(debug, trace)
-}
+	w, err := eventlog.OpenRemote(fqn, natsEventSource)
+	if err != nil {
+		panic(fmt.Sprintf("could not open event log: %v", err))
+	}
 
-func (l *SysLogger) Noticef(format string, v ...interface{}) {
-	l.writer.Println("NOTICE", fmt.Sprintf(format, v...))
-}
-
-func (l *SysLogger) Fatalf(format string, v ...interface{}) {
-	l.writer.Println("CRITICAL", fmt.Sprintf(format, v...))
-}
-
-func (l *SysLogger) Errorf(format string, v ...interface{}) {
-	l.writer.Println("ERROR", fmt.Sprintf(format, v...))
-}
-
-func (l *SysLogger) Debugf(format string, v ...interface{}) {
-	if l.debug {
-		l.writer.Println("DEBUG", fmt.Sprintf(format, v...))
+	return &SysLogger{
+		writer: w,
+		debug:  debug,
+		trace:  trace,
 	}
 }
 
+func formatMsg(tag, format string, v ...interface{}) string {
+	orig := fmt.Sprintf(format, v...)
+	return fmt.Sprintf("pid[%d][%s]: %s", os.Getpid(), tag, orig)
+}
+
+// Noticef logs a notice statement
+func (l *SysLogger) Noticef(format string, v ...interface{}) {
+	l.writer.Info(1, formatMsg("NOTICE", format, v...))
+}
+
+// Fatalf logs a fatal error
+func (l *SysLogger) Fatalf(format string, v ...interface{}) {
+	msg := formatMsg("FATAL", format, v...)
+	l.writer.Error(5, msg)
+	panic(msg)
+}
+
+// Errorf logs an error statement
+func (l *SysLogger) Errorf(format string, v ...interface{}) {
+	l.writer.Error(2, formatMsg("ERROR", format, v...))
+}
+
+// Debugf logs a debug statement
+func (l *SysLogger) Debugf(format string, v ...interface{}) {
+	if l.debug {
+		l.writer.Info(3, formatMsg("DEBUG", format, v...))
+	}
+}
+
+// Tracef logs a trace statement
 func (l *SysLogger) Tracef(format string, v ...interface{}) {
 	if l.trace {
-		l.writer.Println("NOTICE", fmt.Sprintf(format, v...))
+		l.writer.Info(4, formatMsg("TRACE", format, v...))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ Server Options:
 Logging Options:
     -l, --log <file>                 File to redirect log output
     -T, --logtime                    Timestamp log entries (default: true)
-    -s, --syslog                     Enable syslog as log method
+    -s, --syslog                     Log to syslog or windows event log
     -r, --remote_syslog <addr>       Syslog server addr (udp://localhost:514)
     -D, --debug                      Enable debugging output
     -V, --trace                      Trace the raw protocol

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -26,6 +26,15 @@
 			"branch": "master",
 			"path": "/blowfish",
 			"notests": true
+		},
+		{
+			"importpath": "golang.org/x/sys/windows",
+			"repository": "https://go.googlesource.com/sys",
+			"vcs": "git",
+			"revision": "d75a52659825e75fff6158388dddc6a5b04f9ba5",
+			"branch": "master",
+			"path": "windows",
+			"notests": true
 		}
 	]
 }


### PR DESCRIPTION
Currently, the windows sys logger is a stub for standard logging.  This PR implements windows event logging as the “syslog" for the NATS server on windows.

Using the `-s` or `-r` parameters on windows will enable logging to the windows event log.

- The event source is `NATS-Server`, and data is written to the `Application` log.
- Writing to the event log requires an elevated privilege.  If the user does not have required privileges, the server panics.
- Log messages are written to the Application event log in the following format: `pid[<pid>]:[<type>]: Message`
- `Notice`, `Trace`, and `Debug` messages are written as info messages and `Errorf` or `Fatalf` log messages are logged as event log errors.
- Remote logging is supported.
- Includes tests and vendoring

Here is what a NATS server log entry looks like in the windows event viewer:
![screen shot 2016-12-29 at 3 32 28 pm](https://cloud.githubusercontent.com/assets/11180189/21556314/c6e8e082-cddc-11e6-9004-1d4583ce4f86.png)