### PR TITLE
Increase the internal test client dial timeout

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -152,7 +152,7 @@ func createRouteConn(t tLogger, host string, port int) net.Conn {
 
 func createClientConn(t tLogger, host string, port int) net.Conn {
 	addr := fmt.Sprintf("%s:%d", host, port)
-	c, err := net.DialTimeout("tcp", addr, 1*time.Second)
+	c, err := net.DialTimeout("tcp", addr, 3*time.Second)
 	if err != nil {
 		stackFatalf(t, "Could not connect to server: %v\n", err)
 	}


### PR DESCRIPTION
* Windows and very stressed test machines may require more time to connect; this was causing flappers.