### PR TITLE
[ADDED] Make Write deadline configurable

### DIFF
--- a/server/configs/test.conf
+++ b/server/configs/test.conf
@@ -37,3 +37,6 @@ max_payload: 65536
 # ping interval and no pong threshold
 ping_interval: 60
 ping_max: 3
+
+# how long server can block on a socket write to a client
+write_deadline: 3

--- a/server/opts.go
+++ b/server/opts.go
@@ -82,6 +82,7 @@ type Options struct {
 	TLSKey         string        `json:"-"`
 	TLSCaCert      string        `json:"-"`
 	TLSConfig      *tls.Config   `json:"-"`
+	WriteDeadline  time.Duration `json:"-"`
 }
 
 // Configuration file authorization section.
@@ -234,6 +235,8 @@ func ProcessConfigFile(configFile string) (*Options, error) {
 				return nil, err
 			}
 			opts.TLSTimeout = tc.Timeout
+		case "write_deadline":
+			opts.WriteDeadline = time.Duration(v.(int64)) * time.Second
 		}
 	}
 	return opts, nil
@@ -840,5 +843,8 @@ func processOptions(opts *Options) {
 	}
 	if opts.MaxPayload == 0 {
 		opts.MaxPayload = MAX_PAYLOAD_SIZE
+	}
+	if opts.WriteDeadline == time.Duration(0) {
+		opts.WriteDeadline = DEFAULT_FLUSH_DEADLINE
 	}
 }

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -27,6 +27,7 @@ func TestDefaultOptions(t *testing.T) {
 			AuthTimeout: float64(AUTH_TIMEOUT) / float64(time.Second),
 			TLSTimeout:  float64(TLS_TIMEOUT) / float64(time.Second),
 		},
+		WriteDeadline: DEFAULT_FLUSH_DEADLINE,
 	}
 
 	opts := &Options{}
@@ -69,6 +70,7 @@ func TestConfigFile(t *testing.T) {
 		MaxConn:        100,
 		PingInterval:   60 * time.Second,
 		MaxPingsOut:    3,
+		WriteDeadline:  3 * time.Second,
 	}
 
 	opts, err := ProcessConfigFile("./configs/test.conf")
@@ -230,6 +232,7 @@ func TestMergeOverrides(t *testing.T) {
 			NoAdvertise:    true,
 			ConnectRetries: 2,
 		},
+		WriteDeadline: 3 * time.Second,
 	}
 	fopts, err := ProcessConfigFile("./configs/test.conf")
 	if err != nil {


### PR DESCRIPTION
We use a hardcoded value of 2 seconds for Write deadline when
writing data to client's socket. This PR makes that value configurable.

Question is should we push the setting down to the client's object
to avoid indirection such as client.srv.opts.WriteDeadline?