### PR TITLE
Fixed errors found by staticcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ script:
 - go build
 - go fmt ./...
 - go vet $EXCLUDE_VENDOR
+- staticcheck -ignore "$(cat staticcheck.ignore)" $EXCLUDE_VENDOR
 - go test -i -race $EXCLUDE_VENDOR
 - go test -v -race $EXCLUDE_VENDOR
-- staticcheck -ignore "$(cat staticcheck.ignore)" $EXCLUDE_VENDOR
 after_success:
 - if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]]; then ./scripts/cov.sh TRAVIS; fi
 - if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]] && [ "$TRAVIS_TAG" != "" ]; then ./scripts/cross_compile.sh $TRAVIS_TAG; ghr --owner nats-io --token $GITHUB_TOKEN --draft --replace $TRAVIS_TAG pkg/; fi

--- a/main.go
+++ b/main.go
@@ -278,6 +278,9 @@ func configureClusterOpts(opts *server.Options) error {
 	// If cluster flag override, process it
 	if opts.Cluster.ListenStr != "" {
 		clusterURL, err := url.Parse(opts.Cluster.ListenStr)
+		if err != nil {
+			return err
+		}
 		h, p, err := net.SplitHostPort(clusterURL.Host)
 		if err != nil {
 			return err

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -159,15 +159,13 @@ func TestTLSConfigFile(t *testing.T) {
 	}
 
 	// Test an unrecognized/bad cipher
-	opts, err = ProcessConfigFile("./configs/tls_bad_cipher.conf")
-	if err == nil {
-		t.Fatal("Did not receive an error from a unrecognized cipher.")
+	if _, err := ProcessConfigFile("./configs/tls_bad_cipher.conf"); err == nil {
+		t.Fatal("Did not receive an error from a unrecognized cipher")
 	}
 
 	// Test an empty cipher entry in a config file.
-	opts, err = ProcessConfigFile("./configs/tls_empty_cipher.conf")
-	if err == nil {
-		t.Fatal("Did not receive an error from empty cipher_suites.")
+	if _, err := ProcessConfigFile("./configs/tls_empty_cipher.conf"); err == nil {
+		t.Fatal("Did not receive an error from empty cipher_suites")
 	}
 
 	// Test a curve preference from the config.
@@ -196,14 +194,12 @@ func TestTLSConfigFile(t *testing.T) {
 	}
 
 	// Test an unrecognized/bad curve preference
-	opts, err = ProcessConfigFile("./configs/tls_bad_curve_prefs.conf")
-	if err == nil {
-		t.Fatal("Did not receive an error from a unrecognized curve preference.")
+	if _, err := ProcessConfigFile("./configs/tls_bad_curve_prefs.conf"); err == nil {
+		t.Fatal("Did not receive an error from a unrecognized curve preference")
 	}
 	// Test an empty curve preference
-	opts, err = ProcessConfigFile("./configs/tls_empty_curve_prefs.conf")
-	if err == nil {
-		t.Fatal("Did not receive an error from empty curve preferences.")
+	if _, err := ProcessConfigFile("./configs/tls_empty_curve_prefs.conf"); err == nil {
+		t.Fatal("Did not receive an error from empty curve preferences")
 	}
 }
 

--- a/test/pid_test.go
+++ b/test/pid_test.go
@@ -19,6 +19,9 @@ func TestPidFile(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	file, err := ioutil.TempFile(tmpDir, "gnatsd:pid_")
+	if err != nil {
+		t.Fatalf("Unable to create temp file: %v", err)
+	}
 	file.Close()
 	opts.PidFile = file.Name()
 

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -26,12 +26,14 @@ func TestTLSConnection(t *testing.T) {
 	nurl := fmt.Sprintf("tls://%s:%s@%s/", opts.Username, opts.Password, endpoint)
 	nc, err := nats.Connect(nurl)
 	if err == nil {
+		nc.Close()
 		t.Fatalf("Expected error trying to connect to secure server")
 	}
 
 	// Do simple SecureConnect
 	nc, err = nats.Connect(fmt.Sprintf("tls://%s/", endpoint))
 	if err == nil {
+		nc.Close()
 		t.Fatalf("Expected error trying to connect to secure server with no auth")
 	}
 
@@ -268,12 +270,14 @@ func TestTLSConnectionCurvePref(t *testing.T) {
 	nurl := fmt.Sprintf("tls://%s:%s@%s/", opts.Username, opts.Password, endpoint)
 	nc, err := nats.Connect(nurl)
 	if err == nil {
+		nc.Close()
 		t.Fatalf("Expected error trying to connect to secure server")
 	}
 
 	// Do simple SecureConnect
 	nc, err = nats.Connect(fmt.Sprintf("tls://%s/", endpoint))
 	if err == nil {
+		nc.Close()
 		t.Fatalf("Expected error trying to connect to secure server with no auth")
 	}
 


### PR DESCRIPTION
Staticcheck has probably been updated and is finding new errors.
They have been fixed.

Also, moved the run of staticcheck before running the test suite,
so if it fails, it fails sooner ;-).