### PR TITLE
[ADDED] Reject clients connecting to route's listen port

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -281,12 +281,8 @@ func (c *client) readLoop() {
 		c.cache.subs = 0
 
 		if err := c.parse(b[:n]); err != nil {
-			// If client connection has been closed, simply return,
-			// otherwise report a generic parsing error.
-			c.mu.Lock()
-			closed := c.nc == nil
-			c.mu.Unlock()
-			if !closed {
+			// handled inline
+			if err != ErrMaxPayload && err != ErrAuthorization {
 				c.Errorf("Error reading from client: %s", err.Error())
 				c.sendErr("Parser Error")
 				c.closeConnection()

--- a/server/errors.go
+++ b/server/errors.go
@@ -29,4 +29,8 @@ var (
 	// ErrTooManyConnections signals a client that the maximum number of connections supported by the
 	// server has been reached.
 	ErrTooManyConnections = errors.New("Maximum Connections Exceeded")
+
+	// ErrClientConnectedToRoutePort represents an error condition when a client
+	// attempted to connect to the route listen port.
+	ErrClientConnectedToRoutePort = errors.New("Attempted To Connect To Route Port")
 )


### PR DESCRIPTION
This happens sometimes, and the latest occurence was today:
https://github.com/nats-io/java-nats/issues/96

When it happens, there is no error but subscribers would not receive
anything, etc...

This PR uses the fact that clients set the field Lang in the CONNECT
protocol that ROUTEs do not. I have checked that all Apcera supported
clients do set Lang in the CONNECT protocol.
If we plan to add Lang for routes, we need to find another field or
use a new one, in which case that would work only for new clients
(that would need to be updated).

With this change, when the server accepts a connection on the route
port and detects that this protocol field is present, it now closes
the client connection.

The nice thing is that newer clients, when incorrectly connecting
to the route port, get from the route's INFO the list of client URLs,
which means that on the initial connect error, they are able to
subsequently connect to the proper client port, so it is transparent
to the user (which may or may not be a good thing). However, it is not
guaranteed because if the client is not setting NoRandomize to true,
the client URL is added but the array shuffled, so it is possible that
the client library does not find the correct port in the connect loop.