### PR TITLE
Create Endpoint API option for client authorization

### DIFF
--- a/auth/endpoint.go
+++ b/auth/endpoint.go
@@ -1,0 +1,62 @@
+// Copyright 2016 Apcera Inc. All rights reserved.
+
+package auth
+
+import (
+	"bytes"
+	"net/http"
+	"io/ioutil"
+	"encoding/json"
+	"github.com/nats-io/gnatsd/server"
+)
+
+// Auth using endpoint API
+type EndpointAuth struct {
+	Endpoint 	string
+}
+
+func NewEndpointAuth( endpoint string ) *EndpointAuth {
+	m := &EndpointAuth{Endpoint: endpoint}
+	return m
+}
+
+// Check authenticates the client using remote HTTP(S) endpoint
+func (m *EndpointAuth) Check(c server.ClientAuth) bool {
+	opts := c.GetOpts()
+	
+	// If client has no token, cant authenticate
+	if opts.Authorization == "" {
+		return false
+	}
+
+	// Create HTTP Request:
+	url := m.Endpoint
+	var data = []byte(`{"method":"authorization"}`)
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	req.Header.Set("Authorization", "Bearer "+opts.Authorization)
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req); if err != nil {
+		// Authorization Endpoint Error (HTTP call to auth service errored)
+		return false
+	}
+	defer resp.Body.Close()
+
+
+	// If we didnt get a 200, not authenticated
+	if resp.StatusCode != 200 {
+		return false
+	}
+
+	// Parse response for User information
+	user := server.User{}
+	body, _ := ioutil.ReadAll(resp.Body)
+	err = json.Unmarshal([]byte(body), &user); if err != nil {
+		// Error parsing permissions
+	}
+
+	// Register user and allow connection
+	c.RegisterUser(&user)
+	return true
+
+}

--- a/main.go
+++ b/main.go
@@ -203,6 +203,9 @@ func configureAuth(s *server.Server, opts *server.Options) {
 			Token: opts.Authorization,
 		}
 		s.SetClientAuthMethod(auth)
+	}else if opts.Endpoint != "" {
+		auth := auth.NewEndpointAuth(opts.Endpoint)
+		s.SetClientAuthMethod(auth)
 	}
 	// Routes
 	if opts.Cluster.Username != "" {

--- a/server/client.go
+++ b/server/client.go
@@ -231,6 +231,11 @@ func (c *client) RegisterUser(user *User) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	// If the endpoint defined the Username, set it here:
+	if user.Username != "" {
+		c.opts.Username = user.Username
+	}
+
 	// Pre-allocate all to simplify checks later.
 	c.perms = &permissions{}
 	c.perms.sub = NewSublist()

--- a/server/configs/auth_endpoint.conf
+++ b/server/configs/auth_endpoint.conf
@@ -1,0 +1,14 @@
+
+listen: localhost:4242
+http: localhost:8222
+
+# Authorization for client connections using remote endpoint
+authorization {
+  # URL of our authentication/authorization endpoint:
+  # HTTP POST request is made to the following URL with payload of: `{"method":"authorization"}` with header: `authorization`=`Bearer $clients_token`
+  # If we do not get a 200 response, client connection is refused.
+  # If we get a 200, we parse the JSON response into a server.User struct. ( Username, Password and Permissions )
+  # The permissions received are passed into the RegisterUser method which sets the connections permissions.
+  endpoint: http://localhost:8080/v1/auth/client
+  timeout:  5
+}

--- a/server/opts.go
+++ b/server/opts.go
@@ -59,6 +59,7 @@ type Options struct {
 	Username       string        `json:"-"`
 	Password       string        `json:"-"`
 	Authorization  string        `json:"-"`
+	Endpoint       string        `json:"-"`
 	PingInterval   time.Duration `json:"ping_interval"`
 	MaxPingsOut    int           `json:"ping_max"`
 	HTTPHost       string        `json:"http_host"`
@@ -88,6 +89,7 @@ type Options struct {
 // Configuration file authorization section.
 type authorization struct {
 	// Singles
+	endpoint string
 	user string
 	pass string
 	// Multiple Users
@@ -172,8 +174,12 @@ func ProcessConfigFile(configFile string) (*Options, error) {
 			if err != nil {
 				return nil, err
 			}
-			opts.Username = auth.user
-			opts.Password = auth.pass
+			if auth.endpoint != "" {
+				opts.Endpoint = auth.endpoint	
+			}else{
+				opts.Username = auth.user
+				opts.Password = auth.pass
+			}
 			opts.AuthTimeout = auth.timeout
 			// Check for multiple users defined
 			if auth.users != nil {
@@ -336,6 +342,8 @@ func parseAuthorization(am map[string]interface{}) (*authorization, error) {
 	auth := &authorization{}
 	for mk, mv := range am {
 		switch strings.ToLower(mk) {
+		case "endpoint":
+			auth.endpoint = mv.(string)
 		case "user", "username":
 			auth.user = mv.(string)
 		case "pass", "password":


### PR DESCRIPTION
Option to use a remote HTTP(S) endpoint for client authentication/authorization. Please see the server/configs/auth_endpoint.conf for the config options.