### PR TITLE
Fix staticcheck report

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,7 +119,9 @@ func main() {
 	flag.StringVar(&opts.TLSKey, "tlskey", "", "Private key for server certificate.")
 	flag.StringVar(&opts.TLSCaCert, "tlscacert", "", "Client certificate CA for verification.")
 
-	flag.Usage = usage
+	flag.Usage = func() {
+		fmt.Printf("%s\n", usageStr)
+	}
 
 	flag.Parse()
 


### PR DESCRIPTION
Removed `os.Exit()` from function assigned to `flag.Usage`.