### PR TITLE
[WIP] JWT Authentication/Authorization Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,13 +473,13 @@ Joe has no permission grant and therefore inherits the default permission set. Y
 
 Note that `_INBOX.*` subscribe permissions must be granted in order to use the request APIs in Apcera supported clients. If an unauthorized client publishes or attempts to subscribe to a subject, the action fails and is logged at the server, and an error message is returned to the client.
 
-### JWT Authentication/Authorization
+### JWT Authorization
 
-The NATS Server support the use of JWT tokens for authenticating and authorizing connections and subjects. In your configuration, you can optionally specify a `jwt_secret` property that is the secret used to validate JWT tokens to permit connections. You can also use the payload inside a JWT token to authorize publish and subscribe actions on subjects in the same manner as described in the Authorization section.
+The NATS server supports the use of [JWT](https://jwt.io/) tokens for authenticating and authorizing connections and subjects. In your configuration, you can specify a `jwt_secret` property that is the secret used to validate JWT tokens to permit connections and actions on subjects. The payload inside a JWT token is used to authorize publish and subscribe actions on NATS subjects in the same manner as described in the Authorization section.
 
-An external application that generates JWT tokens for your clients can add permissions inside the payload of a JWT token. For example:
+An external application that generates JWT tokens for your clients can add permissions inside the payload of a JWT token. Here is an example JWT token payload:
 
-`
+```
 {
  "permissions": {
   "publish": [
@@ -493,9 +493,9 @@ An external application that generates JWT tokens for your clients can add permi
  "iat": 1486690619,
  "exp": 1486831935
 }
-`
+```
 
-The `permissions` JSON property for this JWT token's payload contains permissions described in JSON in the same manner as it would be described in configuration with a list of `string` subjects which this client would have access to publish and/or subscribe.
+The `permissions` JSON property for this JWT token's payload contains permissions described in JSON in the same manner as it would be described in configuration with a list of `string` subjects which this client would have access to publish and/or subscribe. If the token does not validate for any reason (i.e. invalid signature, expired token, etc.) the connection will be refused. Likewise, if a client attempts to perform a subscribe or publish action on a subject that it does not have access to, that action will be refused with an `authorization violation` exception.
 
 ### TLS
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Authorization Options:
         --user <user>                User required for connections
         --pass <password>            Password required for connections
         --auth <token>               Authorization token required for connections
+        --jwt_secret <secret>        Secret used to validate JWT tokens
 
 TLS Options:
         --tls                        Enable TLS, do not verify clients (default: false)
@@ -471,6 +472,30 @@ Bob is REQUESTOR and can publish requests on subjects "req.foo" or "req.bar", an
 Joe has no permission grant and therefore inherits the default permission set. You set the inherited default permissions by assigning them to the `default_permissions` entry inside of the `authorization` configuration block.
 
 Note that `_INBOX.*` subscribe permissions must be granted in order to use the request APIs in Apcera supported clients. If an unauthorized client publishes or attempts to subscribe to a subject, the action fails and is logged at the server, and an error message is returned to the client.
+
+### JWT Authentication/Authorization
+
+The NATS Server support the use of JWT tokens for authenticating and authorizing connections and subjects. In your configuration, you can optionally specify a `jwt_secret` property that is the secret used to validate JWT tokens to permit connections. You can also use the payload inside a JWT token to authorize publish and subscribe actions on subjects in the same manner as described in the Authorization section.
+
+An external application that generates JWT tokens for your clients can add permissions inside the payload of a JWT token. For example:
+
+`
+{
+ "permissions": {
+  "publish": [
+   "SANDBOX.*", "req.foo"
+  ],
+  "subscribe": [
+   "PUBLIC.>", "_INBOX.>"
+  ]
+ },
+ "jti": "f032476a-6dc7-49c7-9b5d-9b34898e7bed",
+ "iat": 1486690619,
+ "exp": 1486831935
+}
+`
+
+The `permissions` JSON property for this JWT token's payload contains permissions described in JSON in the same manner as it would be described in configuration with a list of `string` subjects which this client would have access to publish and/or subscribe.
 
 ### TLS
 

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -16,10 +16,6 @@ type JWTAuth struct {
 func (p *JWTAuth) Check(c server.ClientAuth) bool {
 	opts := c.GetOpts()
 
-	server.Debugf("c:Authorization", opts.Authorization)
-	server.Debugf("c:JwtSecret", opts.JwtSecret)
-	server.Debugf("p:JwtSecret", opts.JwtSecret)
-
 	if p.Secret != "" {
 
 		// If token == JWT secret, let it authenticate with default permissions.

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -1,0 +1,65 @@
+package auth
+
+import (
+	"fmt"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/nats-io/gnatsd/server"
+)
+
+// JWTAuth holds the JWT secret used to validate a token
+type JWTAuth struct {
+	Secret string
+}
+
+// Check authenticates a client from a token
+func (p *JWTAuth) Check(c server.ClientAuth) bool {
+	opts := c.GetOpts()
+
+	server.Debugf("c:Authorization", opts.Authorization)
+	server.Debugf("c:JwtSecret", opts.JwtSecret)
+	server.Debugf("p:JwtSecret", opts.JwtSecret)
+
+	if p.Secret != "" {
+
+		// If token == JWT secret, let it authenticate with default permissions.
+		if p.Secret == opts.Authorization {
+			return true
+		}
+
+		token, err := jwt.ParseWithClaims(opts.Authorization, &JwtUserClaims{}, func(token *jwt.Token) (interface{}, error) {
+			// Validate the alg:
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+			}
+
+			hmacSecret := []byte(p.Secret)
+			return hmacSecret, nil
+		})
+		if err != nil {
+			return false
+		}
+		if claims, ok := token.Claims.(*JwtUserClaims); ok && token.Valid {
+			c.RegisterUser(claims.toUser())
+			return true
+		}
+
+		return false
+	}
+
+	return false
+}
+
+// JwtUserClaims containing the NATS authorization claims within a JWT token.
+type JwtUserClaims struct {
+	server.User
+	jwt.StandardClaims
+}
+
+// Returns JwtUserClaims as server.User
+func (juc *JwtUserClaims) toUser() *server.User {
+	return &server.User{
+		Username:    juc.Username,
+		Permissions: juc.Permissions,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ Authorization Options:
         --user <user>                User required for connections
         --pass <password>            Password required for connections
         --auth <token>               Authorization token required for connections
+				--jwt_secret <secret>        Secret used to validate JWT tokens
 
 TLS Options:
         --tls                        Enable TLS, do not verify clients (default: false)
@@ -90,6 +91,7 @@ func main() {
 	flag.StringVar(&opts.Username, "user", "", "Username required for connection.")
 	flag.StringVar(&opts.Password, "pass", "", "Password required for connection.")
 	flag.StringVar(&opts.Authorization, "auth", "", "Authorization token required for connection.")
+	flag.StringVar(&opts.JwtSecret, "jwt_secret", "", "Secret used to validate JWT tokens.")
 	flag.IntVar(&opts.HTTPPort, "m", 0, "HTTP Port for /varz, /connz endpoints.")
 	flag.IntVar(&opts.HTTPPort, "http_port", 0, "HTTP Port for /varz, /connz endpoints.")
 	flag.IntVar(&opts.HTTPSPort, "ms", 0, "HTTPS Port for /varz, /connz endpoints.")
@@ -203,6 +205,11 @@ func configureAuth(s *server.Server, opts *server.Options) {
 	} else if opts.Authorization != "" {
 		auth := &auth.Token{
 			Token: opts.Authorization,
+		}
+		s.SetClientAuthMethod(auth)
+	} else if opts.JwtSecret != "" {
+		auth := &auth.JWTAuth{
+			Secret: opts.JwtSecret,
 		}
 		s.SetClientAuthMethod(auth)
 	}

--- a/server/client.go
+++ b/server/client.go
@@ -172,6 +172,7 @@ type clientOpts struct {
 	Pedantic      bool   `json:"pedantic"`
 	SslRequired   bool   `json:"ssl_required"`
 	Authorization string `json:"auth_token"`
+	JwtSecret     string `json:"jwt_secret"`
 	Username      string `json:"user"`
 	Password      string `json:"pass"`
 	Name          string `json:"name"`

--- a/server/opts.go
+++ b/server/opts.go
@@ -59,6 +59,7 @@ type Options struct {
 	Username       string        `json:"-"`
 	Password       string        `json:"-"`
 	Authorization  string        `json:"-"`
+	JwtSecret      string        `json:"jwt_secret"`
 	PingInterval   time.Duration `json:"ping_interval"`
 	MaxPingsOut    int           `json:"ping_max"`
 	HTTPHost       string        `json:"http_host"`

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/nats-io/gnatsd/auth"
 	"github.com/nats-io/gnatsd/server"
 )
@@ -227,4 +228,58 @@ func TestGoodBcryptToken(t *testing.T) {
 	expectAuthRequired(t, c)
 	doAuthConnect(t, c, BCRYPT_AUTH_TOKEN, "", "")
 	expectResult(t, c, okRe)
+}
+
+////////////////////////////////////////////////////////////
+// JWT authorization token version
+////////////////////////////////////////////////////////////
+
+const JWT_SECRET = "JWT-S3cr3t"
+
+func runAuthServerWithJwtSecret() *server.Server {
+	opts := DefaultTestOptions
+	opts.Port = AUTH_PORT
+	return RunServerWithAuth(&opts, &auth.JWTAuth{Secret: JWT_SECRET})
+}
+
+func TestValidJwtToken(t *testing.T) {
+	s := runAuthServerWithJwtSecret()
+	defer s.Shutdown()
+	c := createClientConn(t, "localhost", AUTH_PORT)
+	defer c.Close()
+	expectAuthRequired(t, c)
+
+	validToken := buildJWT(time.Now().Add(time.Hour))
+	t.Logf("Valid Token: %s", validToken)
+	doAuthConnect(t, c, validToken, "", "")
+	expectResult(t, c, okRe)
+}
+
+func TestExpiredJwtToken(t *testing.T) {
+	s := runAuthServerWithJwtSecret()
+	defer s.Shutdown()
+	c := createClientConn(t, "localhost", AUTH_PORT)
+	defer c.Close()
+	expectAuthRequired(t, c)
+
+	expiredToken := buildJWT(time.Now().Add(-time.Hour))
+	t.Logf("Expired Token: %s", expiredToken)
+	doAuthConnect(t, c, expiredToken, "", "")
+	expectResult(t, c, errRe)
+}
+
+func buildJWT(exp time.Time) string {
+	perms := &server.Permissions{
+		Publish:   []string{">"},
+		Subscribe: []string{">"},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"permissions": perms,
+		"exp":         exp.Unix(),
+	})
+
+	tokenString, _ := token.SignedString([]byte(JWT_SECRET))
+
+	return tokenString
 }

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -250,7 +250,6 @@ func TestValidJwtToken(t *testing.T) {
 	expectAuthRequired(t, c)
 
 	validToken := buildJWT(time.Now().Add(time.Hour))
-	t.Logf("Valid Token: %s", validToken)
 	doAuthConnect(t, c, validToken, "", "")
 	expectResult(t, c, okRe)
 }
@@ -263,7 +262,6 @@ func TestExpiredJwtToken(t *testing.T) {
 	expectAuthRequired(t, c)
 
 	expiredToken := buildJWT(time.Now().Add(-time.Hour))
-	t.Logf("Expired Token: %s", expiredToken)
 	doAuthConnect(t, c, expiredToken, "", "")
 	expectResult(t, c, errRe)
 }

--- a/test/test.go
+++ b/test/test.go
@@ -70,6 +70,9 @@ func RunServerWithConfig(configFile string) (srv *server.Server, opts *server.Op
 	if opts.Authorization != "" {
 		a = &auth.Token{Token: opts.Authorization}
 	}
+	if opts.JwtSecret != "" {
+		a = &auth.JWTAuth{Secret: opts.JwtSecret}
+	}
 	if opts.Username != "" {
 		a = &auth.Plain{Username: opts.Username, Password: opts.Password}
 	}


### PR DESCRIPTION
Here is an implementation of [JWT](https://jwt.io/) authentication/authorization support for NATS. It is a pretty lightweight solution to provide a means of securing your NATS endpoints without having to rely on checking an external service.

This PR includes updated documentation and basic tests for its functionality. I marked it work in progress, as there are some things (such as vendoring the external jwt-go dependency), that could use some feedback/direction since I am not familiar with this project's standards/guidelines for some of these practical details.