### PR TITLE
OSCP Feature

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -5,6 +5,7 @@ package server
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -47,42 +48,46 @@ type ClusterOpts struct {
 
 // Options block for gnatsd server.
 type Options struct {
-	Host           string        `json:"addr"`
-	Port           int           `json:"port"`
-	Trace          bool          `json:"-"`
-	Debug          bool          `json:"-"`
-	NoLog          bool          `json:"-"`
-	NoSigs         bool          `json:"-"`
-	Logtime        bool          `json:"-"`
-	MaxConn        int           `json:"max_connections"`
-	Users          []*User       `json:"-"`
-	Username       string        `json:"-"`
-	Password       string        `json:"-"`
-	Authorization  string        `json:"-"`
-	PingInterval   time.Duration `json:"ping_interval"`
-	MaxPingsOut    int           `json:"ping_max"`
-	HTTPHost       string        `json:"http_host"`
-	HTTPPort       int           `json:"http_port"`
-	HTTPSPort      int           `json:"https_port"`
-	AuthTimeout    float64       `json:"auth_timeout"`
-	MaxControlLine int           `json:"max_control_line"`
-	MaxPayload     int           `json:"max_payload"`
-	Cluster        ClusterOpts   `json:"cluster"`
-	ProfPort       int           `json:"-"`
-	PidFile        string        `json:"-"`
-	LogFile        string        `json:"-"`
-	Syslog         bool          `json:"-"`
-	RemoteSyslog   string        `json:"-"`
-	Routes         []*url.URL    `json:"-"`
-	RoutesStr      string        `json:"-"`
-	TLSTimeout     float64       `json:"tls_timeout"`
-	TLS            bool          `json:"-"`
-	TLSVerify      bool          `json:"-"`
-	TLSCert        string        `json:"-"`
-	TLSKey         string        `json:"-"`
-	TLSCaCert      string        `json:"-"`
-	TLSConfig      *tls.Config   `json:"-"`
-	WriteDeadline  time.Duration `json:"-"`
+	Host           string            `json:"addr"`
+	Port           int               `json:"port"`
+	Trace          bool              `json:"-"`
+	Debug          bool              `json:"-"`
+	NoLog          bool              `json:"-"`
+	NoSigs         bool              `json:"-"`
+	Logtime        bool              `json:"-"`
+	MaxConn        int               `json:"max_connections"`
+	Users          []*User           `json:"-"`
+	Username       string            `json:"-"`
+	Password       string            `json:"-"`
+	Authorization  string            `json:"-"`
+	PingInterval   time.Duration     `json:"ping_interval"`
+	MaxPingsOut    int               `json:"ping_max"`
+	HTTPHost       string            `json:"http_host"`
+	HTTPPort       int               `json:"http_port"`
+	HTTPSPort      int               `json:"https_port"`
+	AuthTimeout    float64           `json:"auth_timeout"`
+	MaxControlLine int               `json:"max_control_line"`
+	MaxPayload     int               `json:"max_payload"`
+	Cluster        ClusterOpts       `json:"cluster"`
+	ProfPort       int               `json:"-"`
+	PidFile        string            `json:"-"`
+	LogFile        string            `json:"-"`
+	Syslog         bool              `json:"-"`
+	RemoteSyslog   string            `json:"-"`
+	Routes         []*url.URL        `json:"-"`
+	RoutesStr      string            `json:"-"`
+	TLSTimeout     float64           `json:"tls_timeout"`
+	TLS            bool              `json:"-"`
+	TLSVerify      bool              `json:"-"`
+	TLSCert        string            `json:"-"`
+	TLSKey         string            `json:"-"`
+	TLSCaCert      string            `json:"-"`
+	TLSConfig      *tls.Config       `json:"-"`
+	OCSP           bool              `json:"-"`
+	OCSPAddr       string            `json:"-"`
+	OCSPCert       *x509.Certificate `json:"-"`
+	OCSPCaCert     *x509.Certificate `json:"-"`
+	WriteDeadline  time.Duration     `json:"-"`
 }
 
 // Configuration file authorization section.
@@ -132,6 +137,13 @@ e.g.
 
 Available cipher suites include:
 `
+
+// OSCPConfigOpts holds config file info
+type OSCPConfigOpts struct {
+	Addr     string
+	CertFile string
+	CaFile   string
+}
 
 // ProcessConfigFile processes a configuration file.
 // FIXME(dlc): Hacky
@@ -235,6 +247,20 @@ func ProcessConfigFile(configFile string) (*Options, error) {
 				return nil, err
 			}
 			opts.TLSTimeout = tc.Timeout
+		case "ocsp":
+			ocspm := v.(map[string]interface{})
+			c, err := parseOSCP(ocspm)
+			if err != nil {
+				return nil, err
+			}
+			cert, ca, err := GenOSCPCerts(c)
+			if err != nil {
+				return nil, err
+			}
+			opts.OCSP = true
+			opts.OCSPAddr = c.Addr
+			opts.OCSPCert = cert
+			opts.OCSPCaCert = ca
 		case "write_deadline":
 			opts.WriteDeadline = time.Duration(v.(int64)) * time.Second
 		}
@@ -633,6 +659,41 @@ func GenTLSConfig(tc *TLSConfigOpts) (*tls.Config, error) {
 	}
 
 	return &config, nil
+}
+
+// Helper function to parse OSCP options
+func parseOSCP(pm map[string]interface{}) (*OSCPConfigOpts, error) {
+	p := &OSCPConfigOpts{}
+	for k, v := range pm {
+		switch strings.ToLower(k) {
+		case "addr", "address":
+			p.Addr = v.(string)
+		case "cert_file":
+			p.CertFile = v.(string)
+		case "ca_file":
+			p.CaFile = v.(string)
+		default:
+			return nil, fmt.Errorf("Unknown field %s parsing oscp", k)
+		}
+	}
+	return p, nil
+}
+
+// GenOSCPCerts loads pem certs into memory
+func GenOSCPCerts(c *OSCPConfigOpts) (cert, ca *x509.Certificate, err error) {
+	pemData, _ := ioutil.ReadFile(c.CaFile)
+	b, _ := pem.Decode(pemData)
+	ca, err = x509.ParseCertificate(b.Bytes)
+	if err != nil {
+		return
+	}
+	pemData, _ = ioutil.ReadFile(c.CertFile)
+	b, _ = pem.Decode(pemData)
+	cert, err = x509.ParseCertificate(b.Bytes)
+	if err != nil {
+		return
+	}
+	return
 }
 
 // MergeOptions will merge two options giving preference to the flagOpts


### PR DESCRIPTION
WIP implementation of OSCP verification of client certificates.

When a client connects their certificate is checked, if a "good" response isn't received the connection is closed.

The use case here is where you operate a internet facing instance of gnatsd where clients are authenticated against a CA you control. This lets you invalidate certificates that you've signed but haven't expired but otherwise don't want that user to access the server anymore.

This adds a configuration option "oscp":
```
ocsp {
  addr:      "http://my.ocsp.responder:2560"
  ca_file:   "/path/to/ca.pem"
}
```