### PR TITLE
Update Travis to use Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 go:
 - 1.6.4
 - 1.7.4
-- 1.8beta2
+- 1.8
 install:
 - go get github.com/nats-io/go-nats
 - go get github.com/mattn/goveralls

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -225,7 +225,6 @@ func TestTLSStressConnect(t *testing.T) {
 	wg.Wait()
 
 	var lastError error
-	lastError = nil
 	for i := 0; i < threadCount; i++ {
 		err := <-errCh
 		if err != nil {


### PR DESCRIPTION
Go 1.8 has been released, move from go 1.8beta2 to the current 1.8 release.

* Go 1.8 uncovered a staticcheck violation; the fix is included here.