### PR TITLE
Use atomic.Load to access fields used in /varz and /subsz requests.

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -473,11 +473,11 @@ func (s *Server) HandleVarz(w http.ResponseWriter, r *http.Request) {
 	v.TotalConnections = s.totalClients
 	v.Routes = len(s.routes)
 	v.Remotes = len(s.remotes)
-	v.InMsgs = s.inMsgs
-	v.InBytes = s.inBytes
-	v.OutMsgs = s.outMsgs
-	v.OutBytes = s.outBytes
-	v.SlowConsumers = s.slowConsumers
+	v.InMsgs = atomic.LoadInt64(&s.inMsgs)
+	v.InBytes = atomic.LoadInt64(&s.inBytes)
+	v.OutMsgs = atomic.LoadInt64(&s.outMsgs)
+	v.OutBytes = atomic.LoadInt64(&s.outBytes)
+	v.SlowConsumers = atomic.LoadInt64(&s.slowConsumers)
 	v.Subscriptions = s.sl.Count()
 	s.httpReqStats[VarzPath]++
 	// Need a copy here since s.httpReqStas can change while doing

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -503,11 +503,11 @@ func (s *Sublist) Stats() *SublistStats {
 	st := &SublistStats{}
 	st.NumSubs = s.count
 	st.NumCache = uint32(len(s.cache))
-	st.NumInserts = s.inserts
-	st.NumRemoves = s.removes
-	st.NumMatches = s.matches
-	if s.matches > 0 {
-		st.CacheHitRate = float64(s.cacheHits) / float64(s.matches)
+	st.NumInserts = atomic.LoadUint64(&s.inserts)
+	st.NumRemoves = atomic.LoadUint64(&s.removes)
+	st.NumMatches = atomic.LoadUint64(&s.matches)
+	if st.NumMatches > 0 {
+		st.CacheHitRate = float64(atomic.LoadUint64(&s.cacheHits)) / float64(st.NumMatches)
 	}
 	// whip through cache for fanout stats
 	tot, max := 0, 0

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -503,8 +503,8 @@ func (s *Sublist) Stats() *SublistStats {
 	st := &SublistStats{}
 	st.NumSubs = s.count
 	st.NumCache = uint32(len(s.cache))
-	st.NumInserts = atomic.LoadUint64(&s.inserts)
-	st.NumRemoves = atomic.LoadUint64(&s.removes)
+	st.NumInserts = s.inserts
+	st.NumRemoves = s.removes
 	st.NumMatches = atomic.LoadUint64(&s.matches)
 	if st.NumMatches > 0 {
 		st.CacheHitRate = float64(atomic.LoadUint64(&s.cacheHits)) / float64(st.NumMatches)

--- a/test/monitor_test.go
+++ b/test/monitor_test.go
@@ -34,7 +34,7 @@ func runMonitorServer() *server.Server {
 }
 
 // Runs a clustered pair of monitor servers for testing the /routez endpoint
-func runMonitorServerClusteredPair() (*server.Server, *server.Server) {
+func runMonitorServerClusteredPair(t *testing.T) (*server.Server, *server.Server) {
 	resetPreviousHTTPConnections()
 	opts := DefaultTestOptions
 	opts.Port = CLIENT_PORT
@@ -55,6 +55,8 @@ func runMonitorServerClusteredPair() (*server.Server, *server.Server) {
 	opts2.Routes = server.RoutesFromStr("nats-route://127.0.0.1:10223")
 
 	s2 := RunServer(&opts2)
+
+	checkClusterFormed(t, s1, s2)
 
 	return s1, s2
 }
@@ -139,12 +141,9 @@ func testEndpointDataRace(endpoint string, t *testing.T) {
 
 func TestEndpointDataRaces(t *testing.T) {
 	// setup a small cluster to test /routez
-	s1, s2 := runMonitorServerClusteredPair()
+	s1, s2 := runMonitorServerClusteredPair(t)
 	defer s1.Shutdown()
 	defer s2.Shutdown()
-
-	// give some time for a route to form
-	time.Sleep(2 * time.Second)
 
 	// test all of our endpoints
 	testEndpointDataRace("varz", t)


### PR DESCRIPTION
* Includes a unit test that checks all endpoints for data races.

 - [ ] Link to issue, e.g. `Resolves #NNN` **(N/A, included test demonstrates the issue)**
 - [ ] Documentation added (if applicable) **(N/A)**
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)) **I suggest we squash/rebase with the merge... we can take this offline.**
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

/cc @nats-io/core
