### PR TITLE
Fixes to a couple of `gometalinter` checks

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -399,12 +399,6 @@ type Varz struct {
 	HTTPReqStats     map[string]uint64 `json:"http_req_stats"`
 }
 
-type usage struct {
-	CPU   float32
-	Cores int
-	Mem   int64
-}
-
 func myUptime(d time.Duration) string {
 	// Just use total seconds for uptime, and display days / years
 	tsecs := d / time.Second

--- a/server/opts.go
+++ b/server/opts.go
@@ -625,7 +625,7 @@ func GenTLSConfig(tc *TLSConfigOpts) (*tls.Config, error) {
 			return nil, err
 		}
 		pool := x509.NewCertPool()
-		ok := pool.AppendCertsFromPEM([]byte(rootPEM))
+		ok := pool.AppendCertsFromPEM(rootPEM)
 		if !ok {
 			return nil, fmt.Errorf("failed to parse root ca certificate")
 		}

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -571,7 +571,7 @@ func IsValidSubject(subject string) bool {
 		return false
 	}
 	sfwc := false
-	tokens := strings.Split(string(subject), tsep)
+	tokens := strings.Split(subject, tsep)
 	for _, t := range tokens {
 		if len(t) == 0 || sfwc {
 			return false
@@ -589,7 +589,7 @@ func IsValidSubject(subject string) bool {
 
 // IsValidLiteralSubject returns true if a subject is valid and literal (no wildcards), false otherwise
 func IsValidLiteralSubject(subject string) bool {
-	tokens := strings.Split(string(subject), tsep)
+	tokens := strings.Split(subject, tsep)
 	for _, t := range tokens {
 		if len(t) == 0 {
 			return false


### PR DESCRIPTION
Found the couple nits while running `gometalinter` on the repo

 - [X] Link to issue, e.g. `Resolves #NNN`
 - [N/A] Documentation added (if applicable)
 - [N/A] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request: 

 - Remove unused `usage` type
 - Fix unnecessary conversions
 
/cc @nats-io/core
