### PR TITLE
[FIXED] Server not sending PINGs to TLS connections (clients or routes)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
 - 1.6.4
-- 1.7.4
+- 1.7.5
 - 1.8
 install:
 - go get github.com/nats-io/go-nats

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -7,8 +7,7 @@ go test -v -covermode=atomic -coverprofile=./cov/auth.out ./auth
 go test -v -covermode=atomic -coverprofile=./cov/conf.out ./conf
 go test -v -covermode=atomic -coverprofile=./cov/log.out ./logger
 go test -v -covermode=atomic -coverprofile=./cov/server.out ./server
-go test -v -covermode=atomic -coverprofile=./cov/test.out ./test
-go test -v -covermode=atomic -coverprofile=./cov/test2.out -coverpkg=./server ./test
+go test -v -covermode=atomic -coverprofile=./cov/test.out -coverpkg=./server ./test
 gocovmerge ./cov/*.out > acc.out
 rm -rf ./cov
 

--- a/server/client.go
+++ b/server/client.go
@@ -1193,8 +1193,8 @@ func (c *client) processPingTimer() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.ptmr = nil
-	// Check if we are ready yet..
-	if _, ok := c.nc.(*net.TCPConn); !ok {
+	// Check if connection is still opened
+	if c.nc == nil {
 		return
 	}
 

--- a/test/ping_test.go
+++ b/test/ping_test.go
@@ -3,6 +3,8 @@
 package test
 
 import (
+	"crypto/tls"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -22,6 +24,68 @@ func runPingServer() *server.Server {
 	opts.PingInterval = PING_INTERVAL
 	opts.MaxPingsOut = PING_MAX
 	return RunServer(&opts)
+}
+
+func TestPingSentToTLSConnection(t *testing.T) {
+	opts := DefaultTestOptions
+	opts.Port = PING_TEST_PORT
+	opts.PingInterval = PING_INTERVAL
+	opts.MaxPingsOut = PING_MAX
+	opts.TLSCert = "configs/certs/server-cert.pem"
+	opts.TLSKey = "configs/certs/server-key.pem"
+	opts.TLSCaCert = "configs/certs/ca.pem"
+
+	tc := server.TLSConfigOpts{}
+	tc.CertFile = opts.TLSCert
+	tc.KeyFile = opts.TLSKey
+	tc.CaFile = opts.TLSCaCert
+
+	opts.TLSConfig, _ = server.GenTLSConfig(&tc)
+	s := RunServer(&opts)
+	defer s.Shutdown()
+
+	c := createClientConn(t, "localhost", PING_TEST_PORT)
+	defer c.Close()
+
+	checkInfoMsg(t, c)
+	c = tls.Client(c, &tls.Config{InsecureSkipVerify: true})
+	tlsConn := c.(*tls.Conn)
+	tlsConn.Handshake()
+
+	cs := fmt.Sprintf("CONNECT {\"verbose\":%v,\"pedantic\":%v,\"ssl_required\":%v}\r\n", false, false, true)
+	sendProto(t, c, cs)
+
+	expect := expectCommand(t, c)
+
+	// Expect the max to be delivered correctly..
+	for i := 0; i < PING_MAX; i++ {
+		time.Sleep(PING_INTERVAL / 2)
+		expect(pingRe)
+	}
+
+	// We should get an error from the server
+	time.Sleep(PING_INTERVAL)
+	expect(errRe)
+
+	// Server should close the connection at this point..
+	time.Sleep(PING_INTERVAL)
+	c.SetWriteDeadline(time.Now().Add(PING_INTERVAL))
+
+	var err error
+	for {
+		_, err = c.Write([]byte("PING\r\n"))
+		if err != nil {
+			break
+		}
+	}
+	c.SetWriteDeadline(time.Time{})
+
+	if err == nil {
+		t.Fatal("No error: Expected to have connection closed")
+	}
+	if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		t.Fatal("timeout: Expected to have connection closed")
+	}
 }
 
 func TestPingInterval(t *testing.T) {


### PR DESCRIPTION
 - [X] Link to issue
 - [X] Documentation added (N/A)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #458

### Changes proposed in this pull request: 

- Removed unnecessary cast check to (*net.TCPConn). When the timer
fires, the connection is already established. Replaced with check
that connection has not been closed.
- Add PING test that checks that pings are sent to TLS connections.
- Changed Go version to 1.7.5 in travis.
- Removed test package from code coverage.
 
/cc @nats-io/core
