### PR TITLE
[ADDED] Support for token in configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,16 @@ authorization {
 }
 ```
 
+Or, if you chose to use a token:
+
+```
+authorization {
+  # You can generate the token using /util/mkpassword.go
+  token:   $2a$11$pBwUBpza8vdJ7tWZcP5GRO13qRgh4dwNn8g67k5i/41yIKBp.sHke
+  timeout: 1
+}
+```
+
 **Multi-user authentication**
 
 You can enable multi-user authentication using a NATS server configuration file that defines user credentials (`user` and `password`), and optionally `permissions`, for two or more users. Multi-user authentication leverages [variables](#variables).

--- a/server/opts.go
+++ b/server/opts.go
@@ -88,8 +88,9 @@ type Options struct {
 // Configuration file authorization section.
 type authorization struct {
 	// Singles
-	user string
-	pass string
+	user  string
+	pass  string
+	token string
 	// Multiple Users
 	users              []*User
 	timeout            float64
@@ -174,11 +175,18 @@ func ProcessConfigFile(configFile string) (*Options, error) {
 			}
 			opts.Username = auth.user
 			opts.Password = auth.pass
+			opts.Authorization = auth.token
+			if (auth.user != "" || auth.pass != "") && auth.token != "" {
+				return nil, fmt.Errorf("Cannot have a user/pass and token")
+			}
 			opts.AuthTimeout = auth.timeout
 			// Check for multiple users defined
 			if auth.users != nil {
 				if auth.user != "" {
 					return nil, fmt.Errorf("Can not have a single user/pass and a users array")
+				}
+				if auth.token != "" {
+					return nil, fmt.Errorf("Can not have a token and a users array")
 				}
 				opts.Users = auth.users
 			}
@@ -340,6 +348,8 @@ func parseAuthorization(am map[string]interface{}) (*authorization, error) {
 			auth.user = mv.(string)
 		case "pass", "password":
 			auth.pass = mv.(string)
+		case "token":
+			auth.token = mv.(string)
 		case "timeout":
 			at := float64(1)
 			switch mv.(type) {

--- a/test/client_auth_test.go
+++ b/test/client_auth_test.go
@@ -4,6 +4,8 @@ package test
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/nats-io/go-nats"
@@ -47,4 +49,33 @@ func TestMultipleUserAuth(t *testing.T) {
 		t.Fatalf("Expected a successful connect, got %v\n", err)
 	}
 	defer nc.Close()
+}
+
+// Resolves to "test"
+const testToken = "$2a$05$3sSWEVA1eMCbV0hWavDjXOx.ClBjI6u1CuUdLqf22cbJjXsnzz8/."
+
+func TestTokenInConfig(t *testing.T) {
+	confFileName := "test.conf"
+	defer os.Remove(confFileName)
+	content := `
+	listen: 127.0.0.1:4567
+	authorization={
+		token: ` + testToken + `
+		timeout: 5
+	}`
+	if err := ioutil.WriteFile(confFileName, []byte(content), 0666); err != nil {
+		t.Fatalf("Error writing config file: %v", err)
+	}
+	s, opts := RunServerWithConfig(confFileName)
+	defer s.Shutdown()
+
+	url := fmt.Sprintf("nats://test@%s:%d/", opts.Host, opts.Port)
+	nc, err := nats.Connect(url)
+	if err != nil {
+		t.Fatalf("Expected a successful connect, got %v\n", err)
+	}
+	defer nc.Close()
+	if !nc.AuthRequired() {
+		t.Fatal("Expected auth to be required for the server")
+	}
 }


### PR DESCRIPTION
 - [X] Link to issue
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #464

### Changes proposed in this pull request: 
So far, it was only possible to use token from the command line.

 - Add support for `token` in the `authorization` configuration section.
 
/cc @nats-io/core
