### PR TITLE
[FIXED] Release on linux amd64 is the only one dynamically linked

### DIFF
--- a/scripts/cross_compile.sh
+++ b/scripts/cross_compile.sh
@@ -12,7 +12,7 @@ if [[ -n $1 ]]; then
     export APPNAME=$APPNAME-$1
 fi
 
-gox -osarch="$OSARCH" -ldflags="-s -w" -output "$OUTDIR/$APPNAME-{{.OS}}-{{.Arch}}/gnatsd"
+env CGO_ENABLED=0 gox -osarch="$OSARCH" -ldflags="-s -w" -output "$OUTDIR/$APPNAME-{{.OS}}-{{.Arch}}/gnatsd"
 for dir in $DIRS; do \
     (cp README.md $OUTDIR/$APPNAME-$dir/README.md) ;\
     (cp LICENSE $OUTDIR/$APPNAME-$dir/LICENSE) ;\


### PR DESCRIPTION
 - [X] Link to issue
 - [X] Documentation added (N/A)
 - [X] Tests added (ran the script on a Linux amd64 box)
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves # 470

### Changes proposed in this pull request: 
We are using the tool from https://github.com/mitchellh/gox
for cross compilation. When we issue a new release, we create a
tag and trigger Travis build which will then invoke the script and
upload the files to GH.

We were affected by https://github.com/mitchellh/gox/issues/55

Invoking the script on a Linux amd64 would produce this:

file pkg/gnatsd-linux-amd64/gnatsd
pkg/gnatsd-linux-amd64/gnatsd: ELF 64-bit LSB executable, x86-64,
version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, stripped

With the fix, you'll get this:

file pkg/gnatsd-linux-amd64/gnatsd
pkg/gnatsd-linux-amd64/gnatsd: ELF 64-bit LSB executable, x86-64,
version 1 (SYSV), statically linked, stripped

/cc @nats-io/core
