### PR TITLE
[IMPROVED] Route sid parse performance

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -446,8 +446,7 @@ const (
 	RSID  = "RSID"
 	QRSID = "QRSID"
 
-	QRSID_PREFIX     = QRSID + ":"
-	QRSID_PREFIX_LEN = len(QRSID_PREFIX)
+	QRSID_LEN = len(QRSID)
 )
 
 func (s *Server) routeSidQueueSubscriber(rsid []byte) (*subscription, bool) {
@@ -482,17 +481,18 @@ func routeSid(sub *subscription) string {
 }
 
 func parseRouteSid(rsid []byte) (uint64, []byte, bool) {
-	if !bytes.HasPrefix(rsid, []byte(QRSID_PREFIX)) {
+	if !bytes.HasPrefix(rsid, []byte(QRSID)) {
 		return 0, nil, false
 	}
 
-	for i := QRSID_PREFIX_LEN; i < len(rsid); i++ {
+	// We don't care what's char of rsid[QRSID_LEN+1], it should be ':'
+	for i, count := QRSID_LEN+1, len(rsid); i < count; i++ {
 		switch rsid[i] {
 		case ':':
-			return uint64(parseInt64(rsid[QRSID_PREFIX_LEN:i])), rsid[i+1:], len(rsid[i+1:]) > 0
+			return uint64(parseInt64(rsid[QRSID_LEN+1 : i])), rsid[i+1:], true
 		}
 	}
-	return 0, nil, false
+	return 0, nil, true
 }
 
 func (s *Server) addRoute(c *client, info *Info) (bool, bool) {

--- a/server/route.go
+++ b/server/route.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -447,23 +446,15 @@ const (
 	RSID  = "RSID"
 	QRSID = "QRSID"
 
-	RSID_CID_INDEX   = 1
-	RSID_SID_INDEX   = 2
-	EXPECTED_MATCHES = 3
+	QRSID_PREFIX     = QRSID + ":"
+	QRSID_PREFIX_LEN = len(QRSID_PREFIX)
 )
 
-// FIXME(dlc) - This may be too slow, check at later date.
-var qrsidRe = regexp.MustCompile(`QRSID:(\d+):([^\s]+)`)
-
 func (s *Server) routeSidQueueSubscriber(rsid []byte) (*subscription, bool) {
-	if !bytes.HasPrefix(rsid, []byte(QRSID)) {
+	cid, sid, ok := parseRouteSid(rsid)
+	if !ok {
 		return nil, false
 	}
-	matches := qrsidRe.FindSubmatch(rsid)
-	if matches == nil || len(matches) != EXPECTED_MATCHES {
-		return nil, false
-	}
-	cid := uint64(parseInt64(matches[RSID_CID_INDEX]))
 
 	s.mu.Lock()
 	client := s.clients[cid]
@@ -472,7 +463,6 @@ func (s *Server) routeSidQueueSubscriber(rsid []byte) (*subscription, bool) {
 	if client == nil {
 		return nil, true
 	}
-	sid := matches[RSID_SID_INDEX]
 
 	client.mu.Lock()
 	sub, ok := client.subs[string(sid)]
@@ -489,6 +479,20 @@ func routeSid(sub *subscription) string {
 		qi = "Q"
 	}
 	return fmt.Sprintf("%s%s:%d:%s", qi, RSID, sub.client.cid, sub.sid)
+}
+
+func parseRouteSid(rsid []byte) (cid uint64, sid []byte, ok bool) {
+	if !bytes.HasPrefix(rsid, []byte(QRSID_PREFIX)) {
+		return
+	}
+
+	for i := QRSID_PREFIX_LEN; i < len(rsid); i++ {
+		switch rsid[i] {
+		case ':':
+			return uint64(parseInt64(rsid[QRSID_PREFIX_LEN:i])), rsid[i+1:], true
+		}
+	}
+	return
 }
 
 func (s *Server) addRoute(c *client, info *Info) (bool, bool) {

--- a/server/route.go
+++ b/server/route.go
@@ -481,18 +481,18 @@ func routeSid(sub *subscription) string {
 	return fmt.Sprintf("%s%s:%d:%s", qi, RSID, sub.client.cid, sub.sid)
 }
 
-func parseRouteSid(rsid []byte) (cid uint64, sid []byte, ok bool) {
+func parseRouteSid(rsid []byte) (uint64, []byte, bool) {
 	if !bytes.HasPrefix(rsid, []byte(QRSID_PREFIX)) {
-		return
+		return 0, nil, false
 	}
 
 	for i := QRSID_PREFIX_LEN; i < len(rsid); i++ {
 		switch rsid[i] {
 		case ':':
-			return uint64(parseInt64(rsid[QRSID_PREFIX_LEN:i])), rsid[i+1:], true
+			return uint64(parseInt64(rsid[QRSID_PREFIX_LEN:i])), rsid[i+1:], len(rsid[i+1:]) > 0
 		}
 	}
-	return
+	return 0, nil, false
 }
 
 func (s *Server) addRoute(c *client, info *Info) (bool, bool) {

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -399,17 +399,12 @@ func TestRouteQueueSemantics(t *testing.T) {
 	routeSend("PING\r\n")
 	routeExpect(pongRe)
 
-	// Should be 3 now, 1 for all normal, and one for specific queue subscriber,
-	// others for normal
-	matches = clientExpectMsgs(5)
+	// Should be 2 now, 1 for all normal, and one for specific queue subscriber.
+	matches = clientExpectMsgs(2)
 
-	// Expect first to be the normal subscriber, next will be the queue one,
-	// others to be the normal subscriber
+	// Expect first to be the normal subscriber, next will be the queue one.
 	checkMsg(t, matches[0], "foo", "1", "", "2", "ok")
 	checkMsg(t, matches[1], "foo", "2", "", "2", "ok")
-	checkMsg(t, matches[2], "foo", "1", "", "2", "ok")
-	checkMsg(t, matches[3], "foo", "1", "", "2", "ok")
-	checkMsg(t, matches[4], "foo", "1", "", "2", "ok")
 }
 
 func TestSolicitRouteReconnect(t *testing.T) {

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -390,17 +390,26 @@ func TestRouteQueueSemantics(t *testing.T) {
 	routeSend("MSG foo RSID:1:1 2\r\nok\r\n")
 	// Queue group one.
 	routeSend("MSG foo QRSID:1:2 2\r\nok\r\n")
+	// Invlaid queue sid.
+	routeSend("MSG foo QRSID 2\r\nok\r\n")
+	routeSend("MSG foo QRSID:1 2\r\nok\r\n")
+	routeSend("MSG foo QRSID:1: 2\r\nok\r\n")
 
 	// Use ping roundtrip to make sure its processed.
 	routeSend("PING\r\n")
 	routeExpect(pongRe)
 
-	// Should be 2 now, 1 for all normal, and one for specific queue subscriber.
-	matches = clientExpectMsgs(2)
+	// Should be 3 now, 1 for all normal, and one for specific queue subscriber,
+	// others for normal
+	matches = clientExpectMsgs(5)
 
-	// Expect first to be the normal subscriber, next will be the queue one.
+	// Expect first to be the normal subscriber, next will be the queue one,
+	// others to be the normal subscriber
 	checkMsg(t, matches[0], "foo", "1", "", "2", "ok")
 	checkMsg(t, matches[1], "foo", "2", "", "2", "ok")
+	checkMsg(t, matches[2], "foo", "1", "", "2", "ok")
+	checkMsg(t, matches[3], "foo", "1", "", "2", "ok")
+	checkMsg(t, matches[4], "foo", "1", "", "2", "ok")
 }
 
 func TestSolicitRouteReconnect(t *testing.T) {


### PR DESCRIPTION
- [x] Link to issue
- [x] Documentation added (if applicable)
- [x] Tests added
- [x] Branch rebased on top of current master (git pull --rebase origin master)
- [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [ ] Build is green in Travis CI
- [x] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request: 

Base on [`func (s *Server) routeSidQueueSubscriber(rsid []byte) (*subscription, bool)`](https://github.com/nats-io/gnatsd/blob/master/server/route.go#L458) `rsid` comes from [`func routeSid(sub *subscription) string`](https://github.com/nats-io/gnatsd/blob/master/server/route.go#L486), I think we can replace `regexp.FindSubmatch` with a simple function.

The Benchmark result:
```
go test -bench=. -benchmem
BenchmarkRegexp-4   	 1000000	      1124 ns/op	     144 B/op	       2 allocs/op
BenchmarkParse-4    	50000000	        26.2 ns/op	       0 B/op	       0 allocs/op
```
The Benchmark code:
```
const (
	RSID  = "RSID"
	QRSID = "QRSID"

	QRSID_LEN = len(QRSID)

	RSID_CID_INDEX   = 1
	RSID_SID_INDEX   = 2
	EXPECTED_MATCHES = 3
)

var qrsidRe = regexp.MustCompile(`QRSID:(\d+):([^\s]+)`)
var _rsid = []byte("QRSID:1:hello")

func BenchmarkRegexp(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if !bytes.HasPrefix(_rsid, []byte(QRSID)) {
			continue
		}
		matches := qrsidRe.FindSubmatch(_rsid)
		if matches == nil || len(matches) != EXPECTED_MATCHES {
			continue
		}
		_, _ = matches[RSID_CID_INDEX], matches[RSID_SID_INDEX]
	}
}

func BenchmarkParse(b *testing.B) {
	for i := 0; i < b.N; i++ {
		cid, sid, ok := parseRouteSid(_rsid)
		if !ok {
			continue
		}

		_, _ = cid, sid
	}
}

func parseRouteSid(rsid []byte) (uint64, []byte, bool) {
	if !bytes.HasPrefix(rsid, []byte(QRSID)) {
		return 0, nil, false
	}

	// We don't care what's char of rsid[QRSID_LEN+1], it should be ':'
	for i, count := QRSID_LEN+1, len(rsid); i < count; i++ {
		switch rsid[i] {
		case ':':
			return uint64(parseInt64(rsid[QRSID_LEN+1 : i])), rsid[i+1:], true
		}
	}
	return 0, nil, true
}

// Ascii numbers 0-9
const (
	asciiZero = 48
	asciiNine = 57
)

// parseInt64 expects decimal positive numbers. We
// return -1 to signal error
func parseInt64(d []byte) (n int64) {
	if len(d) == 0 {
		return -1
	}
	for _, dec := range d {
		if dec < asciiZero || dec > asciiNine {
			return -1
		}
		n = n*10 + (int64(dec) - asciiZero)
	}
	return n
}
```
 
/cc @nats-io/core
