### PR TITLE
Fix code coverage script (remove auth package that no longer exists)

### DIFF
--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -3,7 +3,6 @@
 
 rm -rf ./cov
 mkdir cov
-go test -v -covermode=atomic -coverprofile=./cov/auth.out ./auth
 go test -v -covermode=atomic -coverprofile=./cov/conf.out ./conf
 go test -v -covermode=atomic -coverprofile=./cov/log.out ./logger
 go test -v -covermode=atomic -coverprofile=./cov/server.out ./server


### PR DESCRIPTION
Since `auth` package was removed, this would cause the script coverage to fail with error:
```
can't load package: package github.com/nats-io/gnatsd/auth: cannot find package "github.com/nats-io/gnatsd/auth" in any of:
	/home/travis/.gimme/versions/go1.7.5.linux.amd64/src/github.com/nats-io/gnatsd/auth (from $GOROOT)
	/home/travis/gopath/src/github.com/nats-io/gnatsd/auth (from $GOPATH)
```