### PR TITLE
[ADDED] Ability to get the server's HTTP Handler

### DIFF
--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1348,3 +1348,17 @@ func TestConcurrentMonitoring(t *testing.T) {
 	default:
 	}
 }
+
+func TestMonitorHandler(t *testing.T) {
+	s := runMonitorServer()
+	defer s.Shutdown()
+	handler := s.HTTPHandler()
+	if handler == nil {
+		t.Fatal("HTTP Handler should be set")
+	}
+	s.Shutdown()
+	handler = s.HTTPHandler()
+	if handler != nil {
+		t.Fatal("HTTP Handler should be nil")
+	}
+}

--- a/server/pse/pse_darwin.go
+++ b/server/pse/pse_darwin.go
@@ -3,18 +3,18 @@
 package pse
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 )
 
+// ProcUsage returns CPU usage
 func ProcUsage(pcpu *float64, rss, vss *int64) error {
 	pidStr := fmt.Sprintf("%d", os.Getpid())
 	out, err := exec.Command("ps", "o", "pcpu=,rss=,vsz=", "-p", pidStr).Output()
 	if err != nil {
 		*rss, *vss = -1, -1
-		return errors.New(fmt.Sprintf("ps call failed:%v", err))
+		return fmt.Errorf("ps call failed:%v", err)
 	}
 	fmt.Sscanf(string(out), "%f %d %d", pcpu, rss, vss)
 	*rss *= 1024 // 1k blocks, want bytes.


### PR DESCRIPTION
 - [X] Link to issue
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #480

### Changes proposed in this pull request: 
 - Add `Server.HTTPHandler()` function that returns the http handler used by the server after it is started and if it has been configured for monitoring.
 - Add test to make sure that HTTP handler is correctly returned
 - Fix unrelated staticcheck report
 
/cc @nats-io/core