### PR TITLE
Changed write_deadline configuration type

### DIFF
--- a/server/configs/test.conf
+++ b/server/configs/test.conf
@@ -39,4 +39,4 @@ ping_interval: 60
 ping_max: 3
 
 # how long server can block on a socket write to a client
-write_deadline: 3
+write_deadline: "3s"

--- a/server/opts.go
+++ b/server/opts.go
@@ -230,7 +230,19 @@ func ProcessConfigFile(configFile string) (*Options, error) {
 			}
 			opts.TLSTimeout = tc.Timeout
 		case "write_deadline":
-			opts.WriteDeadline = time.Duration(v.(int64)) * time.Second
+			wd, ok := v.(string)
+			if ok {
+				dur, err := time.ParseDuration(wd)
+				if err != nil {
+					return nil, fmt.Errorf("error parsing write_deadline: %v", err)
+				}
+				opts.WriteDeadline = dur
+			} else {
+				// Backward compatible with old type, assume this is the
+				// number of seconds.
+				opts.WriteDeadline = time.Duration(v.(int64)) * time.Second
+				fmt.Printf("WARNING: write_deadline should be converted to a duration\n")
+			}
 		}
 	}
 	return opts, nil

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -651,3 +651,40 @@ func TestTokenWithUsers(t *testing.T) {
 		t.Fatalf("Expected error related to token, got %v", err)
 	}
 }
+
+func TestParseWriteDeadline(t *testing.T) {
+	confFile := "test.conf"
+	defer os.Remove(confFile)
+	if err := ioutil.WriteFile(confFile, []byte("write_deadline: \"1x\"\n"), 0666); err != nil {
+		t.Fatalf("Error writing config file: %v", err)
+	}
+	_, err := ProcessConfigFile(confFile)
+	if err == nil {
+		t.Fatal("Expected error, got none")
+	}
+	if !strings.Contains(err.Error(), "parsing") {
+		t.Fatalf("Expected error related to parsing, got %v", err)
+	}
+	os.Remove(confFile)
+	if err := ioutil.WriteFile(confFile, []byte("write_deadline: \"1s\"\n"), 0666); err != nil {
+		t.Fatalf("Error writing config file: %v", err)
+	}
+	opts, err := ProcessConfigFile(confFile)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if opts.WriteDeadline != time.Second {
+		t.Fatalf("Expected write_deadline to be 1s, got %v", opts.WriteDeadline)
+	}
+	os.Remove(confFile)
+	if err := ioutil.WriteFile(confFile, []byte("write_deadline: 2\n"), 0666); err != nil {
+		t.Fatalf("Error writing config file: %v", err)
+	}
+	opts, err = ProcessConfigFile(confFile)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if opts.WriteDeadline != 2*time.Second {
+		t.Fatalf("Expected write_deadline to be 2s, got %v", opts.WriteDeadline)
+	}
+}


### PR DESCRIPTION
 - [X] Link to issue
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #487

### Changes proposed in this pull request: 

Changing from being the number of seconds to a time.Duration.
For backward compatibility, the configuration with the number
of seconds is still accepted but an error message is printed
asking the user to convert to duration.
 
/cc @nats-io/core @petemiron 
