### PR TITLE
[FIXED] Check for negative Offset and/or Limit when processing Connz

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -82,9 +82,11 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 	auth, _ := strconv.Atoi(r.URL.Query().Get("auth"))
 	subs, _ := strconv.Atoi(r.URL.Query().Get("subs"))
 	c.Offset, _ = strconv.Atoi(r.URL.Query().Get("offset"))
+	if c.Offset < 0 {
+		c.Offset = 0
+	}
 	c.Limit, _ = strconv.Atoi(r.URL.Query().Get("limit"))
-
-	if c.Limit == 0 {
+	if c.Limit <= 0 {
 		c.Limit = DefaultConnListSize
 	}
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -480,6 +480,31 @@ func TestConnzWithOffsetAndLimit(t *testing.T) {
 		t.Fatalf("Expected 0 connections in array, got %p\n", c.Conns)
 	}
 
+	// Test that when given negative values, 0 or default is used
+	resp, err = http.Get(url + "connz?offset=-1&limit=-1")
+	if err != nil {
+		t.Fatalf("Expected no error: Got %v\n", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected a 200 response, got %d\n", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Got an error reading the body: %v\n", err)
+	}
+	c = Connz{}
+	if err := json.Unmarshal(body, &c); err != nil {
+		t.Fatalf("Got an error unmarshalling the body: %v\n", err)
+	}
+	if c.Conns == nil || len(c.Conns) != 0 {
+		t.Fatalf("Expected 0 connections in array, got %p\n", c.Conns)
+	}
+	if c.Offset != 0 {
+		t.Fatalf("Expected offset to be 0, and limit to be %v, got %v and %v",
+			DefaultConnListSize, c.Offset, c.Limit)
+	}
+
 	cl1 := createClientConnSubscribeAndPublish(t)
 	defer cl1.Close()
 


### PR DESCRIPTION
 - [X] Link to issue
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #491

### Changes proposed in this pull request: 

Ensure that if the offset is negative, it is set to 0. If the limit
is negative, it is set to the default value.

/cc @nats-io/core
