### PR TITLE
[FIXED] Specifying HTTP and HTTPs ports produces unexpected behavior

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -223,6 +223,12 @@ func (s *Server) Start() {
 		s.logPid()
 	}
 
+	// Specifying both HTTP and HTTPS ports is a misconfiguration
+	if s.opts.HTTPPort != 0 && s.opts.HTTPSPort != 0 {
+		Fatalf("Can't specify both HTTP (%v) and HTTPs (%v) ports", s.opts.HTTPPort, s.opts.HTTPSPort)
+		return
+	}
+
 	// Start up the http server if needed.
 	if s.opts.HTTPPort != 0 {
 		s.StartHTTPMonitoring()

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -5,18 +5,31 @@ package test
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 )
 
 type dummyLogger struct {
+	sync.Mutex
 	msg string
 }
 
 func (d *dummyLogger) Fatalf(format string, args ...interface{}) {
+	d.Lock()
 	d.msg = fmt.Sprintf(format, args...)
-
+	d.Unlock()
 }
+
 func (d *dummyLogger) Errorf(format string, args ...interface{}) {
+}
+
+func (d *dummyLogger) Debugf(format string, args ...interface{}) {
+}
+
+func (d *dummyLogger) Tracef(format string, args ...interface{}) {
+}
+
+func (d *dummyLogger) Noticef(format string, args ...interface{}) {
 }
 
 func TestStackFatal(t *testing.T) {


### PR DESCRIPTION
The server will now print a Fatal error if user tries to configure
both HTTP and HTTPs ports.

Resolves #495
