### PR TITLE
[FIXED] Ensure Shutdown() always stops http server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
 - 1.6.4
-- 1.7.5
-- 1.8.1
+- 1.7.6
+- 1.8.3
 install:
 - go get github.com/nats-io/go-nats
 - go get github.com/mattn/goveralls


### PR DESCRIPTION
In case one creates a server instance with New() and then starts
the http server manually (s.StartHTTPMonitoring()), calling
s.Shutdown() would not stop the http server because Shutdown()
would return without doing anything if `running` was not true.
This boolean was set to true only in `s.Start()`.

Also added StartMonitoring() to perform the options check and
selectively start http or https server to replace individual calls.
This is useful for NATS Streaming server that will now be able
to call s.StartMonitoring() without having to duplicate code
about options checks and http server code.

This is related to PR #481