### PR TITLE
Remove global logger

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -192,8 +192,8 @@ func (c *client) initClient() {
 	c.cid = atomic.AddUint64(&s.gcid, 1)
 	c.bw = bufio.NewWriterSize(c.nc, startBufSize)
 	c.subs = make(map[string]*subscription)
-	c.debug = (atomic.LoadInt32(&debug) != 0)
-	c.trace = (atomic.LoadInt32(&trace) != 0)
+	c.debug = (atomic.LoadInt32(&c.srv.logging.debug) != 0)
+	c.trace = (atomic.LoadInt32(&c.srv.logging.trace) != 0)
 
 	// This is a scratch buffer used for processMsg()
 	// The msg header starts with "MSG ",
@@ -1350,13 +1350,13 @@ func (c *client) closeConnection() {
 		}
 
 		if rid != "" && srv.remotes[rid] != nil {
-			Debugf("Not attempting reconnect for solicited route, already connected to \"%s\"", rid)
+			c.srv.Debugf("Not attempting reconnect for solicited route, already connected to \"%s\"", rid)
 			return
 		} else if rid == srv.info.ID {
-			Debugf("Detected route to self, ignoring \"%s\"", rurl)
+			c.srv.Debugf("Detected route to self, ignoring \"%s\"", rurl)
 			return
 		} else if rtype != Implicit || retryImplicit {
-			Debugf("Attempting reconnect for solicited route \"%s\"", rurl)
+			c.srv.Debugf("Attempting reconnect for solicited route \"%s\"", rurl)
 			// Keep track of this go-routine so we can wait for it on
 			// server shutdown.
 			srv.startGoRoutine(func() { srv.reConnectToRoute(rurl, rtype) })
@@ -1368,20 +1368,20 @@ func (c *client) closeConnection() {
 
 func (c *client) Errorf(format string, v ...interface{}) {
 	format = fmt.Sprintf("%s - %s", c, format)
-	Errorf(format, v...)
+	c.srv.Errorf(format, v...)
 }
 
 func (c *client) Debugf(format string, v ...interface{}) {
 	format = fmt.Sprintf("%s - %s", c, format)
-	Debugf(format, v...)
+	c.srv.Debugf(format, v...)
 }
 
 func (c *client) Noticef(format string, v ...interface{}) {
 	format = fmt.Sprintf("%s - %s", c, format)
-	Noticef(format, v...)
+	c.srv.Noticef(format, v...)
 }
 
 func (c *client) Tracef(format string, v ...interface{}) {
 	format = fmt.Sprintf("%s - %s", c, format)
-	Tracef(format, v...)
+	c.srv.Tracef(format, v...)
 }

--- a/server/log.go
+++ b/server/log.go
@@ -3,20 +3,10 @@
 package server
 
 import (
-	"sync"
 	"sync/atomic"
 
 	"github.com/nats-io/gnatsd/logger"
 )
-
-// Package globals for performance checks
-var trace int32
-var debug int32
-
-var log = struct {
-	sync.Mutex
-	logger Logger
-}{}
 
 // Logger interface of the NATS Server
 type Logger interface {
@@ -40,19 +30,19 @@ type Logger interface {
 // SetLogger sets the logger of the server
 func (s *Server) SetLogger(logger Logger, debugFlag, traceFlag bool) {
 	if debugFlag {
-		atomic.StoreInt32(&debug, 1)
+		atomic.StoreInt32(&s.logging.debug, 1)
 	} else {
-		atomic.StoreInt32(&debug, 0)
+		atomic.StoreInt32(&s.logging.debug, 0)
 	}
 	if traceFlag {
-		atomic.StoreInt32(&trace, 1)
+		atomic.StoreInt32(&s.logging.trace, 1)
 	} else {
-		atomic.StoreInt32(&trace, 0)
+		atomic.StoreInt32(&s.logging.trace, 0)
 	}
 
-	log.Lock()
-	log.logger = logger
-	log.Unlock()
+	s.logging.Lock()
+	s.logging.logger = logger
+	s.logging.Unlock()
 }
 
 // If the logger is a file based logger, close and re-open the file.
@@ -60,73 +50,73 @@ func (s *Server) SetLogger(logger Logger, debugFlag, traceFlag bool) {
 // the process to trigger this function.
 func (s *Server) ReOpenLogFile() {
 	// Check to make sure this is a file logger.
-	log.Lock()
-	ll := log.logger
-	log.Unlock()
+	s.logging.RLock()
+	ll := s.logging.logger
+	s.logging.RUnlock()
 
 	if ll == nil {
-		Noticef("File log re-open ignored, no logger")
+		s.Noticef("File log re-open ignored, no logger")
 		return
 	}
 	if s.opts.LogFile == "" {
-		Noticef("File log re-open ignored, not a file logger")
+		s.Noticef("File log re-open ignored, not a file logger")
 	} else {
 		fileLog := logger.NewFileLogger(s.opts.LogFile,
 			s.opts.Logtime, s.opts.Debug, s.opts.Trace, true)
 		s.SetLogger(fileLog, s.opts.Debug, s.opts.Trace)
-		Noticef("File log re-opened")
+		s.Noticef("File log re-opened")
 	}
 }
 
 // Noticef logs a notice statement
-func Noticef(format string, v ...interface{}) {
-	executeLogCall(func(logger Logger, format string, v ...interface{}) {
+func (s *Server) Noticef(format string, v ...interface{}) {
+	s.executeLogCall(func(logger Logger, format string, v ...interface{}) {
 		logger.Noticef(format, v...)
 	}, format, v...)
 }
 
 // Errorf logs an error
-func Errorf(format string, v ...interface{}) {
-	executeLogCall(func(logger Logger, format string, v ...interface{}) {
+func (s *Server) Errorf(format string, v ...interface{}) {
+	s.executeLogCall(func(logger Logger, format string, v ...interface{}) {
 		logger.Errorf(format, v...)
 	}, format, v...)
 }
 
 // Fatalf logs a fatal error
-func Fatalf(format string, v ...interface{}) {
-	executeLogCall(func(logger Logger, format string, v ...interface{}) {
+func (s *Server) Fatalf(format string, v ...interface{}) {
+	s.executeLogCall(func(logger Logger, format string, v ...interface{}) {
 		logger.Fatalf(format, v...)
 	}, format, v...)
 }
 
 // Debugf logs a debug statement
-func Debugf(format string, v ...interface{}) {
-	if atomic.LoadInt32(&debug) == 0 {
+func (s *Server) Debugf(format string, v ...interface{}) {
+	if atomic.LoadInt32(&s.logging.debug) == 0 {
 		return
 	}
 
-	executeLogCall(func(logger Logger, format string, v ...interface{}) {
+	s.executeLogCall(func(logger Logger, format string, v ...interface{}) {
 		logger.Debugf(format, v...)
 	}, format, v...)
 }
 
 // Tracef logs a trace statement
-func Tracef(format string, v ...interface{}) {
-	if atomic.LoadInt32(&trace) == 0 {
+func (s *Server) Tracef(format string, v ...interface{}) {
+	if atomic.LoadInt32(&s.logging.trace) == 0 {
 		return
 	}
 
-	executeLogCall(func(logger Logger, format string, v ...interface{}) {
+	s.executeLogCall(func(logger Logger, format string, v ...interface{}) {
 		logger.Tracef(format, v...)
 	}, format, v...)
 }
 
-func executeLogCall(f func(logger Logger, format string, v ...interface{}), format string, args ...interface{}) {
-	log.Lock()
-	defer log.Unlock()
-	if log.logger == nil {
+func (s *Server) executeLogCall(f func(logger Logger, format string, v ...interface{}), format string, args ...interface{}) {
+	s.logging.RLock()
+	defer s.logging.RUnlock()
+	if s.logging.logger == nil {
 		return
 	}
 
-	f(log.logger, format, args...)
+	f(s.logging.logger, format, args...)
 }

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -20,46 +20,46 @@ func TestSetLogger(t *testing.T) {
 	server.SetLogger(dl, true, true)
 
 	// We assert that the logger has change to the DummyLogger
-	_ = log.logger.(*DummyLogger)
+	_ = server.logging.logger.(*DummyLogger)
 
-	if debug != 1 {
-		t.Fatalf("Expected debug 1, received value %d\n", debug)
+	if server.logging.debug != 1 {
+		t.Fatalf("Expected debug 1, received value %d\n", server.logging.debug)
 	}
 
-	if trace != 1 {
-		t.Fatalf("Expected trace 1, received value %d\n", trace)
+	if server.logging.trace != 1 {
+		t.Fatalf("Expected trace 1, received value %d\n", server.logging.trace)
 	}
 
 	// Check traces
 	expectedStr := "This is a Notice"
-	Noticef(expectedStr)
+	server.Noticef(expectedStr)
 	dl.checkContent(t, expectedStr)
 	expectedStr = "This is an Error"
-	Errorf(expectedStr)
+	server.Errorf(expectedStr)
 	dl.checkContent(t, expectedStr)
 	expectedStr = "This is a Fatal"
-	Fatalf(expectedStr)
+	server.Fatalf(expectedStr)
 	dl.checkContent(t, expectedStr)
 	expectedStr = "This is a Debug"
-	Debugf(expectedStr)
+	server.Debugf(expectedStr)
 	dl.checkContent(t, expectedStr)
 	expectedStr = "This is a Trace"
-	Tracef(expectedStr)
+	server.Tracef(expectedStr)
 	dl.checkContent(t, expectedStr)
 
 	// Make sure that we can reset to fal
 	server.SetLogger(dl, false, false)
-	if debug != 0 {
-		t.Fatalf("Expected debug 0, got %v", debug)
+	if server.logging.debug != 0 {
+		t.Fatalf("Expected debug 0, got %v", server.logging.debug)
 	}
-	if trace != 0 {
-		t.Fatalf("Expected trace 0, got %v", trace)
+	if server.logging.trace != 0 {
+		t.Fatalf("Expected trace 0, got %v", server.logging.trace)
 	}
 	// Now, Debug and Trace should not produce anything
 	dl.msg = ""
-	Debugf("This Debug should not be traced")
+	server.Debugf("This Debug should not be traced")
 	dl.checkContent(t, "")
-	Tracef("This Trace should not be traced")
+	server.Tracef("This Trace should not be traced")
 	dl.checkContent(t, "")
 }
 
@@ -115,7 +115,7 @@ func TestReOpenLogFile(t *testing.T) {
 	s.SetLogger(fileLog, false, false)
 	// Add some log
 	expectedStr := "This is a Notice"
-	Noticef(expectedStr)
+	s.Noticef(expectedStr)
 	// Check content of log
 	buf, err := ioutil.ReadFile(s.opts.LogFile)
 	if err != nil {
@@ -139,7 +139,7 @@ func TestReOpenLogFile(t *testing.T) {
 		t.Fatalf("File should indicate that file log was re-opened, got: %v", string(buf))
 	}
 	// Make sure we can append to the log
-	Noticef("New message")
+	s.Noticef("New message")
 	buf, err = ioutil.ReadFile(s.opts.LogFile)
 	if err != nil {
 		t.Fatalf("Error reading file: %v", err)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -242,7 +242,7 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 
 	b, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
-		Errorf("Error marshaling response to /connz request: %v", err)
+		s.Errorf("Error marshaling response to /connz request: %v", err)
 	}
 
 	// Handle response
@@ -333,7 +333,7 @@ func (s *Server) HandleRoutez(w http.ResponseWriter, r *http.Request) {
 
 	b, err := json.MarshalIndent(rs, "", "  ")
 	if err != nil {
-		Errorf("Error marshaling response to /routez request: %v", err)
+		s.Errorf("Error marshaling response to /routez request: %v", err)
 	}
 
 	// Handle response
@@ -349,7 +349,7 @@ func (s *Server) HandleSubsz(w http.ResponseWriter, r *http.Request) {
 	st := &Subsz{s.sl.Stats()}
 	b, err := json.MarshalIndent(st, "", "  ")
 	if err != nil {
-		Errorf("Error marshaling response to /subscriptionsz request: %v", err)
+		s.Errorf("Error marshaling response to /subscriptionsz request: %v", err)
 	}
 
 	// Handle response
@@ -486,7 +486,7 @@ func (s *Server) HandleVarz(w http.ResponseWriter, r *http.Request) {
 
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		Errorf("Error marshaling response to /varz request: %v", err)
+		s.Errorf("Error marshaling response to /varz request: %v", err)
 	}
 
 	// Handle response

--- a/server/opts.go
+++ b/server/opts.go
@@ -736,15 +736,21 @@ func RemoveSelfReference(clusterPort int, routes []*url.URL) ([]*url.URL, error)
 	var cleanRoutes []*url.URL
 	cport := strconv.Itoa(clusterPort)
 
-	selfIPs := getInterfaceIPs()
+	selfIPs, err := getInterfaceIPs()
+	if err != nil {
+		return nil, err
+	}
 	for _, r := range routes {
 		host, port, err := net.SplitHostPort(r.Host)
 		if err != nil {
 			return nil, err
 		}
 
-		if cport == port && isIPInList(selfIPs, getURLIP(host)) {
-			Noticef("Self referencing IP found: ", r)
+		ipList, err := getURLIP(host)
+		if err != nil {
+			return nil, err
+		}
+		if cport == port && isIPInList(selfIPs, ipList) {
 			continue
 		}
 		cleanRoutes = append(cleanRoutes, r)
@@ -764,19 +770,18 @@ func isIPInList(list1 []net.IP, list2 []net.IP) bool {
 	return false
 }
 
-func getURLIP(ipStr string) []net.IP {
+func getURLIP(ipStr string) ([]net.IP, error) {
 	ipList := []net.IP{}
 
 	ip := net.ParseIP(ipStr)
 	if ip != nil {
 		ipList = append(ipList, ip)
-		return ipList
+		return ipList, nil
 	}
 
 	hostAddr, err := net.LookupHost(ipStr)
 	if err != nil {
-		Errorf("Error looking up host with route hostname: %v", err)
-		return ipList
+		return nil, fmt.Errorf("Error looking up host with route hostname: %v", err)
 	}
 	for _, addr := range hostAddr {
 		ip = net.ParseIP(addr)
@@ -784,16 +789,15 @@ func getURLIP(ipStr string) []net.IP {
 			ipList = append(ipList, ip)
 		}
 	}
-	return ipList
+	return ipList, nil
 }
 
-func getInterfaceIPs() []net.IP {
+func getInterfaceIPs() ([]net.IP, error) {
 	var localIPs []net.IP
 
 	interfaceAddr, err := net.InterfaceAddrs()
 	if err != nil {
-		Errorf("Error getting self referencing address: %v", err)
-		return localIPs
+		return nil, fmt.Errorf("Error getting self referencing address: %v", err)
 	}
 
 	for i := 0; i < len(interfaceAddr); i++ {
@@ -801,10 +805,10 @@ func getInterfaceIPs() []net.IP {
 		if net.ParseIP(interfaceIP.String()) != nil {
 			localIPs = append(localIPs, interfaceIP)
 		} else {
-			Errorf("Error parsing self referencing address: %v", err)
+			return nil, fmt.Errorf("Error parsing self referencing address: %v", err)
 		}
 	}
-	return localIPs
+	return localIPs, nil
 }
 
 func processOptions(opts *Options) {

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func dummyClient() *client {
-	return &client{}
+	return &client{srv: New(&defaultServerOptions)}
 }
 
 func dummyRouteClient() *client {
-	return &client{typ: ROUTER}
+	return &client{srv: New(&defaultServerOptions), typ: ROUTER}
 }
 
 func TestParsePing(t *testing.T) {

--- a/server/signal.go
+++ b/server/signal.go
@@ -20,10 +20,10 @@ func (s *Server) handleSignals() {
 
 	go func() {
 		for sig := range c {
-			Debugf("Trapped %q signal", sig)
+			s.Debugf("Trapped %q signal", sig)
 			switch sig {
 			case syscall.SIGINT:
-				Noticef("Server Exiting..")
+				s.Noticef("Server Exiting..")
 				os.Exit(0)
 			case syscall.SIGUSR1:
 				// File log re-open for rotating file logs.

--- a/server/signal_test.go
+++ b/server/signal_test.go
@@ -34,7 +34,7 @@ func TestSignalToReOpenLogFile(t *testing.T) {
 
 	// Add a trace
 	expectedStr := "This is a Notice"
-	Noticef(expectedStr)
+	s.Noticef(expectedStr)
 	buf, err := ioutil.ReadFile(logFile)
 	if err != nil {
 		t.Fatalf("Error reading file: %v", err)

--- a/server/split_test.go
+++ b/server/split_test.go
@@ -288,7 +288,8 @@ func TestSplitConnectArg(t *testing.T) {
 }
 
 func TestSplitDanglingArgBuf(t *testing.T) {
-	c := &client{subs: make(map[string]*subscription)}
+	s := New(&defaultServerOptions)
+	c := &client{srv: s, subs: make(map[string]*subscription)}
 
 	// We test to make sure we do not dangle any argBufs after processing
 	// since that could lead to performance issues.


### PR DESCRIPTION
gnatsd currently uses a global logger. This can cause some problems
(especially around the config-reload work), but global variables are
also just an anti-pattern in general. The current behavior is
particularly surprising because the global logger is configured through
calls to the Server.

This addresses issue #500 by removing the global logger and making it a
field on Server.

@nats-io/core
