### PR TITLE
[FIXED] Intermittent failing test

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -604,6 +604,7 @@ func TestAuthorizationTimeout(t *testing.T) {
 	if _, err := client.ReadString('\n'); err != nil {
 		t.Fatalf("Error receiving info from server: %v\n", err)
 	}
+	time.Sleep(secondsToDuration(serverOptions.AuthTimeout))
 	l, err := client.ReadString('\n')
 	if err != nil {
 		t.Fatalf("Error receiving info from server: %v\n", err)

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -591,7 +591,7 @@ func TestClientMapRemoval(t *testing.T) {
 func TestAuthorizationTimeout(t *testing.T) {
 	serverOptions := defaultServerOptions
 	serverOptions.Authorization = "my_token"
-	serverOptions.AuthTimeout = 1
+	serverOptions.AuthTimeout = 0.4
 	s := RunServer(&serverOptions)
 	defer s.Shutdown()
 
@@ -604,7 +604,7 @@ func TestAuthorizationTimeout(t *testing.T) {
 	if _, err := client.ReadString('\n'); err != nil {
 		t.Fatalf("Error receiving info from server: %v\n", err)
 	}
-	time.Sleep(secondsToDuration(serverOptions.AuthTimeout))
+	time.Sleep(2 * secondsToDuration(serverOptions.AuthTimeout))
 	l, err := client.ReadString('\n')
 	if err != nil {
 		t.Fatalf("Error receiving info from server: %v\n", err)


### PR DESCRIPTION
Added the sleep back in to TestAuthorizationTimeout which got removed in #493.
This was causing the test to fail intermittently, though it would
usually pass on Travis CI or with the -race flag since these slowed it
down enough.

@nats-io/core
