### PR TITLE
Implement config reload support for debug

### DIFF
--- a/server/configs/reload/reload.conf
+++ b/server/configs/reload/reload.conf
@@ -1,4 +1,4 @@
 # logging options
-debug:   false
-trace:   false # enable tracing on reload
+debug:   true # enable on reload
+trace:   true # enable on reload
 logtime: false

--- a/server/configs/reload/reload_unsupported.conf
+++ b/server/configs/reload/reload_unsupported.conf
@@ -1,4 +1,4 @@
 # logging options
-debug:   true # debug not supported on config reload
-trace:   false
-logtime: false
+debug:   false
+trace:   true
+logtime: true # logtime not supported on config reload

--- a/server/configs/reload/test.conf
+++ b/server/configs/reload/test.conf
@@ -1,4 +1,4 @@
 # logging options
 debug:   false
-trace:   true
+trace:   false
 logtime: false

--- a/server/reload.go
+++ b/server/reload.go
@@ -30,6 +30,17 @@ func (t *traceOption) Apply(server *Server) {
 	server.Noticef("Reloaded: trace = %v", t.newValue)
 }
 
+// debugOption implements the option interface for the `debug` setting.
+type debugOption struct {
+	newValue bool
+}
+
+// Apply the debug change by reconfiguring the server's logger.
+func (d *debugOption) Apply(server *Server) {
+	server.ConfigureLogger()
+	server.Noticef("Reloaded: debug = %v", d.newValue)
+}
+
 // Reload reads the current configuration file and applies any supported
 // changes. This returns an error if the server was not started with a config
 // file or an option which doesn't support hot-swapping was changed.
@@ -86,6 +97,8 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 		switch strings.ToLower(field.Name) {
 		case "trace":
 			diffOpts = append(diffOpts, &traceOption{newValue.(bool)})
+		case "debug":
+			diffOpts = append(diffOpts, &debugOption{newValue.(bool)})
 		default:
 			// Bail out if attempting to reload any unsupported options.
 			return nil, fmt.Errorf("Config reload not supported for %s", field.Name)

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -34,7 +34,7 @@ func TestConfigReloadUnsupported(t *testing.T) {
 		Port:           4222,
 		AuthTimeout:    1.0,
 		Debug:          false,
-		Trace:          true,
+		Trace:          false,
 		Logtime:        false,
 		MaxControlLine: 1024,
 		MaxPayload:     1048576,
@@ -94,7 +94,7 @@ func TestConfigReloadInvalidConfig(t *testing.T) {
 		Port:           4222,
 		AuthTimeout:    1.0,
 		Debug:          false,
-		Trace:          true,
+		Trace:          false,
 		Logtime:        false,
 		MaxControlLine: 1024,
 		MaxPayload:     1048576,
@@ -154,7 +154,7 @@ func TestConfigReload(t *testing.T) {
 		Port:           4222,
 		AuthTimeout:    1.0,
 		Debug:          false,
-		Trace:          true,
+		Trace:          false,
 		Logtime:        false,
 		MaxControlLine: 1024,
 		MaxPayload:     1048576,
@@ -188,7 +188,6 @@ func TestConfigReload(t *testing.T) {
 		t.Fatalf("Error creating symlink: %v", err)
 	}
 
-	// Should change `trace` to false.
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
 	}
@@ -196,9 +195,10 @@ func TestConfigReload(t *testing.T) {
 	// Ensure config changed.
 	var updatedGolden *Options = &Options{}
 	*updatedGolden = *golden
-	updatedGolden.Trace = false
+	updatedGolden.Trace = true
+	updatedGolden.Debug = true
 	if !reflect.DeepEqual(updatedGolden, server.getOpts()) {
 		t.Fatalf("Options are incorrect.\nexpected: %+v\ngot: %+v",
-			updatedGolden, opts)
+			updatedGolden, server.getOpts())
 	}
 }


### PR DESCRIPTION
Add config reload support for `debug` option.
 
@nats-io/core