### PR TITLE
Cross compile CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 - gosimple $EXCLUDE_VENDOR
 - misspell -error -locale US .
 - staticcheck $EXCLUDE_VENDOR
-- ./scripts/cross_compile.sh $TRAVIS_TAG
+- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]]; then ./scripts/cross_compile.sh $TRAVIS_TAG; fi
 script:
 - go test -i -race $EXCLUDE_VENDOR
 - go test -v -race $EXCLUDE_VENDOR

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,10 @@ before_script:
 - gosimple $EXCLUDE_VENDOR
 - misspell -error -locale US .
 - staticcheck $EXCLUDE_VENDOR
+- ./scripts/cross_compile.sh $TRAVIS_TAG
 script:
 - go test -i -race $EXCLUDE_VENDOR
 - go test -v -race $EXCLUDE_VENDOR
 after_success:
 - if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]]; then ./scripts/cov.sh TRAVIS; fi
-- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]] && [ "$TRAVIS_TAG" != "" ]; then ./scripts/cross_compile.sh $TRAVIS_TAG; ghr --owner nats-io --token $GITHUB_TOKEN --draft --replace $TRAVIS_TAG pkg/; fi
+- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]] && [ "$TRAVIS_TAG" != "" ]; ghr --owner nats-io --token $GITHUB_TOKEN --draft --replace $TRAVIS_TAG pkg/; fi

--- a/scripts/cross_compile.sh
+++ b/scripts/cross_compile.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 go get github.com/mitchellh/gox
 go get github.com/tcnksm/ghr
 


### PR DESCRIPTION
Run the cross-compile script as part of CI to prevent mistakes like [this](https://github.com/nats-io/gnatsd/pull/504) from happening again.

@nats-io/core
