### PR TITLE
Fix Options Clone

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -40,12 +40,15 @@ func (p *Permissions) clone() *Permissions {
 	if p == nil {
 		return nil
 	}
-	clone := &Permissions{
-		Publish:   make([]string, len(p.Publish)),
-		Subscribe: make([]string, len(p.Subscribe)),
+	clone := &Permissions{}
+	if p.Publish != nil {
+		clone.Publish = make([]string, len(p.Publish))
+		copy(clone.Publish, p.Publish)
 	}
-	copy(clone.Publish, p.Publish)
-	copy(clone.Subscribe, p.Subscribe)
+	if p.Subscribe != nil {
+		clone.Subscribe = make([]string, len(p.Subscribe))
+		copy(clone.Subscribe, p.Subscribe)
+	}
 	return clone
 }
 

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -66,6 +66,19 @@ func TestUserClonePermissionsNoLists(t *testing.T) {
 	}
 }
 
+func TestUserCloneNoPermissions(t *testing.T) {
+	user := &User{
+		Username: "foo",
+		Password: "bar",
+	}
+
+	clone := user.clone()
+
+	if clone.Permissions != nil {
+		t.Fatalf("Expected Permissions to be nil, got: %v", clone.Permissions)
+	}
+}
+
 func TestUserCloneNil(t *testing.T) {
 	user := (*User)(nil)
 	clone := user.clone()

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -49,6 +49,23 @@ func TestUserClone(t *testing.T) {
 	}
 }
 
+func TestUserClonePermissionsNoLists(t *testing.T) {
+	user := &User{
+		Username:    "foo",
+		Password:    "bar",
+		Permissions: &Permissions{},
+	}
+
+	clone := user.clone()
+
+	if clone.Permissions.Publish != nil {
+		t.Fatalf("Expected Publish to be nil, got: %v", clone.Permissions.Publish)
+	}
+	if clone.Permissions.Subscribe != nil {
+		t.Fatalf("Expected Subscribe to be nil, got: %v", clone.Permissions.Subscribe)
+	}
+}
+
 func TestUserCloneNil(t *testing.T) {
 	user := (*User)(nil)
 	clone := user.clone()

--- a/server/opts.go
+++ b/server/opts.go
@@ -80,15 +80,19 @@ func (o *Options) Clone() *Options {
 	}
 	clone := &Options{}
 	*clone = *o
-	clone.Users = make([]*User, len(o.Users))
-	for i, user := range o.Users {
-		clone.Users[i] = user.clone()
+	if o.Users != nil {
+		clone.Users = make([]*User, len(o.Users))
+		for i, user := range o.Users {
+			clone.Users[i] = user.clone()
+		}
 	}
-	clone.Routes = make([]*url.URL, len(o.Routes))
-	for i, route := range o.Routes {
-		routeCopy := &url.URL{}
-		*routeCopy = *route
-		clone.Routes[i] = routeCopy
+	if o.Routes != nil {
+		clone.Routes = make([]*url.URL, len(o.Routes))
+		for i, route := range o.Routes {
+			routeCopy := &url.URL{}
+			*routeCopy = *route
+			clone.Routes[i] = routeCopy
+		}
 	}
 	return clone
 }

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -739,6 +739,19 @@ func TestOptionsClone(t *testing.T) {
 	}
 }
 
+func TestOptionsCloneNilLists(t *testing.T) {
+	opts := &Options{}
+
+	clone := opts.Clone()
+
+	if clone.Routes != nil {
+		t.Fatalf("Expected Routes to be nil, got: %v", clone.Routes)
+	}
+	if clone.Users != nil {
+		t.Fatalf("Expected Users to be nil, got: %v", clone.Users)
+	}
+}
+
 func TestOptionsCloneNil(t *testing.T) {
 	opts := (*Options)(nil)
 	clone := opts.Clone()


### PR DESCRIPTION
Ensure Options.Clone() only initializes Users and Routes when the
Options it's cloning has them initialized.

@kozlovic 
