### PR TITLE
Updated test to suppress stdout output

### DIFF
--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -683,6 +683,13 @@ func TestParseWriteDeadline(t *testing.T) {
 		t.Fatalf("Expected write_deadline to be 1s, got %v", opts.WriteDeadline)
 	}
 	os.Remove(confFile)
+	oldStdout := os.Stdout
+	_, w, _ := os.Pipe()
+	defer func() {
+		w.Close()
+		os.Stdout = oldStdout
+	}()
+	os.Stdout = w
 	if err := ioutil.WriteFile(confFile, []byte("write_deadline: 2\n"), 0666); err != nil {
 		t.Fatalf("Error writing config file: %v", err)
 	}


### PR DESCRIPTION
The parsing of write_deadline may produce a warning to stdout
since there is no logger set at this stage.
Updated the test to suppress stdout to not polute the tests output.
