### PR TITLE
Random port extended

### DIFF
--- a/conf/parse.go
+++ b/conf/parse.go
@@ -140,7 +140,7 @@ func (p *parser) processItem(it item) error {
 	case itemInteger:
 		lastDigit := 0
 		for _, r := range it.val {
-			if !unicode.IsDigit(r) {
+			if !unicode.IsDigit(r) && r != '-' {
 				break
 			}
 			lastDigit++

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -634,20 +634,23 @@ func TestTwoTokenPubMatchSingleTokenSub(t *testing.T) {
 }
 
 func TestUnsubRace(t *testing.T) {
-	s := RunServer(nil)
+	opts := DefaultOptions()
+	s := RunServer(opts)
 	defer s.Shutdown()
 
-	nc, err := nats.Connect(fmt.Sprintf("nats://%s:%d",
-		DefaultOptions.Host,
-		DefaultOptions.Port))
+	url := fmt.Sprintf("nats://%s:%d",
+		s.getOpts().Host,
+		s.Addr().(*net.TCPAddr).Port,
+	)
+	nc, err := nats.Connect(url)
 	if err != nil {
-		t.Fatalf("Error creating client: %v\n", err)
+		t.Fatalf("Error creating client to %s: %v\n", url, err)
 	}
 	defer nc.Close()
 
 	ncp, err := nats.Connect(fmt.Sprintf("nats://%s:%d",
-		DefaultOptions.Host,
-		DefaultOptions.Port))
+		s.getOpts().Host,
+		s.Addr().(*net.TCPAddr).Port))
 	if err != nil {
 		t.Fatalf("Error creating client: %v\n", err)
 	}

--- a/server/configs/malformed_cluster_address.conf
+++ b/server/configs/malformed_cluster_address.conf
@@ -1,0 +1,6 @@
+# Copyright 2016 Apcera Inc. All rights reserved.
+
+# Test malformed cluster listen address
+cluster {
+  listen: 266.0.0.1:foo
+}

--- a/server/configs/malformed_listen_address.conf
+++ b/server/configs/malformed_listen_address.conf
@@ -1,0 +1,4 @@
+# Copyright 2016 Apcera Inc. All rights reserved.
+
+# test garbage listen address for failure
+listen: 10.0.1.22:foo

--- a/server/configs/reload/basic.conf
+++ b/server/configs/reload/basic.conf
@@ -1,0 +1,1 @@
+listen: localhost:-1

--- a/server/configs/reload/tls_test.conf
+++ b/server/configs/reload/tls_test.conf
@@ -1,0 +1,10 @@
+
+# Simple TLS config file
+
+listen: localhost:-1
+
+tls {
+  cert_file:  "./configs/certs/server.pem"
+  key_file:   "./configs/certs/key.pem"
+  timeout:    2
+}

--- a/server/configs/reload/tls_verify_test.conf
+++ b/server/configs/reload/tls_verify_test.conf
@@ -1,0 +1,12 @@
+
+# Simple TLS config file
+
+listen: localhost:-1
+
+tls {
+  cert_file:  "./configs/certs/cert.new.pem"
+  key_file:   "./configs/certs/key.new.pem"
+  ca_file:    "./configs/certs/cert.new.pem"
+  verify:     true
+  timeout:    2
+}

--- a/server/log.go
+++ b/server/log.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"sync/atomic"
 
-	"fmt"
 	"github.com/nats-io/gnatsd/logger"
 )
 
@@ -119,11 +118,6 @@ func (s *Server) Errorf(format string, v ...interface{}) {
 
 // Fatalf logs a fatal error
 func (s *Server) Fatalf(format string, v ...interface{}) {
-	s.mu.Lock()
-	// always store the fatal log
-	errStr := fmt.Sprintf(format, v)
-	s.fatalError = errStr
-	s.mu.Unlock()
 	s.executeLogCall(func(logger Logger, format string, v ...interface{}) {
 		logger.Fatalf(format, v...)
 	}, format, v...)

--- a/server/log.go
+++ b/server/log.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/nats-io/gnatsd/logger"
+	"fmt"
 )
 
 // Logger interface of the NATS Server
@@ -118,6 +119,11 @@ func (s *Server) Errorf(format string, v ...interface{}) {
 
 // Fatalf logs a fatal error
 func (s *Server) Fatalf(format string, v ...interface{}) {
+	s.mu.Lock()
+	// always store the fatal log
+	errStr := fmt.Sprintf(format, v)
+	s.fatalError = errStr
+	s.mu.Unlock()
 	s.executeLogCall(func(logger Logger, format string, v ...interface{}) {
 		logger.Fatalf(format, v...)
 	}, format, v...)

--- a/server/log.go
+++ b/server/log.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"sync/atomic"
 
-	"github.com/nats-io/gnatsd/logger"
 	"fmt"
+	"github.com/nats-io/gnatsd/logger"
 )
 
 // Logger interface of the NATS Server

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -23,15 +23,15 @@ const MONITOR_PORT = -1
 const CLUSTER_PORT = -1
 
 func DefaultMonitorOptions() *Options {
-	return &Options {
+	return &Options{
 		Host:     "localhost",
 		Port:     CLIENT_PORT,
 		HTTPHost: "127.0.0.1",
 		HTTPPort: MONITOR_PORT,
-		NoLog:   true,
-		NoSigs:  true,
-		Debug:   true,
-		Trace:   true,
+		NoLog:    true,
+		NoSigs:   true,
+		Debug:    true,
+		Trace:    true,
 	}
 }
 

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -30,8 +30,6 @@ func DefaultMonitorOptions() *Options {
 		HTTPPort: MONITOR_PORT,
 		NoLog:    true,
 		NoSigs:   true,
-		Debug:    true,
-		Trace:    true,
 	}
 }
 
@@ -592,7 +590,6 @@ func TestConnzWithOffsetAndLimit(t *testing.T) {
 
 func TestConnzDefaultSorted(t *testing.T) {
 	s := runMonitorServer()
-	s.ConfigureLogger()
 	defer s.Shutdown()
 
 	clients := make([]*nats.Conn, 4)
@@ -1271,7 +1268,7 @@ func TestConnzWithNamedClient(t *testing.T) {
 
 // Create a connection to test ConnInfo
 func createClientConnSubscribeAndPublish(t *testing.T, s *Server) *nats.Conn {
-	natsUrl := fmt.Sprintf("nats://127.0.0.1:%d", s.Addr().(*net.TCPAddr).Port)
+	natsUrl := fmt.Sprintf("nats://localhost:%d", s.Addr().(*net.TCPAddr).Port)
 	client := nats.DefaultOptions
 	client.Servers = []string{natsUrl}
 	nc, err := client.Connect()

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -104,7 +104,7 @@ func TestVarz(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "varz")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -176,7 +176,7 @@ func TestVarz(t *testing.T) {
 	}
 
 	// Test JSONP
-	respj, errj := http.Get(fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port) + "varz?callback=callback")
+	respj, errj := http.Get(fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port) + "varz?callback=callback")
 	if errj != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
 	}
@@ -191,7 +191,7 @@ func TestConnz(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "connz")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -311,7 +311,7 @@ func TestConnz(t *testing.T) {
 	}
 
 	// Test JSONP
-	respj, errj := http.Get(fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port) + "connz?callback=callback")
+	respj, errj := http.Get(fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port) + "connz?callback=callback")
 	if errj != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
 	}
@@ -329,7 +329,7 @@ func TestConnzWithSubs(t *testing.T) {
 	nc := createClientConnSubscribeAndPublish(t, s)
 	defer nc.Close()
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "connz?subs=1")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -368,7 +368,7 @@ func TestConnzLastActivity(t *testing.T) {
 	nc2.Flush()
 
 	pollConz := func() *Connz {
-		url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+		url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 		resp, err := http.Get(url + "connz?subs=1")
 		if err != nil {
 			t.Fatalf("Expected no error: Got %v\n", err)
@@ -456,7 +456,7 @@ func TestConnzWithOffsetAndLimit(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 
 	// Test that offset and limit ok when not enough connections
 	resp, err := http.Get(url + "connz?offset=1&limit=1")
@@ -598,7 +598,7 @@ func TestConnzDefaultSorted(t *testing.T) {
 		defer clients[i].Close()
 	}
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "connz")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -634,7 +634,7 @@ func TestConnzSortedByCid(t *testing.T) {
 		defer clients[i].Close()
 	}
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "connz?sort=cid")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -678,7 +678,7 @@ func TestConnzSortedByBytesAndMsgs(t *testing.T) {
 		defer clients[i].Close()
 	}
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "connz?sort=bytes_to")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -704,7 +704,7 @@ func TestConnzSortedByBytesAndMsgs(t *testing.T) {
 			c.Conns[0].OutBytes, c.Conns[1].OutBytes, c.Conns[2].OutBytes, c.Conns[3].OutBytes)
 	}
 
-	url = fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url = fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err = http.Get(url + "connz?sort=msgs_to")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -730,7 +730,7 @@ func TestConnzSortedByBytesAndMsgs(t *testing.T) {
 			c.Conns[0].OutMsgs, c.Conns[1].OutMsgs, c.Conns[2].OutMsgs, c.Conns[3].OutMsgs)
 	}
 
-	url = fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url = fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err = http.Get(url + "connz?sort=bytes_from")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -756,7 +756,7 @@ func TestConnzSortedByBytesAndMsgs(t *testing.T) {
 			c.Conns[0].InBytes, c.Conns[1].InBytes, c.Conns[2].InBytes, c.Conns[3].InBytes)
 	}
 
-	url = fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url = fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err = http.Get(url + "connz?sort=msgs_from")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -796,7 +796,7 @@ func TestConnzSortedByPending(t *testing.T) {
 	}
 	defer firstClient.Close()
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "connz?sort=pending")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -836,7 +836,7 @@ func TestConnzSortedBySubs(t *testing.T) {
 	}
 	defer firstClient.Close()
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "connz?sort=subs")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -880,7 +880,7 @@ func TestConnzSortedByLast(t *testing.T) {
 		clients[i].Flush()
 	}
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "connz?sort=last")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -918,7 +918,7 @@ func TestConnzSortedByUptime(t *testing.T) {
 		time.Sleep(250 * time.Millisecond)
 	}
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "connz?sort=uptime")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -964,7 +964,7 @@ func TestConnzSortedByIdle(t *testing.T) {
 	time.Sleep(time.Second)
 	firstClient.Publish("client.1", []byte("new message"))
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "connz?sort=idle")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -1021,7 +1021,7 @@ func TestConnzSortBadRequest(t *testing.T) {
 	}
 	defer firstClient.Close()
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "connz?sort=foo")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -1052,7 +1052,7 @@ func TestConnzWithRoutes(t *testing.T) {
 		NoLog:  true,
 		NoSigs: true,
 	}
-	routeURL, _ := url.Parse(fmt.Sprintf("nats-route://127.0.0.1:%d", s.ClusterAddr().(*net.TCPAddr).Port))
+	routeURL, _ := url.Parse(fmt.Sprintf("nats-route://127.0.0.1:%d", s.ClusterAddr().Port))
 	opts.Routes = []*url.URL{routeURL}
 
 	sc := RunServer(opts)
@@ -1060,7 +1060,7 @@ func TestConnzWithRoutes(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "connz")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -1093,7 +1093,7 @@ func TestConnzWithRoutes(t *testing.T) {
 	}
 
 	// Now check routez
-	url = fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url = fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err = http.Get(url + "routez")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -1127,7 +1127,7 @@ func TestConnzWithRoutes(t *testing.T) {
 	}
 
 	// Test JSONP
-	respj, errj := http.Get(fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port) + "routez?callback=callback")
+	respj, errj := http.Get(fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port) + "routez?callback=callback")
 	if errj != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
 	}
@@ -1145,7 +1145,7 @@ func TestSubsz(t *testing.T) {
 	nc := createClientConnSubscribeAndPublish(t, s)
 	defer nc.Close()
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "subscriptionsz")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -1178,7 +1178,7 @@ func TestSubsz(t *testing.T) {
 	}
 
 	// Test JSONP
-	respj, errj := http.Get(fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port) + "subscriptionsz?callback=callback")
+	respj, errj := http.Get(fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port) + "subscriptionsz?callback=callback")
 	ct = respj.Header.Get("Content-Type")
 	if errj != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -1197,7 +1197,7 @@ func TestHandleRoot(t *testing.T) {
 	nc := createClientConnSubscribeAndPublish(t, s)
 	defer nc.Close()
 
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port))
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port))
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
 	}
@@ -1230,7 +1230,7 @@ func TestConnzWithNamedClient(t *testing.T) {
 	nc := createClientConnWithName(t, clientName, s)
 	defer nc.Close()
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "connz")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -1302,7 +1302,7 @@ func TestStacksz(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	resp, err := http.Get(url + "stacksz")
 	if err != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -1325,7 +1325,7 @@ func TestStacksz(t *testing.T) {
 		t.Fatalf("Result does not seem to contain server's stacks:\n%v", str)
 	}
 	// Test JSONP
-	respj, errj := http.Get(fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port) + "subscriptionsz?callback=callback")
+	respj, errj := http.Get(fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port) + "subscriptionsz?callback=callback")
 	ct = respj.Header.Get("Content-Type")
 	if errj != nil {
 		t.Fatalf("Expected no error: Got %v\n", err)
@@ -1340,7 +1340,7 @@ func TestConcurrentMonitoring(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
 
-	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("http://localhost:%d/", s.MonitorAddr().Port)
 	// Get some endpoints. Make sure we have at least varz,
 	// and the more the merrier.
 	endpoints := []string{"varz", "varz", "varz", "connz", "connz", "subsz", "subsz", "routez", "routez"}

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -746,3 +746,29 @@ func TestOptionsCloneNil(t *testing.T) {
 		t.Fatalf("Expected nil, got: %+v", clone)
 	}
 }
+
+func TestEmptyConfig(t *testing.T) {
+	opts, err := ProcessConfigFile("")
+
+	if err != nil {
+		t.Fatalf("Expected no error from empty config, got: %+v", err)
+	}
+
+	if opts.ConfigFile != "" {
+		t.Fatalf("Expected empty config, got: %+v", opts)
+	}
+}
+
+func TestMalformedListenAddress(t *testing.T) {
+	opts, err := ProcessConfigFile("./configs/malformed_listen_address.conf")
+	if err == nil {
+		t.Fatalf("Expected an error reading config file: got %+v\n", opts)
+	}
+}
+
+func TestMalformedClusterAddress(t *testing.T) {
+	opts, err := ProcessConfigFile("./configs/malformed_cluster_address.conf")
+	if err == nil {
+		t.Fatalf("Expected an error reading config file: got %+v\n", opts)
+	}
+}

--- a/server/reload.go
+++ b/server/reload.go
@@ -123,9 +123,23 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 		case "tlstimeout":
 			// TLSTimeout change is picked up when Options is swapped.
 			continue
+		case "port":
+			// check to see if newValue == 0 and continue if so.
+			if newValue == 0 {
+				// ignore RANDOM_PORT
+				continue
+			} else {
+				return nil, fmt.Errorf("Config reload not supported for %s", field.Name)
+			}
+		case "http_port", "https_port":
+			// check to see if newValue == -1 (RANDOM_PORT for http/https monitoring port)
+			if newValue == -1 {
+				continue
+			}
+			fallthrough
 		default:
 			// Bail out if attempting to reload any unsupported options.
-			return nil, fmt.Errorf("Config reload not supported for %s", field.Name)
+			return nil, fmt.Errorf("Config reload not supported for %s: old=%v, new=%v", field.Name, oldValue, newValue)
 		}
 	}
 

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/nats-io/go-nats"
+	"net"
 )
 
 // Ensure Reload returns an error when attempting to reload a server that did
@@ -225,7 +226,7 @@ func TestConfigReloadRotateTLS(t *testing.T) {
 	}
 	config := filepath.Join(dir, "tmp.conf")
 
-	if err := os.Symlink("./configs/tls_test.conf", config); err != nil {
+	if err := os.Symlink("./configs/reload/tls_test.conf", config); err != nil {
 		t.Fatalf("Error creating symlink: %v", err)
 	}
 	defer os.Remove(config)
@@ -239,7 +240,7 @@ func TestConfigReloadRotateTLS(t *testing.T) {
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
-	addr := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
+	addr := fmt.Sprintf("nats://%s:%d", opts.Host, server.Addr().(*net.TCPAddr).Port)
 	nc, err := nats.Connect(addr, nats.Secure())
 	if err != nil {
 		t.Fatalf("Error creating client: %v", err)
@@ -255,7 +256,7 @@ func TestConfigReloadRotateTLS(t *testing.T) {
 	if err := os.Remove(config); err != nil {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
-	if err := os.Symlink("./configs/tls_verify_test.conf", config); err != nil {
+	if err := os.Symlink("./configs/reload/tls_verify_test.conf", config); err != nil {
 		t.Fatalf("Error creating symlink: %v", err)
 	}
 	if err := server.Reload(); err != nil {
@@ -298,7 +299,7 @@ func TestConfigReloadEnableTLS(t *testing.T) {
 	}
 	config := filepath.Join(dir, "tmp.conf")
 
-	if err := os.Symlink("./configs/basic.conf", config); err != nil {
+	if err := os.Symlink("./configs/reload/basic.conf", config); err != nil {
 		t.Fatalf("Error creating symlink: %v", err)
 	}
 	defer os.Remove(config)
@@ -312,7 +313,7 @@ func TestConfigReloadEnableTLS(t *testing.T) {
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
-	addr := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
+	addr := fmt.Sprintf("nats://%s:%d", opts.Host, server.Addr().(*net.TCPAddr).Port)
 	nc, err := nats.Connect(addr)
 	if err != nil {
 		t.Fatalf("Error creating client: %v", err)
@@ -323,7 +324,7 @@ func TestConfigReloadEnableTLS(t *testing.T) {
 	if err := os.Remove(config); err != nil {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
-	if err := os.Symlink("./configs/tls_test.conf", config); err != nil {
+	if err := os.Symlink("./configs/reload/tls_test.conf", config); err != nil {
 		t.Fatalf("Error creating symlink: %v", err)
 	}
 	if err := server.Reload(); err != nil {
@@ -354,7 +355,7 @@ func TestConfigReloadDisableTLS(t *testing.T) {
 	}
 	config := filepath.Join(dir, "tmp.conf")
 
-	if err := os.Symlink("./configs/tls_test.conf", config); err != nil {
+	if err := os.Symlink("./configs/reload/tls_test.conf", config); err != nil {
 		t.Fatalf("Error creating symlink: %v", err)
 	}
 	defer os.Remove(config)
@@ -368,7 +369,7 @@ func TestConfigReloadDisableTLS(t *testing.T) {
 	defer server.Shutdown()
 
 	// Ensure we can connect as a sanity check.
-	addr := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
+	addr := fmt.Sprintf("nats://%s:%d", opts.Host, server.Addr().(*net.TCPAddr).Port)
 	nc, err := nats.Connect(addr, nats.Secure())
 	if err != nil {
 		t.Fatalf("Error creating client: %v", err)
@@ -379,7 +380,7 @@ func TestConfigReloadDisableTLS(t *testing.T) {
 	if err := os.Remove(config); err != nil {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
-	if err := os.Symlink("./configs/basic.conf", config); err != nil {
+	if err := os.Symlink("./configs/reload/basic.conf", config); err != nil {
 		t.Fatalf("Error creating symlink: %v", err)
 	}
 	if err := server.Reload(); err != nil {

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	"github.com/nats-io/go-nats"
-	"net"
 )
 
 // Ensure Reload returns an error when attempting to reload a server that did

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -188,12 +188,12 @@ func TestSeedSolicitWorks(t *testing.T) {
 
 	optsA := nextServerOpts(optsSeed)
 	optsA.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsSeed.Cluster.Host,
-		srvSeed.ClusterAddr().(*net.TCPAddr).Port))
+		srvSeed.ClusterAddr().Port))
 
 	srvA := RunServer(optsA)
 	defer srvA.Shutdown()
 
-	urlA := fmt.Sprintf("nats://%s:%d/", optsA.Host, srvA.ClusterAddr().(*net.TCPAddr).Port)
+	urlA := fmt.Sprintf("nats://%s:%d/", optsA.Host, srvA.ClusterAddr().Port)
 
 	nc1, err := nats.Connect(urlA)
 	if err != nil {
@@ -208,12 +208,12 @@ func TestSeedSolicitWorks(t *testing.T) {
 
 	optsB := nextServerOpts(optsA)
 	optsB.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsSeed.Cluster.Host,
-		srvSeed.ClusterAddr().(*net.TCPAddr).Port))
+		srvSeed.ClusterAddr().Port))
 
 	srvB := RunServer(optsB)
 	defer srvB.Shutdown()
 
-	urlB := fmt.Sprintf("nats://%s:%d/", optsB.Host, srvB.ClusterAddr().(*net.TCPAddr).Port)
+	urlB := fmt.Sprintf("nats://%s:%d/", optsB.Host, srvB.ClusterAddr().Port)
 
 	nc2, err := nats.Connect(urlB)
 	if err != nil {
@@ -242,7 +242,7 @@ func TestTLSSeedSolicitWorks(t *testing.T) {
 	defer srvSeed.Shutdown()
 
 	seedRouteUrl := fmt.Sprintf("nats://%s:%d", optsSeed.Cluster.Host,
-		srvSeed.ClusterAddr().(*net.TCPAddr).Port)
+		srvSeed.ClusterAddr().Port)
 	optsA := nextServerOpts(optsSeed)
 	optsA.Routes = RoutesFromStr(seedRouteUrl)
 
@@ -297,7 +297,7 @@ func TestChainedSolicitWorks(t *testing.T) {
 	defer srvSeed.Shutdown()
 
 	seedRouteUrl := fmt.Sprintf("nats://%s:%d", optsSeed.Cluster.Host,
-		srvSeed.ClusterAddr().(*net.TCPAddr).Port)
+		srvSeed.ClusterAddr().Port)
 	optsA := nextServerOpts(optsSeed)
 	optsA.Routes = RoutesFromStr(seedRouteUrl)
 
@@ -320,7 +320,7 @@ func TestChainedSolicitWorks(t *testing.T) {
 	optsB := nextServerOpts(optsA)
 	// Server B connects to A
 	optsB.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsA.Cluster.Host,
-		srvA.ClusterAddr().(*net.TCPAddr).Port))
+		srvA.ClusterAddr().Port))
 
 	srvB := RunServer(optsB)
 	defer srvB.Shutdown()
@@ -354,7 +354,7 @@ func TestTLSChainedSolicitWorks(t *testing.T) {
 	defer srvSeed.Shutdown()
 
 	urlSeedRoute := fmt.Sprintf("nats://%s:%d", optsSeed.Cluster.Host,
-		srvSeed.ClusterAddr().(*net.TCPAddr).Port)
+		srvSeed.ClusterAddr().Port)
 	optsA := nextServerOpts(optsSeed)
 	optsA.Routes = RoutesFromStr(urlSeedRoute)
 
@@ -377,7 +377,7 @@ func TestTLSChainedSolicitWorks(t *testing.T) {
 	optsB := nextServerOpts(optsA)
 	// Server B connects to A
 	optsB.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsA.Cluster.Host,
-		srvA.ClusterAddr().(*net.TCPAddr).Port))
+		srvA.ClusterAddr().Port))
 
 	srvB := RunServer(optsB)
 	defer srvB.Shutdown()
@@ -504,7 +504,7 @@ func TestClientConnectToRoutePort(t *testing.T) {
 	s := RunServer(opts)
 	defer s.Shutdown()
 
-	url := fmt.Sprintf("nats://%s:%d", opts.Cluster.Host, s.ClusterAddr().(*net.TCPAddr).Port)
+	url := fmt.Sprintf("nats://%s:%d", opts.Cluster.Host, s.ClusterAddr().Port)
 	clientURL := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
 	// When connecting to the ROUTE port, the client library will receive the
 	// CLIENT port in the INFO protocol. This URL is added to the client's pool

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -502,8 +502,7 @@ func TestClientConnectToRoutePort(t *testing.T) {
 	opts.Cluster.Host = "localhost"
 	opts.Cluster.NoAdvertise = true
 	s := RunServer(opts)
-	s.Noticef("%+v\n", opts)
-	// defer s.Shutdown()
+	defer s.Shutdown()
 
 	url := fmt.Sprintf("nats://%s:%d", opts.Cluster.Host, s.ClusterAddr().(*net.TCPAddr).Port)
 	clientURL := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
@@ -516,7 +515,6 @@ func TestClientConnectToRoutePort(t *testing.T) {
 	// attempts rather small.
 	total := 10
 	for i := 0; i < total; i++ {
-		s.Noticef("URL: %s", url)
 		nc, err := nats.Connect(url)
 		if err != nil {
 			t.Fatalf("Unexepected error on connect: %v", err)

--- a/server/server.go
+++ b/server/server.go
@@ -920,23 +920,23 @@ func (s *Server) Addr() net.Addr {
 }
 
 // MonitorAddr will return the net.Addr object for the monitoring listener.
-func (s *Server) MonitorAddr() net.Addr {
+func (s *Server) MonitorAddr() *net.TCPAddr {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.http == nil {
 		return nil
 	}
-	return s.http.Addr()
+	return s.http.Addr().(*net.TCPAddr)
 }
 
 // RouteAddr returns the net.Addr object for the route listener.
-func (s *Server) ClusterAddr() net.Addr {
+func (s *Server) ClusterAddr() *net.TCPAddr {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.routeListener == nil {
 		return nil
 	}
-	return s.routeListener.Addr()
+	return s.routeListener.Addr().(*net.TCPAddr)
 }
 
 // ReadyForConnections returns `true` if the server is ready to accept client

--- a/server/server.go
+++ b/server/server.go
@@ -477,7 +477,10 @@ func (s *Server) StartProfiler() {
 
 	go func() {
 		// if this errors out, it's probably because the server is being shutdown
-		srv.Serve(l)
+		err := srv.Serve(l)
+		if err != nil {
+			s.Fatalf("error starting profiler: %s", err)
+		}
 		s.done <- true
 	}()
 }

--- a/server/server.go
+++ b/server/server.go
@@ -79,7 +79,7 @@ type Server struct {
 	grRunning     bool
 	grWG          sync.WaitGroup // to wait on various go routines
 	cproto        int64          // number of clients supporting async INFO
-	fatalError  string // Captures the error string for any fatal error
+	fatalError    string         // Captures the error string for any fatal error
 	logging       struct {
 		sync.RWMutex
 		logger Logger

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -368,7 +368,7 @@ func TestRandomPorts(t *testing.T) {
 		t.Fatal("Should not have dynamically assigned default port: 4222.")
 	}
 
-	if s.MonitorAddr() == nil || s.MonitorAddr().(*net.TCPAddr).Port <= 0 {
+	if s.MonitorAddr() == nil || s.MonitorAddr().Port <= 0 {
 		t.Fatal("Should have dynamically assigned monitoring port.")
 	}
 


### PR DESCRIPTION
### Changes proposed in this pull request: 

- Moves clustering and profiler to Random Ports
- Enables setting Random Ports in config files
- Adds capture of the last error string for future enhancements to unit tests
- Converts Default Option maps to methods generating a new map for each test
 
/cc @nats-io/core
