### PR TITLE
Cluster reload

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -130,6 +130,10 @@ func (s *Server) isRouterAuthorized(c *client) bool {
 	// Snapshot server options.
 	opts := s.getOpts()
 
+	if opts.Cluster.Username == "" {
+		return true
+	}
+
 	if opts.Cluster.Username != c.opts.Username {
 		return false
 	}

--- a/server/client.go
+++ b/server/client.go
@@ -1342,6 +1342,11 @@ func (c *client) closeConnection() {
 		}
 	}
 
+	// Don't reconnect routes that are being closed.
+	if c.route != nil && c.route.closed {
+		return
+	}
+
 	// Check for a solicited route. If it was, start up a reconnect unless
 	// we are already connected to the other end.
 	if c.isSolicitedRoute() || retryImplicit {

--- a/server/client.go
+++ b/server/client.go
@@ -1325,6 +1325,11 @@ func (c *client) closeConnection() {
 		retryImplicit = c.route.retry
 	}
 
+	closed := false
+	if c.route != nil {
+		closed = c.route.closed
+	}
+
 	c.mu.Unlock()
 
 	if srv != nil {
@@ -1343,7 +1348,7 @@ func (c *client) closeConnection() {
 	}
 
 	// Don't reconnect routes that are being closed.
-	if c.route != nil && c.route.closed {
+	if c.route != nil && closed {
 		return
 	}
 

--- a/server/configs/reload/reload.conf
+++ b/server/configs/reload/reload.conf
@@ -20,3 +20,8 @@ authorization {
     password: T0pS3cr3t
     timeout:  2
 }
+
+cluster {
+    listen:       localhost:-1
+    no_advertise: true # enable on reload
+}

--- a/server/configs/reload/srv_a_1.conf
+++ b/server/configs/reload/srv_a_1.conf
@@ -1,0 +1,13 @@
+# Copyright 2017 Apcera Inc. All rights reserved.
+
+# Cluster Server A
+
+listen: localhost:-1
+
+cluster {
+  listen: 127.0.0.1:7244
+
+  routes = [
+    nats-route://127.0.0.1:7246
+  ]
+}

--- a/server/configs/reload/srv_a_2.conf
+++ b/server/configs/reload/srv_a_2.conf
@@ -1,0 +1,13 @@
+# Copyright 2017 Apcera Inc. All rights reserved.
+
+# Cluster Server A
+
+listen: localhost:-1
+
+cluster {
+  listen: 127.0.0.1:7244
+
+  routes = [
+    nats-route://tyler:foo@127.0.0.1:7246 # Use route credentials
+  ]
+}

--- a/server/configs/reload/srv_a_3.conf
+++ b/server/configs/reload/srv_a_3.conf
@@ -1,0 +1,13 @@
+# Copyright 2017 Apcera Inc. All rights reserved.
+
+# Cluster Server A
+
+listen: localhost:-1
+
+cluster {
+  listen: 127.0.0.1:7244
+
+  routes = [
+    nats-route://127.0.0.1:7247 # Remove srv b route and add srv c
+  ]
+}

--- a/server/configs/reload/srv_a_3.conf
+++ b/server/configs/reload/srv_a_3.conf
@@ -8,6 +8,6 @@ cluster {
   listen: 127.0.0.1:7244
 
   routes = [
-    nats-route://127.0.0.1:7247 # Remove srv b route and add srv c
+    nats-route://localhost:7247 # Remove srv b route and add srv c
   ]
 }

--- a/server/configs/reload/srv_b_1.conf
+++ b/server/configs/reload/srv_b_1.conf
@@ -1,0 +1,9 @@
+# Copyright 2017 Apcera Inc. All rights reserved.
+
+# Cluster Server B
+
+listen: localhost:-1
+
+cluster {
+  listen: 127.0.0.1:7246
+}

--- a/server/configs/reload/srv_b_2.conf
+++ b/server/configs/reload/srv_b_2.conf
@@ -1,0 +1,15 @@
+# Copyright 2017 Apcera Inc. All rights reserved.
+
+# Cluster Server B
+
+listen: localhost:-1
+
+cluster {
+  listen: 127.0.0.1:7246
+
+  # Enable route authorization.
+  authorization {
+    user:     tyler
+    password: foo
+  }
+}

--- a/server/configs/reload/srv_c_1.conf
+++ b/server/configs/reload/srv_c_1.conf
@@ -1,0 +1,9 @@
+# Copyright 2017 Apcera Inc. All rights reserved.
+
+# Cluster Server C
+
+listen: localhost:-1
+
+cluster {
+  listen: localhost:7247
+}

--- a/server/configs/reload/test.conf
+++ b/server/configs/reload/test.conf
@@ -5,3 +5,8 @@ debug:   false
 trace:   false
 logtime: false
 log_file: "/tmp/gnatsd.log"
+
+cluster {
+    listen:       localhost:-1
+    no_advertise: false
+}

--- a/server/opts.go
+++ b/server/opts.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/nats-io/gnatsd/conf"
+	"github.com/nats-io/gnatsd/util"
 )
 
 // Options for clusters.
@@ -93,6 +94,12 @@ func (o *Options) Clone() *Options {
 			*routeCopy = *route
 			clone.Routes[i] = routeCopy
 		}
+	}
+	if o.TLSConfig != nil {
+		clone.TLSConfig = util.CloneTLSConfig(o.TLSConfig)
+	}
+	if o.Cluster.TLSConfig != nil {
+		clone.Cluster.TLSConfig = util.CloneTLSConfig(o.Cluster.TLSConfig)
 	}
 	return clone
 }

--- a/server/reload.go
+++ b/server/reload.go
@@ -318,6 +318,10 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 		case "routes":
 			add, remove := diffRoutes(oldValue.([]*url.URL), newValue.([]*url.URL))
 			diffOpts = append(diffOpts, &routesOption{add: add, remove: remove})
+		case "nolog":
+			// Ignore NoLog option since it's not parsed and only used in
+			// testing.
+			continue
 		case "port":
 			// check to see if newValue == 0 and continue if so.
 			if newValue == 0 {

--- a/server/reload.go
+++ b/server/reload.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net/url"
 	"reflect"
 	"strings"
 )
@@ -176,6 +177,64 @@ func (u *usersOption) Apply(server *Server) {
 	server.Noticef("Reloaded: authorization users")
 }
 
+// clusterOption implements the option interface for the `cluster` setting.
+type clusterOption struct {
+	noopOption
+	newValue ClusterOpts
+}
+
+// Apply the cluster change.
+func (c *clusterOption) Apply(server *Server) {
+	server.mu.Lock()
+	tlsRequired := c.newValue.TLSConfig != nil
+	server.routeInfo.TLSRequired = tlsRequired
+	server.routeInfo.SSLRequired = tlsRequired
+	server.routeInfo.TLSVerify = tlsRequired
+	server.routeInfo.AuthRequired = c.newValue.Username != ""
+	server.generateRouteInfoJSON()
+	server.mu.Unlock()
+	server.Noticef("Reloaded: cluster")
+}
+
+// routesOption implements the option interface for the cluster `routes`
+// setting.
+type routesOption struct {
+	noopOption
+	add    []*url.URL
+	remove []*url.URL
+}
+
+// Apply the route changes by adding and removing the necessary routes.
+func (r *routesOption) Apply(server *Server) {
+	server.mu.Lock()
+	routes := make([]*client, len(server.routes))
+	i := 0
+	for _, client := range server.routes {
+		routes[i] = client
+		i++
+	}
+	server.mu.Unlock()
+
+	// Remove routes.
+	for _, remove := range r.remove {
+		for _, client := range routes {
+			if client.route.url == remove {
+				client.mu.Lock()
+				// Do not attempt to reconnect when route is removed.
+				client.route.closed = true
+				client.mu.Unlock()
+				client.closeConnection()
+				server.Noticef("Removed route %v", remove)
+			}
+		}
+	}
+
+	// Add routes.
+	server.solicitRoutes(r.add)
+
+	server.Noticef("Reloaded: cluster routes")
+}
+
 // Reload reads the current configuration file and applies any supported
 // changes. This returns an error if the server was not started with a config
 // file or an option which doesn't support hot-swapping was changed.
@@ -250,6 +309,15 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 			diffOpts = append(diffOpts, &authTimeoutOption{newValue: newValue.(float64)})
 		case "users":
 			diffOpts = append(diffOpts, &usersOption{newValue: newValue.([]*User)})
+		case "cluster":
+			newClusterOpts := newValue.(ClusterOpts)
+			if err := validateClusterOpts(oldValue.(ClusterOpts), newClusterOpts); err != nil {
+				return nil, err
+			}
+			diffOpts = append(diffOpts, &clusterOption{newValue: newClusterOpts})
+		case "routes":
+			add, remove := diffRoutes(oldValue.([]*url.URL), newValue.([]*url.URL))
+			diffOpts = append(diffOpts, &routesOption{add: add, remove: remove})
 		case "port":
 			// check to see if newValue == 0 and continue if so.
 			if newValue == 0 {
@@ -315,4 +383,46 @@ func (s *Server) reloadAuthorization() {
 		// Remove any unauthorized subscriptions.
 		s.removeUnauthorizedSubs(client)
 	}
+}
+
+// validateClusterOpts ensures the new ClusterOpts does not change host or
+// port, which do not support reload.
+func validateClusterOpts(old, new ClusterOpts) error {
+	if old.Host != new.Host {
+		return fmt.Errorf("Config reload not supported for cluster host: old=%s, new=%s",
+			old.Host, new.Host)
+	}
+	if old.Port != new.Port {
+		return fmt.Errorf("Config reload not supported for cluster port: old=%d, new=%d",
+			old.Port, new.Port)
+	}
+	return nil
+}
+
+// diffRoutes diffs the old routes and the new routes and returns the ones that
+// should be added and removed from the server.
+func diffRoutes(old, new []*url.URL) (add, remove []*url.URL) {
+	// Find routes to remove.
+removeLoop:
+	for _, oldRoute := range old {
+		for _, newRoute := range new {
+			if oldRoute == newRoute {
+				continue removeLoop
+			}
+		}
+		remove = append(remove, oldRoute)
+	}
+
+	// Find routes to add.
+addLoop:
+	for _, newRoute := range new {
+		for _, oldRoute := range old {
+			if oldRoute == newRoute {
+				continue addLoop
+			}
+		}
+		add = append(add, newRoute)
+	}
+
+	return add, remove
 }

--- a/server/reload.go
+++ b/server/reload.go
@@ -185,6 +185,7 @@ type clusterOption struct {
 
 // Apply the cluster change.
 func (c *clusterOption) Apply(server *Server) {
+	// TODO: support enabling/disabling clustering.
 	server.mu.Lock()
 	tlsRequired := c.newValue.TLSConfig != nil
 	server.routeInfo.TLSRequired = tlsRequired

--- a/server/reload.go
+++ b/server/reload.go
@@ -396,7 +396,9 @@ func (s *Server) reloadAuthorization() {
 	for _, client := range routes {
 		// Disconnect any unauthorized routes.
 		if !s.isRouterAuthorized(client) {
+			client.mu.Lock()
 			client.route.closed = true
+			client.mu.Unlock()
 			client.authViolation()
 		}
 	}

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -48,6 +48,10 @@ func TestConfigReloadUnsupported(t *testing.T) {
 		PingInterval:   2 * time.Minute,
 		MaxPingsOut:    2,
 		WriteDeadline:  2 * time.Second,
+		Cluster: ClusterOpts{
+			Host: "localhost",
+			Port: -1,
+		},
 	}
 	processOptions(golden)
 
@@ -109,6 +113,10 @@ func TestConfigReloadInvalidConfig(t *testing.T) {
 		PingInterval:   2 * time.Minute,
 		MaxPingsOut:    2,
 		WriteDeadline:  2 * time.Second,
+		Cluster: ClusterOpts{
+			Host: "localhost",
+			Port: -1,
+		},
 	}
 	processOptions(golden)
 
@@ -170,6 +178,10 @@ func TestConfigReload(t *testing.T) {
 		PingInterval:   2 * time.Minute,
 		MaxPingsOut:    2,
 		WriteDeadline:  2 * time.Second,
+		Cluster: ClusterOpts{
+			Host: "localhost",
+			Port: -1,
+		},
 	}
 	processOptions(golden)
 
@@ -228,6 +240,9 @@ func TestConfigReload(t *testing.T) {
 	}
 	if !server.info.AuthRequired {
 		t.Fatal("Expected AuthRequired to be true")
+	}
+	if !updated.Cluster.NoAdvertise {
+		t.Fatal("Expected NoAdvertise to be true")
 	}
 }
 

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -312,7 +312,7 @@ func TestConfigReloadRotateTLS(t *testing.T) {
 		t.Fatalf("Error publishing: %v", err)
 	}
 	nc.Flush()
-	msg, err := sub.NextMsg(time.Second)
+	msg, err := sub.NextMsg(2 * time.Second)
 	if err != nil {
 		t.Fatalf("Error receiving msg: %v", err)
 	}
@@ -955,7 +955,7 @@ func TestConfigReloadRotateUsersAuthentication(t *testing.T) {
 		t.Fatalf("Error publishing: %v", err)
 	}
 	nc.Flush()
-	msg, err := sub.NextMsg(time.Second)
+	msg, err := sub.NextMsg(2 * time.Second)
 	if err != nil {
 		t.Fatalf("Error receiving msg: %v", err)
 	}
@@ -1153,7 +1153,7 @@ func TestConfigReloadChangePermissions(t *testing.T) {
 	}
 	conn.Flush()
 
-	msg, err := sub.NextMsg(time.Second)
+	msg, err := sub.NextMsg(2 * time.Second)
 	if err != nil {
 		t.Fatalf("Error receiving msg: %v", err)
 	}
@@ -1166,7 +1166,7 @@ func TestConfigReloadChangePermissions(t *testing.T) {
 	}
 	nc.Flush()
 
-	msg, err = sub2.NextMsg(time.Second)
+	msg, err = sub2.NextMsg(2 * time.Second)
 	if err != nil {
 		t.Fatalf("Error receiving msg: %v", err)
 	}
@@ -1242,7 +1242,7 @@ func TestConfigReloadChangePermissions(t *testing.T) {
 		t.Fatalf("Error publishing message: %v", err)
 	}
 	nc.Flush()
-	msg, err = sub.NextMsg(time.Second)
+	msg, err = sub.NextMsg(2 * time.Second)
 	if err != nil {
 		t.Fatalf("Error receiving msg: %v", err)
 	}
@@ -1390,7 +1390,7 @@ func TestConfigReloadEnableClusterAuthorization(t *testing.T) {
 		t.Fatalf("Error publishing: %v", err)
 	}
 	srvbConn.Flush()
-	msg, err := sub.NextMsg(time.Second)
+	msg, err := sub.NextMsg(2 * time.Second)
 	if err != nil {
 		t.Fatalf("Error receiving message: %v", err)
 	}
@@ -1446,7 +1446,7 @@ func TestConfigReloadEnableClusterAuthorization(t *testing.T) {
 		t.Fatalf("Error publishing: %v", err)
 	}
 	srvbConn.Flush()
-	msg, err = sub.NextMsg(time.Second)
+	msg, err = sub.NextMsg(2 * time.Second)
 	if err != nil {
 		t.Fatalf("Error receiving message: %v", err)
 	}
@@ -1522,7 +1522,7 @@ func TestConfigReloadDisableClusterAuthorization(t *testing.T) {
 		t.Fatalf("Error publishing: %v", err)
 	}
 	srvbConn.Flush()
-	msg, err := sub.NextMsg(time.Second)
+	msg, err := sub.NextMsg(2 * time.Second)
 	if err != nil {
 		t.Fatalf("Error receiving message: %v", err)
 	}
@@ -1550,7 +1550,7 @@ func TestConfigReloadDisableClusterAuthorization(t *testing.T) {
 		t.Fatalf("Error publishing: %v", err)
 	}
 	srvbConn.Flush()
-	msg, err = sub.NextMsg(time.Second)
+	msg, err = sub.NextMsg(2 * time.Second)
 	if err != nil {
 		t.Fatalf("Error receiving message: %v", err)
 	}
@@ -1634,7 +1634,7 @@ func TestConfigReloadClusterRoutes(t *testing.T) {
 		t.Fatalf("Error publishing: %v", err)
 	}
 	srvbConn.Flush()
-	msg, err := sub.NextMsg(time.Second)
+	msg, err := sub.NextMsg(2 * time.Second)
 	if err != nil {
 		t.Fatalf("Error receiving message: %v", err)
 	}
@@ -1656,6 +1656,7 @@ func TestConfigReloadClusterRoutes(t *testing.T) {
 	if err := srva.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
 	}
+	time.Sleep(20 * time.Millisecond)
 
 	srvcAddr := fmt.Sprintf("nats://%s:%d", srvcOpts.Host, srvcOpts.Port)
 	srvcConn, err := nats.Connect(srvcAddr)
@@ -1665,11 +1666,13 @@ func TestConfigReloadClusterRoutes(t *testing.T) {
 	defer srvcConn.Close()
 
 	// Ensure messages flow through the new cluster.
-	if err := srvcConn.Publish("foo", []byte("hola")); err != nil {
-		t.Fatalf("Error publishing: %v", err)
+	for i := 0; i < 5; i++ {
+		if err := srvcConn.Publish("foo", []byte("hola")); err != nil {
+			t.Fatalf("Error publishing: %v", err)
+		}
+		srvcConn.Flush()
 	}
-	srvcConn.Flush()
-	msg, err = sub.NextMsg(time.Second)
+	msg, err = sub.NextMsg(2 * time.Second)
 	if err != nil {
 		t.Fatalf("Error receiving message: %v", err)
 	}

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -113,7 +113,7 @@ func TestConfigReloadInvalidConfig(t *testing.T) {
 	processOptions(golden)
 
 	if err := os.Symlink("./configs/reload/test.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 	opts, err := ProcessConfigFile(config)
@@ -132,7 +132,7 @@ func TestConfigReloadInvalidConfig(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/invalid.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 
 	// This should fail because the new config should not parse.
@@ -174,7 +174,7 @@ func TestConfigReload(t *testing.T) {
 	processOptions(golden)
 
 	if err := os.Symlink("./configs/reload/test.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 	opts, err := ProcessConfigFile(config)
@@ -193,7 +193,7 @@ func TestConfigReload(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/reload.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 
 	if err := server.Reload(); err != nil {
@@ -243,7 +243,7 @@ func TestConfigReloadRotateTLS(t *testing.T) {
 	config := filepath.Join(dir, "tmp.conf")
 
 	if err := os.Symlink("./configs/reload/tls_test.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 
@@ -273,7 +273,7 @@ func TestConfigReloadRotateTLS(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/tls_verify_test.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
@@ -316,7 +316,7 @@ func TestConfigReloadEnableTLS(t *testing.T) {
 	config := filepath.Join(dir, "tmp.conf")
 
 	if err := os.Symlink("./configs/reload/basic.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 
@@ -341,7 +341,7 @@ func TestConfigReloadEnableTLS(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/tls_test.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
@@ -372,7 +372,7 @@ func TestConfigReloadDisableTLS(t *testing.T) {
 	config := filepath.Join(dir, "tmp.conf")
 
 	if err := os.Symlink("./configs/reload/tls_test.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 
@@ -397,7 +397,7 @@ func TestConfigReloadDisableTLS(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/basic.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
@@ -428,7 +428,7 @@ func TestConfigReloadRotateUserAuthentication(t *testing.T) {
 	config := filepath.Join(dir, "tmp.conf")
 
 	if err := os.Symlink("./configs/reload/single_user_authentication_1.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 
@@ -460,7 +460,7 @@ func TestConfigReloadRotateUserAuthentication(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/single_user_authentication_2.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
@@ -508,7 +508,7 @@ func TestConfigReloadEnableUserAuthentication(t *testing.T) {
 	config := filepath.Join(dir, "tmp.conf")
 
 	if err := os.Symlink("./configs/reload/basic.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 
@@ -540,7 +540,7 @@ func TestConfigReloadEnableUserAuthentication(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/single_user_authentication_1.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
@@ -588,7 +588,7 @@ func TestConfigReloadDisableUserAuthentication(t *testing.T) {
 	config := filepath.Join(dir, "tmp.conf")
 
 	if err := os.Symlink("./configs/reload/single_user_authentication_1.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 
@@ -615,7 +615,7 @@ func TestConfigReloadDisableUserAuthentication(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/basic.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
@@ -641,7 +641,7 @@ func TestConfigReloadRotateTokenAuthentication(t *testing.T) {
 	config := filepath.Join(dir, "tmp.conf")
 
 	if err := os.Symlink("./configs/reload/token_authentication_1.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 
@@ -673,7 +673,7 @@ func TestConfigReloadRotateTokenAuthentication(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/token_authentication_2.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
@@ -721,7 +721,7 @@ func TestConfigReloadEnableTokenAuthentication(t *testing.T) {
 	config := filepath.Join(dir, "tmp.conf")
 
 	if err := os.Symlink("./configs/reload/basic.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 
@@ -753,7 +753,7 @@ func TestConfigReloadEnableTokenAuthentication(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/token_authentication_1.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
@@ -801,7 +801,7 @@ func TestConfigReloadDisableTokenAuthentication(t *testing.T) {
 	config := filepath.Join(dir, "tmp.conf")
 
 	if err := os.Symlink("./configs/reload/token_authentication_1.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 
@@ -828,7 +828,7 @@ func TestConfigReloadDisableTokenAuthentication(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/basic.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
@@ -854,7 +854,7 @@ func TestConfigReloadRotateUsersAuthentication(t *testing.T) {
 	config := filepath.Join(dir, "tmp.conf")
 
 	if err := os.Symlink("./configs/reload/multiple_users_1.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 
@@ -898,7 +898,7 @@ func TestConfigReloadRotateUsersAuthentication(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/multiple_users_2.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
@@ -959,7 +959,7 @@ func TestConfigReloadEnableUsersAuthentication(t *testing.T) {
 	config := filepath.Join(dir, "tmp.conf")
 
 	if err := os.Symlink("./configs/reload/basic.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 
@@ -991,7 +991,7 @@ func TestConfigReloadEnableUsersAuthentication(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/multiple_users_1.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
@@ -1039,7 +1039,7 @@ func TestConfigReloadDisableUsersAuthentication(t *testing.T) {
 	config := filepath.Join(dir, "tmp.conf")
 
 	if err := os.Symlink("./configs/reload/multiple_users_1.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 
@@ -1066,7 +1066,7 @@ func TestConfigReloadDisableUsersAuthentication(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/basic.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
@@ -1092,7 +1092,7 @@ func TestConfigReloadChangePermissions(t *testing.T) {
 	config := filepath.Join(dir, "tmp.conf")
 
 	if err := os.Symlink("./configs/reload/authorization_1.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	defer os.Remove(config)
 
@@ -1162,7 +1162,7 @@ func TestConfigReloadChangePermissions(t *testing.T) {
 		t.Fatalf("Error deleting symlink: %v", err)
 	}
 	if err := os.Symlink("./configs/reload/authorization_2.conf", config); err != nil {
-		t.Fatalf("Error creating symlink: %v", err)
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
 	}
 	if err := server.Reload(); err != nil {
 		t.Fatalf("Error reloading config: %v", err)
@@ -1237,5 +1237,426 @@ func TestConfigReloadChangePermissions(t *testing.T) {
 	case err := <-asyncErr:
 		t.Fatalf("Received unexpected error: %v", err)
 	default:
+	}
+}
+
+// Ensure Reload returns an error when attempting to change cluster address
+// host.
+func TestConfigReloadClusterHostUnsupported(t *testing.T) {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Error getting working directory: %v", err)
+	}
+	config := filepath.Join(dir, "tmp.conf")
+
+	if err := os.Symlink("./configs/reload/srv_a_1.conf", config); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+	defer os.Remove(config)
+	opts, err := ProcessConfigFile(config)
+	if err != nil {
+		t.Fatalf("Error processing config file: %v", err)
+	}
+	server := New(opts)
+
+	// Attempt to change cluster listen host.
+	if err := os.Remove(config); err != nil {
+		t.Fatalf("Error deleting symlink: %v", err)
+	}
+	if err := os.Symlink("./configs/reload/srv_c_1.conf", config); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+
+	// This should fail because cluster address cannot be changed.
+	if err := server.Reload(); err == nil {
+		t.Fatal("Expected Reload to return an error")
+	}
+}
+
+// Ensure Reload returns an error when attempting to change cluster address
+// port.
+func TestConfigReloadClusterPortUnsupported(t *testing.T) {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Error getting working directory: %v", err)
+	}
+	config := filepath.Join(dir, "tmp.conf")
+
+	if err := os.Symlink("./configs/reload/srv_a_1.conf", config); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+	defer os.Remove(config)
+	opts, err := ProcessConfigFile(config)
+	if err != nil {
+		t.Fatalf("Error processing config file: %v", err)
+	}
+	server := New(opts)
+
+	// Attempt to change cluster listen port.
+	if err := os.Remove(config); err != nil {
+		t.Fatalf("Error deleting symlink: %v", err)
+	}
+	if err := os.Symlink("./configs/reload/srv_b_1.conf", config); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+
+	// This should fail because cluster address cannot be changed.
+	if err := server.Reload(); err == nil {
+		t.Fatal("Expected Reload to return an error")
+	}
+}
+
+// Ensure Reload supports enabling route authorization. Test this by starting
+// two servers in a cluster without authorization, ensuring messages flow
+// between them, then reloading with authorization and ensuring messages no
+// longer flow until reloading with the correct credentials.
+func TestConfigReloadEnableClusterAuthorization(t *testing.T) {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Error getting working directory: %v", err)
+	}
+	srvbConfig := filepath.Join(dir, "tmp_b.conf")
+
+	if err := os.Symlink("./configs/reload/srv_b_1.conf", srvbConfig); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+	defer os.Remove(srvbConfig)
+
+	srvbOpts, err := ProcessConfigFile(srvbConfig)
+	if err != nil {
+		t.Fatalf("Error processing config file: %v", err)
+	}
+	srvbOpts.NoLog = true
+
+	srvb := RunServer(srvbOpts)
+	defer srvb.Shutdown()
+
+	srvaConfig := filepath.Join(dir, "tmp_a.conf")
+	if err := os.Symlink("./configs/reload/srv_a_1.conf", srvaConfig); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+	defer os.Remove(srvaConfig)
+
+	srvaOpts, err := ProcessConfigFile(srvaConfig)
+	if err != nil {
+		t.Fatalf("Error processing config file: %v", err)
+	}
+	srvaOpts.NoLog = true
+
+	srva := RunServer(srvaOpts)
+	defer srva.Shutdown()
+
+	srvaAddr := fmt.Sprintf("nats://%s:%d", srvaOpts.Host, srvaOpts.Port)
+	srvaConn, err := nats.Connect(srvaAddr)
+	if err != nil {
+		t.Fatalf("Error creating client: %v", err)
+	}
+
+	sub, err := srvaConn.SubscribeSync("foo")
+	if err != nil {
+		t.Fatalf("Error subscribing: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	srvbAddr := fmt.Sprintf("nats://%s:%d", srvbOpts.Host, srvbOpts.Port)
+	srvbConn, err := nats.Connect(srvbAddr)
+	if err != nil {
+		t.Fatalf("Error creating client: %v", err)
+	}
+
+	if numRoutes := srvb.NumRoutes(); numRoutes != 1 {
+		t.Fatalf("Expected 1 route, got %d", numRoutes)
+	}
+
+	// Ensure messages flow through the cluster as a sanity check.
+	if err := srvbConn.Publish("foo", []byte("hello")); err != nil {
+		t.Fatalf("Error publishing: %v", err)
+	}
+	msg, err := sub.NextMsg(time.Second)
+	if err != nil {
+		t.Fatalf("Error receiving message: %v", err)
+	}
+	if string(msg.Data) != "hello" {
+		t.Fatalf("Msg is incorrect.\nexpected: %+v\ngot: %+v", []byte("hello"), msg.Data)
+	}
+
+	// Enable route authorization.
+	if err := os.Remove(srvbConfig); err != nil {
+		t.Fatalf("Error deleting symlink: %v", err)
+	}
+	if err := os.Symlink("./configs/reload/srv_b_2.conf", srvbConfig); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+	if err := srvb.Reload(); err != nil {
+		t.Fatalf("Error reloading config: %v", err)
+	}
+
+	if numRoutes := srvb.NumRoutes(); numRoutes != 0 {
+		t.Fatalf("Expected 0 routes, got %d", numRoutes)
+	}
+
+	// Ensure messages no longer flow through the cluster.
+	for i := 0; i < 5; i++ {
+		if err := srvbConn.Publish("foo", []byte("world")); err != nil {
+			t.Fatalf("Error publishing: %v", err)
+		}
+	}
+	if _, err := sub.NextMsg(50 * time.Millisecond); err != nats.ErrTimeout {
+		t.Fatalf("Expected ErrTimeout, got %v", err)
+	}
+
+	// Reload Server A with correct route credentials.
+	if err := os.Remove(srvaConfig); err != nil {
+		t.Fatalf("Error deleting symlink: %v", err)
+	}
+	if err := os.Symlink("./configs/reload/srv_a_2.conf", srvaConfig); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+	defer os.Remove(srvaConfig)
+	if err := srva.Reload(); err != nil {
+		t.Fatalf("Error reloading config: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	if numRoutes := srvb.NumRoutes(); numRoutes != 1 {
+		t.Fatalf("Expected 1 route, got %d", numRoutes)
+	}
+
+	// Ensure messages flow through the cluster now.
+	if err := srvbConn.Publish("foo", []byte("hola")); err != nil {
+		t.Fatalf("Error publishing: %v", err)
+	}
+	msg, err = sub.NextMsg(time.Second)
+	if err != nil {
+		t.Fatalf("Error receiving message: %v", err)
+	}
+	if string(msg.Data) != "hola" {
+		t.Fatalf("Msg is incorrect.\nexpected: %+v\ngot: %+v", []byte("hola"), msg.Data)
+	}
+}
+
+// Ensure Reload supports disabling route authorization. Test this by starting
+// two servers in a cluster with authorization, ensuring messages flow
+// between them, then reloading without authorization and ensuring messages
+// still flow.
+func TestConfigReloadDisableClusterAuthorization(t *testing.T) {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Error getting working directory: %v", err)
+	}
+	srvbConfig := filepath.Join(dir, "tmp_b.conf")
+
+	if err := os.Symlink("./configs/reload/srv_b_2.conf", srvbConfig); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+	defer os.Remove(srvbConfig)
+
+	srvbOpts, err := ProcessConfigFile(srvbConfig)
+	if err != nil {
+		t.Fatalf("Error processing config file: %v", err)
+	}
+	srvbOpts.NoLog = true
+
+	srvb := RunServer(srvbOpts)
+	defer srvb.Shutdown()
+
+	srvaConfig := filepath.Join(dir, "tmp_a.conf")
+	if err := os.Symlink("./configs/reload/srv_a_2.conf", srvaConfig); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+	defer os.Remove(srvaConfig)
+
+	srvaOpts, err := ProcessConfigFile(srvaConfig)
+	if err != nil {
+		t.Fatalf("Error processing config file: %v", err)
+	}
+	srvaOpts.NoLog = true
+
+	srva := RunServer(srvaOpts)
+	defer srva.Shutdown()
+
+	srvaAddr := fmt.Sprintf("nats://%s:%d", srvaOpts.Host, srvaOpts.Port)
+	srvaConn, err := nats.Connect(srvaAddr)
+	if err != nil {
+		t.Fatalf("Error creating client: %v", err)
+	}
+
+	sub, err := srvaConn.SubscribeSync("foo")
+	if err != nil {
+		t.Fatalf("Error subscribing: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	srvbAddr := fmt.Sprintf("nats://%s:%d", srvbOpts.Host, srvbOpts.Port)
+	srvbConn, err := nats.Connect(srvbAddr)
+	if err != nil {
+		t.Fatalf("Error creating client: %v", err)
+	}
+
+	if numRoutes := srvb.NumRoutes(); numRoutes != 1 {
+		t.Fatalf("Expected 1 route, got %d", numRoutes)
+	}
+
+	// Ensure messages flow through the cluster as a sanity check.
+	if err := srvbConn.Publish("foo", []byte("hello")); err != nil {
+		t.Fatalf("Error publishing: %v", err)
+	}
+	msg, err := sub.NextMsg(time.Second)
+	if err != nil {
+		t.Fatalf("Error receiving message: %v", err)
+	}
+	if string(msg.Data) != "hello" {
+		t.Fatalf("Msg is incorrect.\nexpected: %+v\ngot: %+v", []byte("hello"), msg.Data)
+	}
+
+	// Disable route authorization.
+	if err := os.Remove(srvbConfig); err != nil {
+		t.Fatalf("Error deleting symlink: %v", err)
+	}
+	if err := os.Symlink("./configs/reload/srv_b_1.conf", srvbConfig); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+	if err := srvb.Reload(); err != nil {
+		t.Fatalf("Error reloading config: %v", err)
+	}
+
+	if numRoutes := srvb.NumRoutes(); numRoutes != 1 {
+		t.Fatalf("Expected 1 route, got %d", numRoutes)
+	}
+
+	// Ensure messages still flow through the cluster.
+	if err := srvbConn.Publish("foo", []byte("hola")); err != nil {
+		t.Fatalf("Error publishing: %v", err)
+	}
+	msg, err = sub.NextMsg(time.Second)
+	if err != nil {
+		t.Fatalf("Error receiving message: %v", err)
+	}
+	if string(msg.Data) != "hola" {
+		t.Fatalf("Msg is incorrect.\nexpected: %+v\ngot: %+v", []byte("hola"), msg.Data)
+	}
+}
+
+// Ensure Reload supports changing cluster routes. Test this by starting
+// two servers in a cluster, ensuring messages flow between them, then
+// reloading with a different route and ensuring messages only flow through the
+// new cluster.
+func TestConfigReloadClusterRoutes(t *testing.T) {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Error getting working directory: %v", err)
+	}
+	srvbConfig := filepath.Join(dir, "tmp_b.conf")
+
+	if err := os.Symlink("./configs/reload/srv_b_1.conf", srvbConfig); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+	defer os.Remove(srvbConfig)
+
+	srvbOpts, err := ProcessConfigFile(srvbConfig)
+	if err != nil {
+		t.Fatalf("Error processing config file: %v", err)
+	}
+	srvbOpts.NoLog = true
+
+	srvb := RunServer(srvbOpts)
+	defer srvb.Shutdown()
+
+	srvaConfig := filepath.Join(dir, "tmp_a.conf")
+	if err := os.Symlink("./configs/reload/srv_a_1.conf", srvaConfig); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+	defer os.Remove(srvaConfig)
+
+	srvaOpts, err := ProcessConfigFile(srvaConfig)
+	if err != nil {
+		t.Fatalf("Error processing config file: %v", err)
+	}
+	srvaOpts.NoLog = true
+
+	srva := RunServer(srvaOpts)
+	defer srva.Shutdown()
+
+	srvcOpts, err := ProcessConfigFile("./configs/reload/srv_c_1.conf")
+	if err != nil {
+		t.Fatalf("Error processing config file: %v", err)
+	}
+	srvcOpts.NoLog = true
+
+	srvc := RunServer(srvcOpts)
+	defer srvc.Shutdown()
+
+	srvaAddr := fmt.Sprintf("nats://%s:%d", srvaOpts.Host, srvaOpts.Port)
+	srvaConn, err := nats.Connect(srvaAddr)
+	if err != nil {
+		t.Fatalf("Error creating client: %v", err)
+	}
+
+	sub, err := srvaConn.SubscribeSync("foo")
+	if err != nil {
+		t.Fatalf("Error subscribing: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	srvbAddr := fmt.Sprintf("nats://%s:%d", srvbOpts.Host, srvbOpts.Port)
+	srvbConn, err := nats.Connect(srvbAddr)
+	if err != nil {
+		t.Fatalf("Error creating client: %v", err)
+	}
+
+	if numRoutes := srvb.NumRoutes(); numRoutes != 1 {
+		t.Fatalf("Expected 1 route, got %d", numRoutes)
+	}
+
+	// Ensure messages flow through the cluster as a sanity check.
+	if err := srvbConn.Publish("foo", []byte("hello")); err != nil {
+		t.Fatalf("Error publishing: %v", err)
+	}
+	msg, err := sub.NextMsg(time.Second)
+	if err != nil {
+		t.Fatalf("Error receiving message: %v", err)
+	}
+	if string(msg.Data) != "hello" {
+		t.Fatalf("Msg is incorrect.\nexpected: %+v\ngot: %+v", []byte("hello"), msg.Data)
+	}
+
+	// Reload cluster routes.
+	if err := os.Remove(srvaConfig); err != nil {
+		t.Fatalf("Error deleting symlink: %v", err)
+	}
+	if err := os.Symlink("./configs/reload/srv_a_3.conf", srvaConfig); err != nil {
+		t.Fatalf("Error creating symlink: %v (ensure you have privileges)", err)
+	}
+	if err := srva.Reload(); err != nil {
+		t.Fatalf("Error reloading config: %v", err)
+	}
+
+	// Ensure messages no longer flow through the old cluster.
+	for i := 0; i < 5; i++ {
+		if err := srvbConn.Publish("foo", []byte("world")); err != nil {
+			t.Fatalf("Error publishing: %v", err)
+		}
+	}
+	if _, err := sub.NextMsg(50 * time.Millisecond); err != nats.ErrTimeout {
+		t.Fatalf("Expected ErrTimeout, got %v", err)
+	}
+
+	srvcAddr := fmt.Sprintf("nats://%s:%d", srvcOpts.Host, srvcOpts.Port)
+	srvcConn, err := nats.Connect(srvcAddr)
+	if err != nil {
+		t.Fatalf("Error creating client: %v", err)
+	}
+	defer srvcConn.Close()
+
+	// Ensure messages flow through the new cluster.
+	if err := srvcConn.Publish("foo", []byte("hola")); err != nil {
+		t.Fatalf("Error publishing: %v", err)
+	}
+	msg, err = sub.NextMsg(time.Second)
+	if err != nil {
+		t.Fatalf("Error receiving message: %v", err)
+	}
+	if string(msg.Data) != "hola" {
+		t.Fatalf("Msg is incorrect.\nexpected: %+v\ngot: %+v", []byte("hola"), msg.Data)
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -177,6 +177,15 @@ func (s *Server) generateServerInfoJSON() {
 	s.infoJSON = []byte(fmt.Sprintf("INFO %s %s", b, CR_LF))
 }
 
+func (s *Server) generateRouteInfoJSON() {
+	b, err := json.Marshal(s.routeInfo)
+	if err != nil {
+		s.Fatalf("Error marshaling route INFO JSON: %+v\n", err)
+		return
+	}
+	s.routeInfoJSON = []byte(fmt.Sprintf(InfoProto, b))
+}
+
 // PrintAndDie is exported for access in other packages.
 func PrintAndDie(msg string) {
 	fmt.Fprintf(os.Stderr, "%s\n", msg)

--- a/util/tls.go
+++ b/util/tls.go
@@ -1,5 +1,5 @@
-// Copyright 2016 Apcera Inc. All rights reserved.
-// +build go1.7
+// Copyright 2017 Apcera Inc. All rights reserved.
+// +build go1.8
 
 package util
 
@@ -7,31 +7,7 @@ import (
 	"crypto/tls"
 )
 
-// CloneTLSConfig returns a copy of c. Only the exported fields are copied.
-// This is temporary, until this is provided by the language.
-// https://go-review.googlesource.com/#/c/28075/
+// CloneTLSConfig returns a copy of c.
 func CloneTLSConfig(c *tls.Config) *tls.Config {
-	return &tls.Config{
-		Rand:                        c.Rand,
-		Time:                        c.Time,
-		Certificates:                c.Certificates,
-		NameToCertificate:           c.NameToCertificate,
-		GetCertificate:              c.GetCertificate,
-		RootCAs:                     c.RootCAs,
-		NextProtos:                  c.NextProtos,
-		ServerName:                  c.ServerName,
-		ClientAuth:                  c.ClientAuth,
-		ClientCAs:                   c.ClientCAs,
-		InsecureSkipVerify:          c.InsecureSkipVerify,
-		CipherSuites:                c.CipherSuites,
-		PreferServerCipherSuites:    c.PreferServerCipherSuites,
-		SessionTicketsDisabled:      c.SessionTicketsDisabled,
-		SessionTicketKey:            c.SessionTicketKey,
-		ClientSessionCache:          c.ClientSessionCache,
-		MinVersion:                  c.MinVersion,
-		MaxVersion:                  c.MaxVersion,
-		CurvePreferences:            c.CurvePreferences,
-		DynamicRecordSizingDisabled: c.DynamicRecordSizingDisabled,
-		Renegotiation:               c.Renegotiation,
-	}
+	return c.Clone()
 }

--- a/util/tls_pre17.go
+++ b/util/tls_pre17.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Apcera Inc. All rights reserved.
+// Copyright 2017 Apcera Inc. All rights reserved.
 // +build go1.5,!go1.7
 
 package util

--- a/util/tls_pre18.go
+++ b/util/tls_pre18.go
@@ -1,0 +1,37 @@
+// Copyright 2017 Apcera Inc. All rights reserved.
+// +build go1.7,!go1.8
+
+package util
+
+import (
+	"crypto/tls"
+)
+
+// CloneTLSConfig returns a copy of c. Only the exported fields are copied.
+// This is temporary, until this is provided by the language.
+// https://go-review.googlesource.com/#/c/28075/
+func CloneTLSConfig(c *tls.Config) *tls.Config {
+	return &tls.Config{
+		Rand:                        c.Rand,
+		Time:                        c.Time,
+		Certificates:                c.Certificates,
+		NameToCertificate:           c.NameToCertificate,
+		GetCertificate:              c.GetCertificate,
+		RootCAs:                     c.RootCAs,
+		NextProtos:                  c.NextProtos,
+		ServerName:                  c.ServerName,
+		ClientAuth:                  c.ClientAuth,
+		ClientCAs:                   c.ClientCAs,
+		InsecureSkipVerify:          c.InsecureSkipVerify,
+		CipherSuites:                c.CipherSuites,
+		PreferServerCipherSuites:    c.PreferServerCipherSuites,
+		SessionTicketsDisabled:      c.SessionTicketsDisabled,
+		SessionTicketKey:            c.SessionTicketKey,
+		ClientSessionCache:          c.ClientSessionCache,
+		MinVersion:                  c.MinVersion,
+		MaxVersion:                  c.MaxVersion,
+		CurvePreferences:            c.CurvePreferences,
+		DynamicRecordSizingDisabled: c.DynamicRecordSizingDisabled,
+		Renegotiation:               c.Renegotiation,
+	}
+}


### PR DESCRIPTION
Adds support for cluster/routes config reload. Routes authorization behavior is similar to users: if username/password change, routes that are no longer authorized are closed.

@nats-io/core