### PR TITLE
[ADDED] Build for ARMv7

### DIFF
--- a/scripts/cross_compile.sh
+++ b/scripts/cross_compile.sh
@@ -2,11 +2,10 @@
 set -e
 
 go get github.com/mitchellh/gox
-go get github.com/tcnksm/ghr
 
 export APPNAME="gnatsd"
-export OSARCH="linux/386 linux/amd64 linux/arm darwin/amd64 windows/386 windows/amd64"
-export DIRS="linux-386 linux-amd64 linux-arm darwin-amd64 windows-386 windows-amd64"
+export OSARCH="linux/386 linux/amd64 darwin/amd64 windows/386 windows/amd64"
+export DIRS="linux-386 linux-amd64 linux-arm5 linux-arm7 darwin-amd64 windows-386 windows-amd64"
 export OUTDIR="pkg"
 
 # If we have an arg, assume its a version tag and rename as appropriate.
@@ -14,7 +13,16 @@ if [[ -n $1 ]]; then
     export APPNAME=$APPNAME-$1
 fi
 
+# Build all from OSARCH list
 env CGO_ENABLED=0 gox -osarch="$OSARCH" -ldflags="-s -w" -output "$OUTDIR/$APPNAME-{{.OS}}-{{.Arch}}/gnatsd"
+
+# Be explicit about the ARM builds
+# ARMv5
+env CGO_ENABLED=0 GOARM=5 gox -osarch="linux/arm" -ldflags="-s -w" -output "$OUTDIR/$APPNAME-linux-arm5/gnatsd"
+# ARMv7
+env CGO_ENABLED=0 GOARM=7 gox -osarch="linux/arm" -ldflags="-s -w" -output "$OUTDIR/$APPNAME-linux-arm7/gnatsd"
+
+# Create the zip files
 for dir in $DIRS; do \
     (cp README.md $OUTDIR/$APPNAME-$dir/README.md) ;\
     (cp LICENSE $OUTDIR/$APPNAME-$dir/LICENSE) ;\


### PR DESCRIPTION
The cross compile script compiled an ARM executable, but the ARM
default version varies based on the host, etc..
Made a change to the cross compile script to explicitly compile
ARMv5 and ARMv7.