### PR TITLE
Fix some tests

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -589,10 +589,10 @@ func TestClientMapRemoval(t *testing.T) {
 }
 
 func TestAuthorizationTimeout(t *testing.T) {
-	serverOptions := defaultServerOptions
+	serverOptions := DefaultOptions()
 	serverOptions.Authorization = "my_token"
 	serverOptions.AuthTimeout = 0.4
-	s := RunServer(&serverOptions)
+	s := RunServer(serverOptions)
 	defer s.Shutdown()
 
 	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", serverOptions.Host, serverOptions.Port))

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1351,7 +1351,7 @@ func TestConcurrentMonitoring(t *testing.T) {
 	for _, e := range endpoints {
 		go func(endpoint string) {
 			defer wg.Done()
-			for i := 0; i < 150; i++ {
+			for i := 0; i < 50; i++ {
 				resp, err := http.Get(url + endpoint)
 				if err != nil {
 					ech <- fmt.Sprintf("Expected no error: Got %v\n", err)


### PR DESCRIPTION
Fixing various tests that were failing locally when running in
parallel mode (without -p=1).
In reload_test.go, lots of nats.Conn.Close() were missing which
would require too much memory when running with `-race` mode.
