### PR TITLE
Use loopback for some config reload tests

### DIFF
--- a/server/configs/reload/srv_a_3.conf
+++ b/server/configs/reload/srv_a_3.conf
@@ -8,6 +8,6 @@ cluster {
   listen: 127.0.0.1:7244
 
   routes = [
-    nats-route://localhost:7247 # Remove srv b route and add srv c
+    nats-route://127.0.0.1:7247 # Remove srv b route and add srv c
   ]
 }

--- a/server/configs/reload/srv_c_1.conf
+++ b/server/configs/reload/srv_c_1.conf
@@ -5,5 +5,5 @@
 listen: localhost:-1
 
 cluster {
-  listen: localhost:7247
+  listen: 127.0.0.1:7247
 }


### PR DESCRIPTION
Trying to solve issue with Windows Docker run:
```
=== RUN   TestConfigReloadClusterRoutes
--- FAIL: TestConfigReloadClusterRoutes (13.11s)
        sublist_test.go:28: Expected 1 routes for server "VUlU12p66c8CaA5h9QTaXA", got 0
                2 - C:/gopath/src/github.com/nats-io/gnatsd/server/reload_test.go:1313
                3 - c:/go/src/testing/testing.go:657
                4 - c:/go/src/runtime/asm_amd64.s:2197
```
Already bumped the timeout to 10 seconds, but it did not help.
Noticed that some of the config files involved used `127.0.0.1` while
those 2 used `localhost`. Changed them to use `127.0.0.1`.