### PR TITLE
[FIXED] Windows Docker Images

### DIFF
--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -1,0 +1,11 @@
+FROM golang:1.7.6
+
+MAINTAINER Ivan Kozlovic <ivan.kozlovic@apcera.com>
+
+COPY . /go/src/github.com/nats-io/gnatsd
+WORKDIR /go/src/github.com/nats-io/gnatsd
+
+RUN CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o gnatsd.exe .
+
+ENTRYPOINT ["go"]
+CMD ["version"]

--- a/logger/syslog_windows.go
+++ b/logger/syslog_windows.go
@@ -5,9 +5,10 @@ package logger
 
 import (
 	"fmt"
-	"golang.org/x/sys/windows/svc/eventlog"
 	"os"
 	"strings"
+
+	"golang.org/x/sys/windows/svc/eventlog"
 )
 
 const (

--- a/logger/syslog_windows_test.go
+++ b/logger/syslog_windows_test.go
@@ -4,10 +4,11 @@
 package logger
 
 import (
-	"golang.org/x/sys/windows/svc/eventlog"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"golang.org/x/sys/windows/svc/eventlog"
 )
 
 // Skips testing if we do not have privledges to run this test.

--- a/server/const.go
+++ b/server/const.go
@@ -19,7 +19,7 @@ const (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "1.0.0"
+	VERSION = "1.0.1"
 
 	// DEFAULT_PORT is the default port for client connections.
 	DEFAULT_PORT = 4222


### PR DESCRIPTION
The use of the `svc` API prevented the NATS Server to run as
a container on both nanoserver and windowsservercore Docker images.
An attempt was made to replace svc.Debug with normal server.Start()
if detected to be interactive, however, that did not work. The
fact of detecting if interactive or not already requires connecting
to the service controller apparently.
This change looks up for an environment variable (NATS_DOCKERIZED)
and if set to "1", will not make use of the `svc` package.
This environment variable will be set in the Docker image (in
nats-docker/windows/nanoserver/Dockerfile and windowsservercore/Dockerfile).

Resolves #543
