### PR TITLE
Improved Config Reload test coverage

### DIFF
--- a/server/configs/reload/reload.conf
+++ b/server/configs/reload/reload.conf
@@ -12,7 +12,7 @@ pid_file:         "/tmp/gnatsd.pid" # change on reload
 max_control_line: 512 # change on reload
 ping_interval:    5 # change on reload
 ping_max:         1 # change on reload
-write_deadline:   "2s" # change on reload
+write_deadline:   "3s" # change on reload
 max_payload:      1024 # change on reload
 
 # Enable TLS on reload

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -93,10 +93,10 @@ func TestConfigReloadUnsupportedHotSwapping(t *testing.T) {
 	defer os.Remove(orgConfig)
 	defer os.Remove(newConfig)
 	if err := ioutil.WriteFile(orgConfig, []byte("listen: localhost:-1"), 0666); err != nil {
-		t.Fatalf("Error creatign config file: %v", err)
+		t.Fatalf("Error creating config file: %v", err)
 	}
 	if err := ioutil.WriteFile(newConfig, []byte("listen: localhost:9999"), 0666); err != nil {
-		t.Fatalf("Error creatign config file: %v", err)
+		t.Fatalf("Error creating config file: %v", err)
 	}
 
 	server, _, config := newServerWithSymlinkConfig(t, "tmp.conf", orgConfig)
@@ -110,7 +110,7 @@ func TestConfigReloadUnsupportedHotSwapping(t *testing.T) {
 	// Change config file with unsupported option hot-swap
 	createSymlink(t, config, newConfig)
 
-	// This should fail because `cluster` host cannot be changed.
+	// This should fail because `listen` host cannot be changed.
 	if err := server.Reload(); err == nil || !strings.Contains(err.Error(), "not supported") {
 		t.Fatalf("Expected Reload to return a not supported error, got %v", err)
 	}


### PR DESCRIPTION
- Move the kill of a server in a cluster test to ensure that
  list of routes to remove is not empty.
- Change write_deadline reload value to 3s to make it different
  from default value
- Add test for option that does not support hot-swapping
