### PR TITLE
[FIXED] Handling of duplicate routes

### DIFF
--- a/server/reload.go
+++ b/server/reload.go
@@ -265,10 +265,8 @@ func (r *routesOption) Apply(server *Server) {
 	for _, remove := range r.remove {
 		for _, client := range routes {
 			if client.route.url == remove {
-				client.mu.Lock()
 				// Do not attempt to reconnect when route is removed.
-				client.route.closed = true
-				client.mu.Unlock()
+				client.setRouteNoReconnectOnClose()
 				client.closeConnection()
 				server.Noticef("Removed route %v", remove)
 			}
@@ -597,9 +595,7 @@ func (s *Server) reloadAuthorization() {
 	for _, client := range routes {
 		// Disconnect any unauthorized routes.
 		if !s.isRouterAuthorized(client) {
-			client.mu.Lock()
-			client.route.closed = true
-			client.mu.Unlock()
+			client.setRouteNoReconnectOnClose()
 			client.authViolation()
 		}
 	}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -8,12 +8,12 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/nats-io/go-nats"
-	"strings"
-	"sync"
 )
 
 func TestRouteConfig(t *testing.T) {

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/nats-io/go-nats"
+	"strings"
+	"sync"
 )
 
 func TestRouteConfig(t *testing.T) {
@@ -523,5 +525,69 @@ func TestClientConnectToRoutePort(t *testing.T) {
 		if nc.ConnectedUrl() != clientURL {
 			t.Fatalf("Expected client to be connected to %v, got %v", clientURL, nc.ConnectedUrl())
 		}
+	}
+}
+
+type checkDuplicateRouteLogger struct {
+	sync.Mutex
+	gotDuplicate bool
+}
+
+func (l *checkDuplicateRouteLogger) Noticef(format string, v ...interface{}) {}
+func (l *checkDuplicateRouteLogger) Errorf(format string, v ...interface{})  {}
+func (l *checkDuplicateRouteLogger) Fatalf(format string, v ...interface{})  {}
+func (l *checkDuplicateRouteLogger) Tracef(format string, v ...interface{})  {}
+func (l *checkDuplicateRouteLogger) Debugf(format string, v ...interface{}) {
+	l.Lock()
+	defer l.Unlock()
+	msg := fmt.Sprintf(format, v...)
+	if strings.Contains(msg, "duplicate remote route") {
+		l.gotDuplicate = true
+	}
+}
+
+func TestRoutesToEachOther(t *testing.T) {
+	optsA := DefaultOptions()
+	optsA.Cluster.Port = 7246
+	optsA.Routes = RoutesFromStr("nats://127.0.0.1:7247")
+
+	optsB := DefaultOptions()
+	optsB.Cluster.Port = 7247
+	optsB.Routes = RoutesFromStr("nats://127.0.0.1:7246")
+
+	srvALogger := &checkDuplicateRouteLogger{}
+	srvA := New(optsA)
+	srvA.SetLogger(srvALogger, true, false)
+	defer srvA.Shutdown()
+
+	srvBLogger := &checkDuplicateRouteLogger{}
+	srvB := New(optsB)
+	srvB.SetLogger(srvBLogger, true, false)
+	defer srvB.Shutdown()
+
+	go srvA.Start()
+	go srvB.Start()
+
+	start := time.Now()
+	checkClusterFormed(t, srvA, srvB)
+	end := time.Now()
+
+	srvALogger.Lock()
+	gotIt := srvALogger.gotDuplicate
+	srvALogger.Unlock()
+	if !gotIt {
+		srvBLogger.Lock()
+		gotIt = srvBLogger.gotDuplicate
+		srvBLogger.Unlock()
+	}
+	if gotIt {
+		dur := end.Sub(start)
+		// It should not take too long to have a successful connection
+		// between the 2 servers.
+		if dur > 5*time.Second {
+			t.Logf("Cluster formed, but took a long time: %v", dur)
+		}
+	} else {
+		t.Log("Was not able to get duplicate route this time!")
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -314,6 +314,7 @@ func (s *Server) Shutdown() {
 	s.grMu.Unlock()
 	// Copy off the routes
 	for i, r := range s.routes {
+		r.setRouteNoReconnectOnClose()
 		conns[i] = r
 	}
 


### PR DESCRIPTION
When A connects to B and B connects to A (either based on static
configuration - explicit routes, or because of auto-discovery -
implicit routes), it is possible that each server initially
registers the route from the opposite TCP connection. It will
then result in each server dropping the connection.

We were previously setting a retry flag in the first accepted route
based on the name of servers, which means that regardless of
duplicate detection, the server with the "smaller" server name would
try to reconnect when the route connection was closed. For instance,
suppose that server B connects to server A, when B disconnects, A
would try to reconnect once to B. This became problematic in the
case of configuration reload, because removing the route from B to
A would still result in a route created from A to B.

Also, when a route attempts a reconnect, a random delay is added
to avoid repeated failure cycles that may occur in case where
A connects to B and B to A.
