### PR TITLE
Fixed error of hang subscriptions in the cluster when used auto unsubscribe

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1317,6 +1317,8 @@ func (c *client) closeConnection() {
 	// Snapshot for use.
 	subs := make([]*subscription, 0, len(c.subs))
 	for _, sub := range c.subs {
+		// Auto-unsubscribe subscriptions must be unsubscribed forcibly.
+		sub.max = 0
 		subs = append(subs, sub)
 	}
 	srv := c.srv


### PR DESCRIPTION
 - [x] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [x] Tests added
 - [x] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #549  

