### PR TITLE
Use DefaultOptions as function that produces new Options on every call

### DIFF
--- a/test/client_cluster_test.go
+++ b/test/client_cluster_test.go
@@ -25,7 +25,7 @@ func TestServerRestartReSliceIssue(t *testing.T) {
 
 	servers := []string{urlA, urlB}
 
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Timeout = (5 * time.Second)
 	opts.ReconnectWait = (50 * time.Millisecond)
 	opts.MaxReconnect = 1000
@@ -115,7 +115,7 @@ func TestServerRestartAndQueueSubs(t *testing.T) {
 	urlB := fmt.Sprintf("nats://%s:%d/", optsB.Host, optsB.Port)
 
 	// Client options
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Timeout = (5 * time.Second)
 	opts.ReconnectWait = (50 * time.Millisecond)
 	opts.MaxReconnect = 1000

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -93,7 +93,7 @@ func TestTLSClientCertificate(t *testing.T) {
 		MinVersion:   tls.VersionTLS12,
 	}
 
-	copts := nats.DefaultOptions
+	copts := nats.GetDefaultOptions()
 	copts.Url = nurl
 	copts.Secure = true
 	copts.TLSConfig = config


### PR DESCRIPTION
 - [X] Link to issue, e.g. `Resolves #NNN`
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request: 
 - Corresponding fixes for https://github.com/nats-io/go-nats/pull/308

 
/cc @nats-io/core
