### PR TITLE
Document string escape behavior [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ max_control_line: 512
 max_payload: 65536
 ```
 
-Inside configuration files, string values support the following escape characters: `\xXX, \t, \n, \r, \", \\`.  Take note that when specifying directory paths in options such as `pid_file` and `log_file` on windows, you'll need to escape backslashes, e.g. `log_file:  "c:\\logging\\log.txt"`, or use unix style (`/`) path separators.
+Inside configuration files, string values support the following escape characters: `\xXX, \t, \n, \r, \", \\`.  Take note that when specifying directory paths in options such as `pid_file` and `log_file` on Windows, you'll need to escape backslashes, e.g. `log_file:  "c:\\logging\\log.txt"`, or use unix style (`/`) path separators.
 
 ## Variables
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ max_control_line: 512
 max_payload: 65536
 ```
 
+Inside configuration files, string values support the following escape characters: `\xXX, \t, \n, \r, \", \\`.  Take note that when specifying directory paths in options such as `pid_file` and `log_file` on windows, you'll need to escape backslashes, e.g. `log_file:  "c:\\logging\\log.txt"`, or use unix style (`/`) path separators.
+
 ## Variables
 
 The NATS sever configuration language supports block-scoped variables that can be used for templating in the configuration file, and specifically to ease setting of group values for [permission fields](#authorization) and [user authentication](#authentication).


### PR DESCRIPTION
 - [X] Link to issue, e.g. `Resolves #NNN`
 - [X] Documentation added (if applicable)

Resolves #553 

### Changes proposed in this pull request: 
Document string escape behavior in the configuration file.
 
/cc @nats-io/core
