### PR TITLE
[FIXED] Use of `*` and `>` in subjects as literals

### DIFF
--- a/server/sublist.go
+++ b/server/sublist.go
@@ -616,7 +616,6 @@ func matchLiteral(literal, subject string) bool {
 			return false
 		}
 		b := subject[i]
-		checkb := true
 		switch b {
 		case pwc:
 			// NOTE: This is not testing validity of a subject, instead ensures
@@ -626,9 +625,7 @@ func matchLiteral(literal, subject string) bool {
 			// or first character and followed by a `.`
 			// or last character and preceded by a `.`
 			// or preceded and followed by a `.`
-			if ls == 1 ||
-				(i == 0 && i < ls-1 && subject[i+1] == btsep) ||
-				(i > 0 && subject[i-1] == btsep && ((i == ls-1) || (subject[i+1] == btsep))) {
+			if (i == 0 || subject[i-1] == btsep) && (i == ls-1 || subject[i+1] == btsep) {
 				// Skip token in literal
 				for {
 					if li >= ll || literal[li] == btsep {
@@ -637,19 +634,23 @@ func matchLiteral(literal, subject string) bool {
 					}
 					li++
 				}
-				checkb = false
+			} else if b != literal[li] {
+				return false
 			}
 		case fwc:
 			// For `>` to be a wildcard, it means:
 			// only character in the string
 			// or last character preceded by `.`
-			if ls == 1 ||
-				(i > 0 && subject[i-1] == btsep && i == ls-1) {
+			if (i == 0 || subject[i-1] == btsep) && i == ls-1 {
 				return true
 			}
-		}
-		if checkb && b != literal[li] {
-			return false
+			if b != literal[li] {
+				return false
+			}
+		default:
+			if b != literal[li] {
+				return false
+			}
 		}
 		li++
 	}

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -615,42 +615,60 @@ func matchLiteral(literal, subject string) bool {
 		if li >= ll {
 			return false
 		}
-		b := subject[i]
-		switch b {
+		// This function has been optimized for speed.
+		// For instance, do not set b:=subject[i] here since
+		// we may bump `i` in this loop to avoid `continue` or
+		// skiping common test in a particular test.
+		// Run Benchmark_SublistMatchLiteral before making any change.
+		switch subject[i] {
 		case pwc:
 			// NOTE: This is not testing validity of a subject, instead ensures
-			// that wildcards are treated as such if they follow some basic rules.
-			// For `*` it means:
-			// only character in the string
-			// or first character and followed by a `.`
-			// or last character and preceded by a `.`
-			// or preceded and followed by a `.`
-			if (i == 0 || subject[i-1] == btsep) && (i == ls-1 || subject[i+1] == btsep) {
-				// Skip token in literal
-				for {
-					if li >= ll || literal[li] == btsep {
-						li--
-						break
+			// that wildcards are treated as such if they follow some basic rules,
+			// namely that they are a token on their own.
+			if i == 0 || subject[i-1] == btsep {
+				if i == ls-1 {
+					// There is no more token in the subject after this wildcard.
+					// Skip token in literal and expect to not find a separator.
+					for {
+						// End of literal, this is a match.
+						if li >= ll {
+							return true
+						}
+						// Presence of separator, this can't be a match.
+						if literal[li] == btsep {
+							return false
+						}
+						li++
 					}
-					li++
+				} else if subject[i+1] == btsep {
+					// There is another token in the subject after this wildcard.
+					// Skip token in literal and expect to get a separator.
+					for {
+						// We found the end of the literal before finding a separator,
+						// this can't be a match.
+						if li >= ll {
+							return false
+						}
+						if literal[li] == btsep {
+							break
+						}
+						li++
+					}
+					// Bump `i` since we know there is a `.` following, we are
+					// safe. The common test below is going to check `.` with `.`
+					// which is good. A `continue` here is too costly.
+					i++
 				}
-			} else if b != literal[li] {
-				return false
 			}
 		case fwc:
-			// For `>` to be a wildcard, it means:
-			// only character in the string
-			// or last character preceded by `.`
+			// For `>` to be a wildcard, it means being the only or last character
+			// in the string preceded by a `.`
 			if (i == 0 || subject[i-1] == btsep) && i == ls-1 {
 				return true
 			}
-			if b != literal[li] {
-				return false
-			}
-		default:
-			if b != literal[li] {
-				return false
-			}
+		}
+		if subject[i] != literal[li] {
+			return false
 		}
 		li++
 	}

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -370,6 +370,49 @@ func TestSublistValidLiteralSubjects(t *testing.T) {
 	checkBool(IsValidLiteralSubject("foo.bar.>"), false, t)
 	checkBool(IsValidLiteralSubject("*"), false, t)
 	checkBool(IsValidLiteralSubject(">"), false, t)
+	// The followings have widlcards characters but are not
+	// considered as such because they are not individual tokens.
+	checkBool(IsValidLiteralSubject("foo*"), true, t)
+	checkBool(IsValidLiteralSubject("foo**"), true, t)
+	checkBool(IsValidLiteralSubject("foo.**"), true, t)
+	checkBool(IsValidLiteralSubject("foo*bar"), true, t)
+	checkBool(IsValidLiteralSubject("foo.*bar"), true, t)
+	checkBool(IsValidLiteralSubject("foo*.bar"), true, t)
+	checkBool(IsValidLiteralSubject("*bar"), true, t)
+	checkBool(IsValidLiteralSubject("foo>"), true, t)
+	checkBool(IsValidLiteralSubject("foo>>"), true, t)
+	checkBool(IsValidLiteralSubject("foo.>>"), true, t)
+	checkBool(IsValidLiteralSubject("foo>bar"), true, t)
+	checkBool(IsValidLiteralSubject("foo.>bar"), true, t)
+	checkBool(IsValidLiteralSubject("foo>.bar"), true, t)
+	checkBool(IsValidLiteralSubject(">bar"), true, t)
+}
+
+func TestSublistValidlSubjects(t *testing.T) {
+	checkBool(IsValidSubject("."), false, t)
+	checkBool(IsValidSubject(".foo"), false, t)
+	checkBool(IsValidSubject("foo."), false, t)
+	checkBool(IsValidSubject("foo..bar"), false, t)
+	checkBool(IsValidSubject(">.bar"), false, t)
+	checkBool(IsValidSubject("foo.>.bar"), false, t)
+	checkBool(IsValidSubject("foo"), true, t)
+	checkBool(IsValidSubject("foo.bar.*"), true, t)
+	checkBool(IsValidSubject("foo.bar.>"), true, t)
+	checkBool(IsValidSubject("*"), true, t)
+	checkBool(IsValidSubject(">"), true, t)
+	checkBool(IsValidSubject("foo*"), true, t)
+	checkBool(IsValidSubject("foo**"), true, t)
+	checkBool(IsValidSubject("foo.**"), true, t)
+	checkBool(IsValidSubject("foo*bar"), true, t)
+	checkBool(IsValidSubject("foo.*bar"), true, t)
+	checkBool(IsValidSubject("foo*.bar"), true, t)
+	checkBool(IsValidSubject("*bar"), true, t)
+	checkBool(IsValidSubject("foo>"), true, t)
+	checkBool(IsValidSubject("foo.>>"), true, t)
+	checkBool(IsValidSubject("foo>bar"), true, t)
+	checkBool(IsValidSubject("foo.>bar"), true, t)
+	checkBool(IsValidSubject("foo>.bar"), true, t)
+	checkBool(IsValidSubject(">bar"), true, t)
 }
 
 func TestSublistMatchLiterals(t *testing.T) {
@@ -385,6 +428,18 @@ func TestSublistMatchLiterals(t *testing.T) {
 	checkBool(matchLiteral("foo.bar", "foo"), false, t)
 	checkBool(matchLiteral("stats.test.foos", "stats.test.foos"), true, t)
 	checkBool(matchLiteral("stats.test.foos", "stats.test.foo"), false, t)
+
+	// These are cases where wildcards characters should not be considered
+	// wildcards since they do not follow the rules of wildcards.
+	checkBool(matchLiteral("*bar", "*.*"), false, t)
+	checkBool(matchLiteral("*bar", "*.>"), false, t)
+	checkBool(matchLiteral("*bar", "*bar"), true, t) // match literally
+	checkBool(matchLiteral("foo*", "foo.*"), false, t)
+	checkBool(matchLiteral("foo*", "foo.>"), false, t)
+	checkBool(matchLiteral("foo*", "foo*"), true, t) // match literally
+	checkBool(matchLiteral("foo*bar", "foo.*.bar"), false, t)
+	checkBool(matchLiteral("foo*bar", "foo.>"), false, t)
+	checkBool(matchLiteral("foo*bar", "foo*bar"), true, t) // match literally
 }
 
 func TestSublistBadSubjectOnRemove(t *testing.T) {

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -589,3 +589,39 @@ func Benchmark_____________Sublist10XMultipleReads(b *testing.B) {
 func Benchmark____________Sublist100XMultipleReads(b *testing.B) {
 	multiRead(b, 100)
 }
+
+func Benchmark_SublistMatchLiteral(b *testing.B) {
+	b.StopTimer()
+	cachedSubj := "foo.foo.foo.foo.foo.foo.foo.foo.foo.foo"
+	subjects := []string{
+		"foo.foo.foo.foo.foo.foo.foo.foo.foo.foo",
+		"foo.foo.foo.foo.foo.foo.foo.foo.foo.>",
+		"foo.foo.foo.foo.foo.foo.foo.foo.>",
+		"foo.foo.foo.foo.foo.foo.foo.>",
+		"foo.foo.foo.foo.foo.foo.>",
+		"foo.foo.foo.foo.foo.>",
+		"foo.foo.foo.foo.>",
+		"foo.foo.foo.>",
+		"foo.foo.>",
+		"foo.>",
+		">",
+		"foo.foo.foo.foo.foo.foo.foo.foo.foo.*",
+		"foo.foo.foo.foo.foo.foo.foo.foo.*.*",
+		"foo.foo.foo.foo.foo.foo.foo.*.*.*",
+		"foo.foo.foo.foo.foo.foo.*.*.*.*",
+		"foo.foo.foo.foo.foo.*.*.*.*.*",
+		"foo.foo.foo.foo.*.*.*.*.*.*",
+		"foo.foo.foo.*.*.*.*.*.*.*",
+		"foo.foo.*.*.*.*.*.*.*.*",
+		"foo.*.*.*.*.*.*.*.*.*",
+		"*.*.*.*.*.*.*.*.*.*",
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		for _, subject := range subjects {
+			if !matchLiteral(cachedSubj, subject) {
+				b.Fatalf("Subject %q no match with %q", cachedSubj, subject)
+			}
+		}
+	}
+}

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -428,18 +428,20 @@ func TestSublistMatchLiterals(t *testing.T) {
 	checkBool(matchLiteral("foo.bar", "foo"), false, t)
 	checkBool(matchLiteral("stats.test.foos", "stats.test.foos"), true, t)
 	checkBool(matchLiteral("stats.test.foos", "stats.test.foo"), false, t)
+	checkBool(matchLiteral("stats.test", "stats.test.*"), false, t)
+	checkBool(matchLiteral("stats.test.foos", "stats.*"), false, t)
+	checkBool(matchLiteral("stats.test.foos", "stats.*.*.foos"), false, t)
 
 	// These are cases where wildcards characters should not be considered
 	// wildcards since they do not follow the rules of wildcards.
-	checkBool(matchLiteral("*bar", "*.*"), false, t)
-	checkBool(matchLiteral("*bar", "*.>"), false, t)
-	checkBool(matchLiteral("*bar", "*bar"), true, t) // match literally
-	checkBool(matchLiteral("foo*", "foo.*"), false, t)
-	checkBool(matchLiteral("foo*", "foo.>"), false, t)
-	checkBool(matchLiteral("foo*", "foo*"), true, t) // match literally
-	checkBool(matchLiteral("foo*bar", "foo.*.bar"), false, t)
-	checkBool(matchLiteral("foo*bar", "foo.>"), false, t)
-	checkBool(matchLiteral("foo*bar", "foo*bar"), true, t) // match literally
+	checkBool(matchLiteral("*bar", "*bar"), true, t)
+	checkBool(matchLiteral("foo*", "foo*"), true, t)
+	checkBool(matchLiteral("foo*bar", "foo*bar"), true, t)
+	checkBool(matchLiteral("foo.***.bar", "foo.***.bar"), true, t)
+	checkBool(matchLiteral(">bar", ">bar"), true, t)
+	checkBool(matchLiteral("foo>", "foo>"), true, t)
+	checkBool(matchLiteral("foo>bar", "foo>bar"), true, t)
+	checkBool(matchLiteral("foo.>>>.bar", "foo.>>>.bar"), true, t)
 }
 
 func TestSublistBadSubjectOnRemove(t *testing.T) {


### PR DESCRIPTION
The issue was that a subject such as `foo.bar,*,>` would be
inserted to the cache as is, but when trying to remove from the
cache, calling matchLiteral() with the above subject in the cache
against the same subject would return false. This is because
matchLiteral would treat those characters as wildcards token.

Note that the sublist itself splits subjects on the `.` separator
and seem not bothered by such subject (would have `foo` and `bar,*,>`
tokens). Also, note that IsValidSubject() and IsValidLiteralSubject()
properly checked that the characters `*` and `>` are treated
as wildcards only if they are tokens on their own.

Resolves #558

/cc @derekcollison if you could have a look to see if this makes sense, thanks!
