### PR TITLE
increased tls timeout to get test passing on arm.

### DIFF
--- a/test/ping_test.go
+++ b/test/ping_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 Apcera Inc. All rights reserved.
+// Copyright 2012-2017 Apcera Inc. All rights reserved.
 
 package test
 
@@ -41,6 +41,7 @@ func TestPingSentToTLSConnection(t *testing.T) {
 	tc.CaFile = opts.TLSCaCert
 
 	opts.TLSConfig, _ = server.GenTLSConfig(&tc)
+	opts.TLSTimeout = float64(5 * time.Second)
 	s := RunServer(&opts)
 	defer s.Shutdown()
 

--- a/test/ping_test.go
+++ b/test/ping_test.go
@@ -41,7 +41,7 @@ func TestPingSentToTLSConnection(t *testing.T) {
 	tc.CaFile = opts.TLSCaCert
 
 	opts.TLSConfig, _ = server.GenTLSConfig(&tc)
-	opts.TLSTimeout = float64(5 * time.Second)
+	opts.TLSTimeout = 5
 	s := RunServer(&opts)
 	defer s.Shutdown()
 


### PR DESCRIPTION
 - [X] Documentation added (if applicable)
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves:
TLS TImeout causing errors in arm build testing.

/cc @nats-io/core
