### PR TITLE
Implement DLQ

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2016 Apcera Inc. All rights reserved.
+// Copyright 2012-2017 Apcera Inc. All rights reserved.
 
 package main
 
@@ -24,6 +24,7 @@ Server Options:
     -ms,--https_port <port>          Use port for https monitoring
     -c, --config <file>              Configuration file
     -sl,--signal <signal>[=<pid>]    Send signal to gnatsd process (stop, quit, reopen, reload)
+    -dlq                             Enable dead-letter queues (default: false)
 
 Logging Options:
     -l, --log <file>                 File to redirect log output
@@ -101,6 +102,7 @@ func main() {
 	flag.StringVar(&configFile, "config", "", "Configuration file.")
 	flag.StringVar(&signal, "sl", "", "Send signal to gnatsd process (stop, quit, reopen, reload)")
 	flag.StringVar(&signal, "signal", "", "Send signal to gnatsd process (stop, quit, reopen, reload)")
+	flag.BoolVar(&opts.DLQ, "dlq", false, "Enable dead-letter queues.")
 	flag.StringVar(&opts.PidFile, "P", "", "File to store process pid.")
 	flag.StringVar(&opts.PidFile, "pid", "", "File to store process pid.")
 	flag.StringVar(&opts.LogFile, "l", "", "File to store logging output.")

--- a/server/configs/reload/reload.conf
+++ b/server/configs/reload/reload.conf
@@ -14,6 +14,7 @@ ping_interval:    5 # change on reload
 ping_max:         1 # change on reload
 write_deadline:   "3s" # change on reload
 max_payload:      1024 # change on reload
+dlq:              true # enable on reload
 
 # Enable TLS on reload
 tls {

--- a/server/opts.go
+++ b/server/opts.go
@@ -71,6 +71,7 @@ type Options struct {
 	TLSCaCert      string        `json:"-"`
 	TLSConfig      *tls.Config   `json:"-"`
 	WriteDeadline  time.Duration `json:"-"`
+	DLQ            bool          `json:"dead_letter_queue"`
 }
 
 // Clone performs a deep copy of the Options struct, returning a new clone
@@ -186,6 +187,8 @@ func ProcessConfigFile(configFile string) (*Options, error) {
 			opts.Trace = v.(bool)
 		case "logtime":
 			opts.Logtime = v.(bool)
+		case "dlq", "dead_letter_queue":
+			opts.DLQ = v.(bool)
 		case "authorization":
 			am := v.(map[string]interface{})
 			auth, err := parseAuthorization(am)

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -290,6 +290,9 @@ func TestConfigReload(t *testing.T) {
 	if updated.MaxPayload != 1024 {
 		t.Fatalf("MaxPayload is incorrect.\nexpected 1024\ngot: %d", updated.MaxPayload)
 	}
+	if !updated.DLQ {
+		t.Fatal("Expected DLQ to be true")
+	}
 
 	if reloaded := server.ConfigTime(); !reloaded.After(loaded) {
 		t.Fatalf("ConfigTime is incorrect.\nexpected greater than: %s\ngot: %s", loaded, reloaded)

--- a/server/route.go
+++ b/server/route.go
@@ -587,7 +587,12 @@ func (s *Server) broadcastSubscribe(sub *subscription) {
 		return
 	}
 	rsid := routeSid(sub)
-	proto := fmt.Sprintf(subProto, sub.subject, sub.queue, rsid)
+	var proto string
+	if sub.dlq {
+		proto = fmt.Sprintf(subProto, "_SYS.dlq."+string(sub.subject), sub.queue, rsid)
+	} else {
+		proto = fmt.Sprintf(subProto, sub.subject, sub.queue, rsid)
+	}
 	s.broadcastInterestToRoutes(proto)
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2016 Apcera Inc. All rights reserved.
+// Copyright 2012-2017 Apcera Inc. All rights reserved.
 
 package server
 
@@ -47,11 +47,13 @@ type Info struct {
 // Server is our main struct.
 type Server struct {
 	gcid uint64
+	dlq  uint32
 	stats
 	mu            sync.Mutex
 	info          Info
 	infoJSON      []byte
 	sl            *Sublist
+	dlqSl         *Sublist
 	configFile    string
 	optsMu        sync.RWMutex
 	opts          *Options
@@ -118,6 +120,11 @@ func New(opts *Options) *Server {
 		clientConnectURLs: make(map[string]struct{}),
 	}
 
+	dlq := uint32(0)
+	if opts.DLQ {
+		dlq = 1
+	}
+
 	now := time.Now()
 	s := &Server{
 		configFile: opts.ConfigFile,
@@ -127,6 +134,8 @@ func New(opts *Options) *Server {
 		done:       make(chan bool, 1),
 		start:      now,
 		configTime: now,
+		dlq:        dlq,
+		dlqSl:      NewSublist(),
 	}
 
 	s.mu.Lock()


### PR DESCRIPTION
With gnatsd, there is no way of knowing if a message was delivered (or
attempted to be delivered) to a subscriber. However, the server knows
this information when it receives a published message. If there are no
subscribers, the message is dropped on the floor. Typically,
error-handling/timeout/retry logic should be handled by the client, but
in the case where there is no interest on the subject, it's moot.

There are a number of concrete use cases outside of administrative/
monitoring functions where this is useful, including NATS Streaming.
See #568 for further motivation behind this.

As implemented, DLQs are off by default, so there is no performance
impact. In practice, the only performance impact is when messages
are dropped, which seems like a vanity metric anyway.

Resolves #568 and #352.

@nats-io/core
