### PR TITLE
Add back custom Auth api

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -82,7 +82,9 @@ func (s *Server) configureAuthorization() {
 
 	// Check for multiple users first
 	// This just checks and sets up the user map if we have multiple users.
-	if opts.Users != nil {
+	if opts.CustomClientAuthentication != nil {
+		s.info.AuthRequired = true
+	} else if opts.Users != nil {
 		s.users = make(map[string]*User)
 		for _, u := range opts.Users {
 			s.users[u.Username] = u

--- a/server/auth.go
+++ b/server/auth.go
@@ -10,14 +10,14 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-// Auth is an interface for implementing authentication
-type Auth interface {
+// Authentication is an interface for implementing authentication
+type Authentication interface {
 	// Check if a client is authorized to connect
-	Check(c ClientAuth) bool
+	Check(c ClientAuthentication) bool
 }
 
-// ClientAuth is an interface for client authentication
-type ClientAuth interface {
+// ClientAuthentication is an interface for client authentication
+type ClientAuthentication interface {
 	// Get options associated with a client
 	GetOpts() *clientOpts
 	// If TLS is enabled, TLS ConnectionState, nil otherwise
@@ -116,8 +116,8 @@ func (s *Server) isClientAuthorized(c *client) bool {
 	opts := s.getOpts()
 
 	// Check custom auth first, then multiple users, then token, then single user/pass.
-	if s.opts.CustomClientAuth != nil {
-		return s.opts.CustomClientAuth.Check(c)
+	if s.opts.CustomClientAuthentication != nil {
+		return s.opts.CustomClientAuthentication.Check(c)
 	} else if s.users != nil {
 		user, ok := s.users[c.opts.Username]
 		if !ok {
@@ -149,8 +149,8 @@ func (s *Server) isRouterAuthorized(c *client) bool {
 	// Snapshot server options.
 	opts := s.getOpts()
 
-	if s.opts.CustomRouterAuth != nil {
-		return s.opts.CustomRouterAuth.Check(c)
+	if s.opts.CustomRouterAuthentication != nil {
+		return s.opts.CustomRouterAuthentication.Check(c)
 	}
 
 	if opts.Cluster.Username == "" {

--- a/server/opts.go
+++ b/server/opts.go
@@ -72,8 +72,8 @@ type Options struct {
 	TLSConfig      *tls.Config   `json:"-"`
 	WriteDeadline  time.Duration `json:"-"`
 
-	CustomClientAuth Auth `json:"-"`
-	CustomRouterAuth Auth `json:"-"`
+	CustomClientAuthentication Authentication `json:"-"`
+	CustomRouterAuthentication Authentication `json:"-"`
 }
 
 // Clone performs a deep copy of the Options struct, returning a new clone

--- a/server/opts.go
+++ b/server/opts.go
@@ -71,6 +71,9 @@ type Options struct {
 	TLSCaCert      string        `json:"-"`
 	TLSConfig      *tls.Config   `json:"-"`
 	WriteDeadline  time.Duration `json:"-"`
+
+	CustomClientAuth Auth `json:"-"`
+	CustomRouterAuth Auth `json:"-"`
 }
 
 // Clone performs a deep copy of the Options struct, returning a new clone

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -390,7 +390,7 @@ func TestNilMonitoringPort(t *testing.T) {
 type DummyAuth struct{}
 
 func (d *DummyAuth) Check(c ClientAuthentication) bool {
-	return false
+	return c.GetOpts().Username != "test"
 }
 
 func TestCustomClientAuthentication(t *testing.T) {
@@ -404,7 +404,7 @@ func TestCustomClientAuthentication(t *testing.T) {
 	defer s.Shutdown()
 
 	addr := fmt.Sprintf("nats://%s:%d", opts.Host, opts.Port)
-	if _, err := nats.Connect(addr); err == nil {
+	if _, err := nats.Connect(addr, nats.UserInfo("test", "")); err == nil {
 		t.Fatal("Expected client to fail to connect")
 	}
 }
@@ -419,10 +419,11 @@ func TestCustomRouterAuthentication(t *testing.T) {
 
 	opts2 := DefaultOptions()
 	opts2.Cluster.Host = "127.0.0.1"
-	opts2.Routes = RoutesFromStr(fmt.Sprintf("nats://127.0.0.1:%d", clusterPort))
+	opts2.Routes = RoutesFromStr(fmt.Sprintf("nats://test@127.0.0.1:%d", clusterPort))
 	s2 := RunServer(opts2)
 	defer s2.Shutdown()
 	if nr := s2.NumRoutes(); nr != 0 {
 		t.Fatalf("Expected no route, got %v", nr)
 	}
+
 }


### PR DESCRIPTION
Add back a SetCustomClientAuth as a replacement for SetClientAuthMethod that was removed for 1.0.x.)

Resolves #476 (waiting for #434)
 
/cc @nats-io/core
