### PR TITLE
[FIXED] Override from command line not always working

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,9 +65,7 @@ func usage() {
 func main() {
 	// Create a FlagSet and sets the usage
 	fs := flag.NewFlagSet("nats-server", flag.ExitOnError)
-	fs.Usage = func() {
-		usage()
-	}
+	fs.Usage = usage
 
 	// Configure the options from the flags/config file
 	opts, err := server.ConfigureOptions(fs, os.Args[1:])

--- a/server/opts.go
+++ b/server/opts.go
@@ -1014,7 +1014,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string) (*Options, error) {
 
 	// Process signal control.
 	if signal != "" {
-		if err := processSignal(fs, signal); err != nil {
+		if err := processSignal(signal); err != nil {
 			return nil, err
 		}
 	}
@@ -1157,7 +1157,7 @@ func overrideCluster(opts *Options) error {
 	return nil
 }
 
-func processSignal(fs *flag.FlagSet, signal string) error {
+func processSignal(signal string) error {
 	var (
 		pid           string
 		commandAndPid = strings.Split(signal, "=")

--- a/server/server.go
+++ b/server/server.go
@@ -212,7 +212,7 @@ func ProcessCommandLineArgs(cmd *flag.FlagSet) (showVersion bool, showHelp bool,
 		case "help":
 			return false, true, nil
 		default:
-			return false, false, fmt.Errorf("Unrecognized command: %q\n", arg)
+			return false, false, fmt.Errorf("unrecognized command: %q", arg)
 		}
 	}
 


### PR DESCRIPTION
There were some cases where override would not work. Any command
line parameter that would be set to the type default value (false
for boolean, "" for string, etc) would not be taken into account.

I moved all the flags parsing and options configuration into
a new function, which may help reduce code duplication in
NATS Streaming.

The other advantage of moving this in a function is that it
can now be unit tested.

I am also removing call to `RemoveSelfReference()` which attempted
to remove a route to self, which has been already solved at runtime
with detecting and ignoring a route to self.

This function would be invoked only when routes were defined in
the configuration file, not in the command line parameter.

Removing this call also solves an user issue (#577)

Resolves #574
Resolves #577
