### PR TITLE
Remove for loop in parseSize to enable inlining

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2016 Apcera Inc. All rights reserved.
+// Copyright 2012-2017 Apcera Inc. All rights reserved.
 
 package server
 
@@ -20,16 +20,30 @@ const (
 )
 
 // parseSize expects decimal positive numbers. We
-// return -1 to signal error
+// return -1 to signal error.
 func parseSize(d []byte) (n int) {
-	if len(d) == 0 {
+	l := len(d)
+	if l == 0 {
 		return -1
 	}
-	for _, dec := range d {
-		if dec < asciiZero || dec > asciiNine {
-			return -1
-		}
-		n = n*10 + (int(dec) - asciiZero)
+	var (
+		i   int
+		dec byte
+	)
+
+	// Note: Use `goto` here to avoid for loop in order
+	// to have the function be inlined.
+	// See: https://github.com/golang/go/issues/14768
+loop:
+	dec = d[i]
+	if dec < asciiZero || dec > asciiNine {
+		return -1
+	}
+	n = n*10 + (int(dec) - asciiZero)
+
+	i++
+	if i < l {
+		goto loop
 	}
 	return n
 }


### PR DESCRIPTION
Using a `goto` based loop makes it become a leaf function which can be inlined, making us get a slight performance increase as this is in the fast path:

```
# before
go test ./... -gcflags="-m -m" -run TestParseSize -v 
...
server/util.go:24:6: cannot inline parseSize: unhandled op range

# after
go test ./... -gcflags="-m -m" -run TestParseSize -v
server/util.go:24:6: can inline parseSize as: func([]byte) int {...
```

Local benchmarks:

```
benchmark                           old ns/op     new ns/op     delta
BenchmarkParseSize-4                8.81          5.74          -34.85%
Benchmark_____Pub0b_Payload-4       92.9          85.6          -7.86%
Benchmark_____Pub8b_Payload-4       96.1          86.4          -10.09%
Benchmark____Pub32b_Payload-4       106           99.7          -5.94%
Benchmark___Pub128B_Payload-4       131           129           -1.53%
Benchmark___Pub256B_Payload-4       152           143           -5.92%
Benchmark_____Pub1K_Payload-4       348           329           -5.46%
Benchmark_____Pub4K_Payload-4       1474          1440          -2.31%
Benchmark_____Pub8K_Payload-4       3330          3305          -0.75%

benchmark                           old MB/s     new MB/s     speedup
BenchmarkParseSize-4                113.53       174.29       1.54x
Benchmark_____Pub0b_Payload-4       118.45       128.51       1.08x
Benchmark_____Pub8b_Payload-4       197.74       219.83       1.11x
Benchmark____Pub32b_Payload-4       413.47       441.53       1.07x
Benchmark___Pub128B_Payload-4       1072.63      1090.36      1.02x
Benchmark___Pub256B_Payload-4       1765.96      1878.76      1.06x
Benchmark_____Pub1K_Payload-4       2979.37      3150.57      1.06x
Benchmark_____Pub4K_Payload-4       2788.11      2852.61      1.02x
Benchmark_____Pub8K_Payload-4       2464.19      2482.35      1.01x
```

 - [x] Link to issue, e.g. `Resolves #NNN`
 - [x] Documentation added (if applicable)
 - [x] Tests added
 - [x] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)
 
/cc @nats-io/core
