### PR TITLE
Remove check for '\r\n' when processing pub args

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -679,7 +679,7 @@ func (c *client) processPub(arg []byte) error {
 	start := -1
 	for i, b := range arg {
 		switch b {
-		case ' ', '\t', '\r', '\n':
+		case ' ', '\t':
 			if start >= 0 {
 				args = append(args, arg[start:i])
 				start = -1


### PR DESCRIPTION
The parser has already dropped CRLF by when `processPub` [is called](https://github.com/nats-io/gnatsd/blob/master/server/parser.go#L167-L183), so we can skip doing these checks there.  This change also refactors the pub arg tests to use `t.Run` closure along with more checks for when parsing reply inboxes.

 - [x] Link to issue, e.g. `Resolves #NNN`
 - [x] Documentation added (if applicable)
 - [x] Tests added
 - [x] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

/cc @nats-io/core
