### PR TITLE
Add write_deadline configuration option [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ max_control_line: 512
 
 # maximum payload
 max_payload: 65536
+
+# Duration the server can block on a socket write to a client.  Exceeding the 
+# deadline will designate a client as a slow consumer.
+write_deadline: "2s"
 ```
 
 Inside configuration files, string values support the following escape characters: `\xXX, \t, \n, \r, \", \\`.  Take note that when specifying directory paths in options such as `pid_file` and `log_file` on Windows, you'll need to escape backslashes, e.g. `log_file:  "c:\\logging\\log.txt"`, or use unix style (`/`) path separators.


### PR DESCRIPTION
 - [X] Documentation added (if applicable)
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request: 

Add the write_deadline configuration option to the example configuration file.
 
/cc @nats-io/core
