### PR TITLE
Always Notify changes

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ Cluster Options:
         --routes <rurl-1, rurl-2>    Routes to solicit and connect
         --cluster <cluster-url>      Cluster URL for solicited routes
         --no_advertise <bool>        Advertise known cluster IPs to clients
+        --always_notify <bool>       Always notify clients when a server reconnects
         --connect_retries <number>   For implicit routes, number of connect retries
 
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -31,6 +31,7 @@ type ClusterOpts struct {
 	TLSConfig      *tls.Config `json:"-"`
 	ListenStr      string      `json:"-"`
 	NoAdvertise    bool        `json:"-"`
+	AlwaysNotify   bool        `json:"-"`
 	ConnectRetries int         `json:"-"`
 }
 
@@ -389,6 +390,8 @@ func parseCluster(cm map[string]interface{}, opts *Options) error {
 			opts.Cluster.TLSTimeout = tc.Timeout
 		case "no_advertise":
 			opts.Cluster.NoAdvertise = mv.(bool)
+		case "always_notify":
+			opts.Cluster.AlwaysNotify = mv.(bool)
 		case "connect_retries":
 			opts.Cluster.ConnectRetries = int(mv.(int64))
 		}
@@ -975,6 +978,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.StringVar(&opts.Cluster.ListenStr, "cluster", "", "Cluster url from which members can solicit routes.")
 	fs.StringVar(&opts.Cluster.ListenStr, "cluster_listen", "", "Cluster url from which members can solicit routes.")
 	fs.BoolVar(&opts.Cluster.NoAdvertise, "no_advertise", false, "Advertise known cluster IPs to clients.")
+	fs.BoolVar(&opts.Cluster.AlwaysNotify, "always_notify", false, "Always notify clients when a server connects to the cluster.")
 	fs.IntVar(&opts.Cluster.ConnectRetries, "connect_retries", 0, "For implicit routes, number of connect retries")
 	fs.BoolVar(&showTLSHelp, "help_tls", false, "TLS help.")
 	fs.BoolVar(&opts.TLS, "tls", false, "Enable TLS.")

--- a/server/route.go
+++ b/server/route.go
@@ -160,8 +160,9 @@ func (c *client) processRouteInfo(info *Info) {
 		// protocol to all clients that support it (unless the feature is disabled).
 		// Also send out the notification if the 'always notify' flag is on regardless
 		// of whether the server was already in the Server Info.
-		opts := s.getOpts()
-		if s.updateServerINFO(info.ClientConnectURLs) || opts.Cluster.AlwaysNotify {
+		// opts := s.getOpts()
+		// if s.updateServerINFO(info.ClientConnectURLs) || opts.Cluster.AlwaysNotify {
+		if s.updateServerINFO(info.ClientConnectURLs) {
 			s.sendAsyncInfoToClients()
 		}
 	} else {

--- a/server/route.go
+++ b/server/route.go
@@ -158,7 +158,10 @@ func (c *client) processRouteInfo(info *Info) {
 		}
 		// If the server Info did not have these URLs, update and send an INFO
 		// protocol to all clients that support it (unless the feature is disabled).
-		if s.updateServerINFO(info.ClientConnectURLs) {
+		// Also send out the notification if the 'always notify' flag is on regardless
+		// of whether the server was already in the Server Info.
+		opts := s.getOpts()
+		if s.updateServerINFO(info.ClientConnectURLs) || opts.Cluster.AlwaysNotify {
 			s.sendAsyncInfoToClients()
 		}
 	} else {

--- a/server/route.go
+++ b/server/route.go
@@ -158,10 +158,6 @@ func (c *client) processRouteInfo(info *Info) {
 		}
 		// If the server Info did not have these URLs, update and send an INFO
 		// protocol to all clients that support it (unless the feature is disabled).
-		// Also send out the notification if the 'always notify' flag is on regardless
-		// of whether the server was already in the Server Info.
-		// opts := s.getOpts()
-		// if s.updateServerINFO(info.ClientConnectURLs) || opts.Cluster.AlwaysNotify {
 		if s.updateServerINFO(info.ClientConnectURLs) {
 			s.sendAsyncInfoToClients()
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -787,7 +787,7 @@ func (s *Server) updateServerINFO(urls []string) bool {
 	if wasUpdated {
 		s.generateServerInfoJSON()
 	}
-	
+
 	// If notification of server additions is always allowed
 	// then always return true, regardless of whether the URL
 	// list is updated or not

--- a/server/server.go
+++ b/server/server.go
@@ -793,7 +793,6 @@ func (s *Server) updateServerINFO(urls []string) bool {
 	// If notification of server additions is always allowed
 	// then always return true, regardless of whether the URL
 	// list is updated or not
-	//
 	// This means that we will send the INFO protocol even if
 	// its content was not updated
 	if cluster.AlwaysNotify {

--- a/server/server.go
+++ b/server/server.go
@@ -774,16 +774,6 @@ func (s *Server) updateServerINFO(urls []string) bool {
 		return false
 	}
 
-	// If notification of server additions is always allowed
-	// then always return true, regardless of whether the URL
-	// list is updated or not
-	//
-	// This means that we will send the INFO protocol even if
-	// its content was not updated
-	if s.getOpts().Cluster.AlwaysNotify {
-		return true
-	}
-
 	// Will be set to true if we alter the server's Info object.
 	wasUpdated := false
 	for _, url := range urls {
@@ -796,6 +786,16 @@ func (s *Server) updateServerINFO(urls []string) bool {
 	}
 	if wasUpdated {
 		s.generateServerInfoJSON()
+	}
+	
+	// If notification of server additions is always allowed
+	// then always return true, regardless of whether the URL
+	// list is updated or not
+	//
+	// This means that we will send the INFO protocol even if
+	// its content was not updated
+	if s.getOpts().Cluster.AlwaysNotify {
+		wasUpdated = true
 	}
 
 	return wasUpdated

--- a/server/server.go
+++ b/server/server.go
@@ -769,8 +769,10 @@ func (s *Server) updateServerINFO(urls []string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	cluster := s.getOps().Cluster
+
 	// Feature disabled, do not update.
-	if s.getOpts().Cluster.NoAdvertise {
+	if cluster.NoAdvertise {
 		return false
 	}
 
@@ -794,7 +796,7 @@ func (s *Server) updateServerINFO(urls []string) bool {
 	//
 	// This means that we will send the INFO protocol even if
 	// its content was not updated
-	if s.getOpts().Cluster.AlwaysNotify {
+	if cluster.AlwaysNotify {
 		wasUpdated = true
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -769,7 +769,7 @@ func (s *Server) updateServerINFO(urls []string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	cluster := s.getOps().Cluster
+	cluster := s.getOpts().Cluster
 
 	// Feature disabled, do not update.
 	if cluster.NoAdvertise {

--- a/server/server.go
+++ b/server/server.go
@@ -783,7 +783,9 @@ func (s *Server) updateServerINFO(urls []string) bool {
 	}
 
 	// If notification of server additions is always allowed
-	// Set wasUpdated to true so that the notification gets sent.
+	// set wasUpdated to true so that the notification gets sent.
+	// This means that we will send the INFO protocol even if
+	// its content was not updated
 	if s.getOpts().Cluster.AlwaysNotify {
             return true
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -787,7 +787,7 @@ func (s *Server) updateServerINFO(urls []string) bool {
 	// This means that we will send the INFO protocol even if
 	// its content was not updated
 	if s.getOpts().Cluster.AlwaysNotify {
-            return true
+		return true
 	}
 
 	return wasUpdated

--- a/server/server.go
+++ b/server/server.go
@@ -758,7 +758,13 @@ func (s *Server) createClient(conn net.Conn) *client {
 // array of URLs and re-generate the infoJSON byte array, only if the
 // given URLs were not already recorded and if the feature is not
 // disabled.
+//
 // Returns a boolean indicating if server's Info was updated.
+//
+// If the 'AlwaysNotify' flag is set in the options, this
+// function will also return 'true' after the 'NoAdvertise'
+// check is made.
+//
 func (s *Server) updateServerINFO(urls []string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -766,6 +772,16 @@ func (s *Server) updateServerINFO(urls []string) bool {
 	// Feature disabled, do not update.
 	if s.getOpts().Cluster.NoAdvertise {
 		return false
+	}
+
+	// If notification of server additions is always allowed
+	// then always return true, regardless of whether the URL
+	// list is updated or not
+	//
+	// This means that we will send the INFO protocol even if
+	// its content was not updated
+	if s.getOpts().Cluster.AlwaysNotify {
+		return true
 	}
 
 	// Will be set to true if we alter the server's Info object.
@@ -780,14 +796,6 @@ func (s *Server) updateServerINFO(urls []string) bool {
 	}
 	if wasUpdated {
 		s.generateServerInfoJSON()
-	}
-
-	// If notification of server additions is always allowed
-	// set wasUpdated to true so that the notification gets sent.
-	// This means that we will send the INFO protocol even if
-	// its content was not updated
-	if s.getOpts().Cluster.AlwaysNotify {
-		return true
 	}
 
 	return wasUpdated

--- a/server/server.go
+++ b/server/server.go
@@ -781,6 +781,13 @@ func (s *Server) updateServerINFO(urls []string) bool {
 	if wasUpdated {
 		s.generateServerInfoJSON()
 	}
+
+	// If notification of server additions is always allowed
+	// Set wasUpdated to true so that the notification gets sent.
+	if s.getOpts().Cluster.AlwaysNotify {
+            return true
+	}
+
 	return wasUpdated
 }
 


### PR DESCRIPTION

 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)


### Changes proposed in this pull request: 

This is a quick modification to the server notification behavior in cluster mode.

As the server code currently stands, the clients are not notified if a previously existing server rejoins the cluster.  I am proposing that a server option ("--always_notify") be added to the option list so that all clients in the cluster will _always_ be notified of any topology change via the INFO message which will carry the updated server list.  

This would allow the clients to decide if they wish to switch their connections back over to the recovered 'local' server node.

### Who Benefits From The Change(s)?

Applications using physically dispersed server nodes in mesh mode would benefit by allowing clients to reconnect to the 'nearest' (network wise) server as soon as it becomes re-enabled for better performance.

This pull request is an example of how it might be accomplished.
 
/cc @nats-io/core
