### PR TITLE
Update Go version to 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
 - 1.7.x
-- 1.8.x
-- 1.9.x
+- 1.8.5
+- 1.9.2
 install:
 - go get github.com/nats-io/go-nats
 - go get github.com/mattn/goveralls
@@ -16,9 +16,9 @@ before_script:
 - go vet $EXCLUDE_VENDOR
 - misspell -error -locale US .
 - megacheck $EXCLUDE_VENDOR
-- if [[ "$TRAVIS_GO_VERSION" == 1.8.* ]]; then ./scripts/cross_compile.sh $TRAVIS_TAG; fi
+- if [[ "$TRAVIS_GO_VERSION" == 1.9.* ]]; then ./scripts/cross_compile.sh $TRAVIS_TAG; fi
 script:
 - go test -i -race $EXCLUDE_VENDOR
-- if [[ "$TRAVIS_GO_VERSION" == 1.8.* ]]; then ./scripts/cov.sh TRAVIS; else go test -v -race $EXCLUDE_VENDOR; fi
+- if [[ "$TRAVIS_GO_VERSION" == 1.9.* ]]; then ./scripts/cov.sh TRAVIS; else go test -v -race $EXCLUDE_VENDOR; fi
 after_success:
-- if [[ "$TRAVIS_GO_VERSION" == 1.8.* ]] && [ "$TRAVIS_TAG" != "" ]; then ghr --owner nats-io --token $GITHUB_TOKEN --draft --replace $TRAVIS_TAG pkg/; fi
+- if [[ "$TRAVIS_GO_VERSION" == 1.9.* ]] && [ "$TRAVIS_TAG" != "" ]; then ghr --owner nats-io --token $GITHUB_TOKEN --draft --replace $TRAVIS_TAG pkg/; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3
+FROM golang:1.9.2
 
 MAINTAINER Derek Collison <derek@apcera.com>
 

--- a/Dockerfile.all
+++ b/Dockerfile.all
@@ -1,4 +1,4 @@
-FROM golang:1.8.3
+FROM golang:1.9.2
 
 MAINTAINER Ivan Kozlovic <ivan.kozlovic@apcera.com>
 


### PR DESCRIPTION
Updated travis to use 1.8.5 and 1.9.2 and build/push release
for 1.9.2 release.
Updated Docker files too.
