### PR TITLE
[FIXED] Connz would "block" for TLS clients still in TLS handshake

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -53,9 +53,10 @@ type clientFlag byte
 
 // Some client state represented as flags
 const (
-	connectReceived clientFlag = 1 << iota // The CONNECT proto has been received
-	firstPongSent                          // The first PONG has been sent
-	infoUpdated                            // The server's Info object has changed before first PONG was sent
+	connectReceived   clientFlag = 1 << iota // The CONNECT proto has been received
+	firstPongSent                            // The first PONG has been sent
+	infoUpdated                              // The server's Info object has changed before first PONG was sent
+	handshakeComplete                        // For TLS clients, indicate that the handshake is complete
 )
 
 // set the flag (would be equivalent to set the boolean to true)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -208,7 +208,9 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// If the connection is gone, too bad, we won't set TLSVersion and TLSCipher.
-		if tlsRequired && client.nc != nil {
+		// Exclude clients that are still doing handshake so we don't block in
+		// ConnectionState().
+		if tlsRequired && client.flags.isSet(handshakeComplete) && client.nc != nil {
 			conn := client.nc.(*tls.Conn)
 			cs := conn.ConnectionState()
 			ci.TLSVersion = tlsVersion(cs.Version)

--- a/server/server.go
+++ b/server/server.go
@@ -715,6 +715,9 @@ func (s *Server) createClient(conn net.Conn) *client {
 
 		// Re-Grab lock
 		c.mu.Lock()
+
+		// Indicate that handshake is complete (used in monitoring)
+		c.flags.set(handshakeComplete)
 	}
 
 	// The connection may have been closed


### PR DESCRIPTION
If server requires TLS and clients are connecting, and a Connz
request is made while clients are still in TLS Handshake, the
call to tls.Conn.ConnectionState() would block for the duration
of the handshake. This would cause the overall http request to
take too long.
We will now not try to gather TLSVersion and TLSCipher from a
client that is still in TLS handshake.

Resolves #600
