### PR TITLE
[ADDED] Client and Cluster Advertise. Issue #447

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ Server Options:
     -ms,--https_port <port>          Use port for https monitoring
     -c, --config <file>              Configuration file
     -sl,--signal <signal>[=<pid>]    Send signal to gnatsd process (stop, quit, reopen, reload)
+        --client_advertise <string>  Client URL to advertise to other servers
 
 Logging Options:
     -l, --log <file>                 File to redirect log output
@@ -47,6 +48,7 @@ Cluster Options:
         --routes <rurl-1, rurl-2>    Routes to solicit and connect
         --cluster <cluster-url>      Cluster URL for solicited routes
         --no_advertise <bool>        Advertise known cluster IPs to clients
+        --cluster_advertise <string> Cluster URL to advertise to other servers
         --connect_retries <number>   For implicit routes, number of connect retries
 
 

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/nats-io/gnatsd/logger"
@@ -64,28 +65,41 @@ func TestSetLogger(t *testing.T) {
 }
 
 type DummyLogger struct {
+	sync.Mutex
 	msg string
 }
 
-func (dl *DummyLogger) checkContent(t *testing.T, expectedStr string) {
-	if dl.msg != expectedStr {
-		stackFatalf(t, "Expected log to be: %v, got %v", expectedStr, dl.msg)
+func (l *DummyLogger) checkContent(t *testing.T, expectedStr string) {
+	l.Lock()
+	defer l.Unlock()
+	if l.msg != expectedStr {
+		stackFatalf(t, "Expected log to be: %v, got %v", expectedStr, l.msg)
 	}
 }
 
 func (l *DummyLogger) Noticef(format string, v ...interface{}) {
+	l.Lock()
+	defer l.Unlock()
 	l.msg = fmt.Sprintf(format, v...)
 }
 func (l *DummyLogger) Errorf(format string, v ...interface{}) {
+	l.Lock()
+	defer l.Unlock()
 	l.msg = fmt.Sprintf(format, v...)
 }
 func (l *DummyLogger) Fatalf(format string, v ...interface{}) {
+	l.Lock()
+	defer l.Unlock()
 	l.msg = fmt.Sprintf(format, v...)
 }
 func (l *DummyLogger) Debugf(format string, v ...interface{}) {
+	l.Lock()
+	defer l.Unlock()
 	l.msg = fmt.Sprintf(format, v...)
 }
 func (l *DummyLogger) Tracef(format string, v ...interface{}) {
+	l.Lock()
+	defer l.Unlock()
 	l.msg = fmt.Sprintf(format, v...)
 }
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -22,17 +22,18 @@ import (
 
 // ClusterOpts are options for clusters.
 type ClusterOpts struct {
-	Host           string      `json:"addr"`
-	Port           int         `json:"cluster_port"`
-	Username       string      `json:"-"`
-	Password       string      `json:"-"`
-	AuthTimeout    float64     `json:"auth_timeout"`
-	TLSTimeout     float64     `json:"-"`
-	TLSConfig      *tls.Config `json:"-"`
-	ListenStr      string      `json:"-"`
-	AdvertiseStr   string      `json:"-"`
-	NoAdvertise    bool        `json:"-"`
-	ConnectRetries int         `json:"-"`
+	Host                string      `json:"addr"`
+	Port                int         `json:"cluster_port"`
+	Username            string      `json:"-"`
+	Password            string      `json:"-"`
+	AuthTimeout         float64     `json:"auth_timeout"`
+	TLSTimeout          float64     `json:"-"`
+	TLSConfig           *tls.Config `json:"-"`
+	ListenStr           string      `json:"-"`
+	ClientAdvertiseStr  string      `json:"-"`
+	ClusterAdvertiseStr string      `json:"-"`
+	NoAdvertise         bool        `json:"-"`
+	ConnectRetries      int         `json:"-"`
 }
 
 // Options block for gnatsd server.
@@ -388,8 +389,8 @@ func parseCluster(cm map[string]interface{}, opts *Options) error {
 			opts.Cluster.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
 			opts.Cluster.TLSConfig.RootCAs = opts.Cluster.TLSConfig.ClientCAs
 			opts.Cluster.TLSTimeout = tc.Timeout
-		case "cluster_advertise":
-			opts.Cluster.AdvertiseStr = mv.(string)
+		case "cluster_client_advertise":
+			opts.Cluster.ClientAdvertiseStr = mv.(string)
 		case "no_advertise":
 			opts.Cluster.NoAdvertise = mv.(bool)
 		case "connect_retries":
@@ -756,8 +757,8 @@ func MergeOptions(fileOpts, flagOpts *Options) *Options {
 	if flagOpts.Cluster.ListenStr != "" {
 		opts.Cluster.ListenStr = flagOpts.Cluster.ListenStr
 	}
-	if flagOpts.Cluster.AdvertiseStr != "" {
-		opts.Cluster.AdvertiseStr = flagOpts.Cluster.AdvertiseStr
+	if flagOpts.Cluster.ClientAdvertiseStr != "" {
+		opts.Cluster.ClientAdvertiseStr = flagOpts.Cluster.ClientAdvertiseStr
 	}
 	if flagOpts.Cluster.NoAdvertise {
 		opts.Cluster.NoAdvertise = true
@@ -980,7 +981,8 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.StringVar(&opts.RoutesStr, "routes", "", "Routes to actively solicit a connection.")
 	fs.StringVar(&opts.Cluster.ListenStr, "cluster", "", "Cluster url from which members can solicit routes.")
 	fs.StringVar(&opts.Cluster.ListenStr, "cluster_listen", "", "Cluster url from which members can solicit routes.")
-	fs.StringVar(&opts.Cluster.AdvertiseStr, "cluster_advertise", "", "Cluster URL sent on info for use with proxied connections.")
+	fs.StringVar(&opts.Cluster.ClientAdvertiseStr, "cluster_client_advertise", "", "Client url(s) for discovered servers.")
+	fs.StringVar(&opts.Cluster.ClusterAdvertiseStr, "cluster_advertise", "", "Cluster url(s) for discovered servers.")
 	fs.BoolVar(&opts.Cluster.NoAdvertise, "no_advertise", false, "Advertise known cluster IPs to clients.")
 	fs.IntVar(&opts.Cluster.ConnectRetries, "connect_retries", 0, "For implicit routes, number of connect retries")
 	fs.BoolVar(&showTLSHelp, "help_tls", false, "TLS help.")

--- a/server/opts.go
+++ b/server/opts.go
@@ -30,7 +30,7 @@ type ClusterOpts struct {
 	TLSTimeout     float64     `json:"-"`
 	TLSConfig      *tls.Config `json:"-"`
 	ListenStr      string      `json:"-"`
-	RouteAdvertise string      `json:"-"`
+	Advertise      string      `json:"-"`
 	NoAdvertise    bool        `json:"-"`
 	ConnectRetries int         `json:"-"`
 }
@@ -391,8 +391,8 @@ func parseCluster(cm map[string]interface{}, opts *Options) error {
 			opts.Cluster.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
 			opts.Cluster.TLSConfig.RootCAs = opts.Cluster.TLSConfig.ClientCAs
 			opts.Cluster.TLSTimeout = tc.Timeout
-		case "route_advertise":
-			opts.Cluster.RouteAdvertise = mv.(string)
+		case "cluster_advertise", "advertise":
+			opts.Cluster.Advertise = mv.(string)
 		case "no_advertise":
 			opts.Cluster.NoAdvertise = mv.(bool)
 		case "connect_retries":
@@ -768,6 +768,9 @@ func MergeOptions(fileOpts, flagOpts *Options) *Options {
 	if flagOpts.Cluster.ConnectRetries != 0 {
 		opts.Cluster.ConnectRetries = flagOpts.Cluster.ConnectRetries
 	}
+	if flagOpts.Cluster.Advertise != "" {
+		opts.Cluster.Advertise = flagOpts.Cluster.Advertise
+	}
 	if flagOpts.RoutesStr != "" {
 		mergeRoutes(&opts, flagOpts)
 	}
@@ -951,7 +954,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.StringVar(&opts.Host, "addr", "", "Network host to listen on.")
 	fs.StringVar(&opts.Host, "a", "", "Network host to listen on.")
 	fs.StringVar(&opts.Host, "net", "", "Network host to listen on.")
-	fs.StringVar(&opts.ClientAdvertise, "client_advertise", "", "Client url for discovered servers.")
+	fs.StringVar(&opts.ClientAdvertise, "client_advertise", "", "Client URL to advertise to other servers.")
 	fs.BoolVar(&opts.Debug, "D", false, "Enable Debug logging.")
 	fs.BoolVar(&opts.Debug, "debug", false, "Enable Debug logging.")
 	fs.BoolVar(&opts.Trace, "V", false, "Enable Trace logging.")
@@ -984,7 +987,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.StringVar(&opts.RoutesStr, "routes", "", "Routes to actively solicit a connection.")
 	fs.StringVar(&opts.Cluster.ListenStr, "cluster", "", "Cluster url from which members can solicit routes.")
 	fs.StringVar(&opts.Cluster.ListenStr, "cluster_listen", "", "Cluster url from which members can solicit routes.")
-	fs.StringVar(&opts.Cluster.RouteAdvertise, "route_advertise", "", "Cluster url(s) for discovered servers.")
+	fs.StringVar(&opts.Cluster.Advertise, "cluster_advertise", "", "Cluster URL to advertise to other servers.")
 	fs.BoolVar(&opts.Cluster.NoAdvertise, "no_advertise", false, "Advertise known cluster IPs to clients.")
 	fs.IntVar(&opts.Cluster.ConnectRetries, "connect_retries", 0, "For implicit routes, number of connect retries")
 	fs.BoolVar(&showTLSHelp, "help_tls", false, "TLS help.")

--- a/server/opts.go
+++ b/server/opts.go
@@ -22,59 +22,59 @@ import (
 
 // ClusterOpts are options for clusters.
 type ClusterOpts struct {
-	Host                string      `json:"addr"`
-	Port                int         `json:"cluster_port"`
-	Username            string      `json:"-"`
-	Password            string      `json:"-"`
-	AuthTimeout         float64     `json:"auth_timeout"`
-	TLSTimeout          float64     `json:"-"`
-	TLSConfig           *tls.Config `json:"-"`
-	ListenStr           string      `json:"-"`
-	ClientAdvertiseStr  string      `json:"-"`
-	ClusterAdvertiseStr string      `json:"-"`
-	NoAdvertise         bool        `json:"-"`
-	ConnectRetries      int         `json:"-"`
+	Host           string      `json:"addr"`
+	Port           int         `json:"cluster_port"`
+	Username       string      `json:"-"`
+	Password       string      `json:"-"`
+	AuthTimeout    float64     `json:"auth_timeout"`
+	TLSTimeout     float64     `json:"-"`
+	TLSConfig      *tls.Config `json:"-"`
+	ListenStr      string      `json:"-"`
+	RouteAdvertise string      `json:"-"`
+	NoAdvertise    bool        `json:"-"`
+	ConnectRetries int         `json:"-"`
 }
 
 // Options block for gnatsd server.
 type Options struct {
-	ConfigFile     string        `json:"-"`
-	Host           string        `json:"addr"`
-	Port           int           `json:"port"`
-	Trace          bool          `json:"-"`
-	Debug          bool          `json:"-"`
-	NoLog          bool          `json:"-"`
-	NoSigs         bool          `json:"-"`
-	Logtime        bool          `json:"-"`
-	MaxConn        int           `json:"max_connections"`
-	Users          []*User       `json:"-"`
-	Username       string        `json:"-"`
-	Password       string        `json:"-"`
-	Authorization  string        `json:"-"`
-	PingInterval   time.Duration `json:"ping_interval"`
-	MaxPingsOut    int           `json:"ping_max"`
-	HTTPHost       string        `json:"http_host"`
-	HTTPPort       int           `json:"http_port"`
-	HTTPSPort      int           `json:"https_port"`
-	AuthTimeout    float64       `json:"auth_timeout"`
-	MaxControlLine int           `json:"max_control_line"`
-	MaxPayload     int           `json:"max_payload"`
-	Cluster        ClusterOpts   `json:"cluster"`
-	ProfPort       int           `json:"-"`
-	PidFile        string        `json:"-"`
-	LogFile        string        `json:"-"`
-	Syslog         bool          `json:"-"`
-	RemoteSyslog   string        `json:"-"`
-	Routes         []*url.URL    `json:"-"`
-	RoutesStr      string        `json:"-"`
-	TLSTimeout     float64       `json:"tls_timeout"`
-	TLS            bool          `json:"-"`
-	TLSVerify      bool          `json:"-"`
-	TLSCert        string        `json:"-"`
-	TLSKey         string        `json:"-"`
-	TLSCaCert      string        `json:"-"`
-	TLSConfig      *tls.Config   `json:"-"`
-	WriteDeadline  time.Duration `json:"-"`
+	ConfigFile      string        `json:"-"`
+	Host            string        `json:"addr"`
+	Port            int           `json:"port"`
+	ClientAdvertise string        `json:"-"`
+	Trace           bool          `json:"-"`
+	Debug           bool          `json:"-"`
+	NoLog           bool          `json:"-"`
+	NoSigs          bool          `json:"-"`
+	Logtime         bool          `json:"-"`
+	MaxConn         int           `json:"max_connections"`
+	Users           []*User       `json:"-"`
+	Username        string        `json:"-"`
+	Password        string        `json:"-"`
+	Authorization   string        `json:"-"`
+	PingInterval    time.Duration `json:"ping_interval"`
+	MaxPingsOut     int           `json:"ping_max"`
+	HTTPHost        string        `json:"http_host"`
+	HTTPPort        int           `json:"http_port"`
+	HTTPSPort       int           `json:"https_port"`
+	AuthTimeout     float64       `json:"auth_timeout"`
+	MaxControlLine  int           `json:"max_control_line"`
+	MaxPayload      int           `json:"max_payload"`
+	Cluster         ClusterOpts   `json:"cluster"`
+	ProfPort        int           `json:"-"`
+	PidFile         string        `json:"-"`
+	LogFile         string        `json:"-"`
+	Syslog          bool          `json:"-"`
+	RemoteSyslog    string        `json:"-"`
+	Routes          []*url.URL    `json:"-"`
+	RoutesStr       string        `json:"-"`
+	TLSTimeout      float64       `json:"tls_timeout"`
+	TLS             bool          `json:"-"`
+	TLSVerify       bool          `json:"-"`
+	TLSCert         string        `json:"-"`
+	TLSKey          string        `json:"-"`
+	TLSCaCert       string        `json:"-"`
+	TLSConfig       *tls.Config   `json:"-"`
+	WriteDeadline   time.Duration `json:"-"`
 
 	CustomClientAuthentication Authentication `json:"-"`
 	CustomRouterAuthentication Authentication `json:"-"`
@@ -204,6 +204,8 @@ func (o *Options) ProcessConfigFile(configFile string) error {
 			}
 			o.Host = hp.host
 			o.Port = hp.port
+		case "client_advertise":
+			o.ClientAdvertise = v.(string)
 		case "port":
 			o.Port = int(v.(int64))
 		case "host", "net":
@@ -389,8 +391,8 @@ func parseCluster(cm map[string]interface{}, opts *Options) error {
 			opts.Cluster.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
 			opts.Cluster.TLSConfig.RootCAs = opts.Cluster.TLSConfig.ClientCAs
 			opts.Cluster.TLSTimeout = tc.Timeout
-		case "cluster_client_advertise":
-			opts.Cluster.ClientAdvertiseStr = mv.(string)
+		case "route_advertise":
+			opts.Cluster.RouteAdvertise = mv.(string)
 		case "no_advertise":
 			opts.Cluster.NoAdvertise = mv.(bool)
 		case "connect_retries":
@@ -724,6 +726,9 @@ func MergeOptions(fileOpts, flagOpts *Options) *Options {
 	if flagOpts.Host != "" {
 		opts.Host = flagOpts.Host
 	}
+	if flagOpts.ClientAdvertise != "" {
+		opts.ClientAdvertise = flagOpts.ClientAdvertise
+	}
 	if flagOpts.Username != "" {
 		opts.Username = flagOpts.Username
 	}
@@ -756,9 +761,6 @@ func MergeOptions(fileOpts, flagOpts *Options) *Options {
 	}
 	if flagOpts.Cluster.ListenStr != "" {
 		opts.Cluster.ListenStr = flagOpts.Cluster.ListenStr
-	}
-	if flagOpts.Cluster.ClientAdvertiseStr != "" {
-		opts.Cluster.ClientAdvertiseStr = flagOpts.Cluster.ClientAdvertiseStr
 	}
 	if flagOpts.Cluster.NoAdvertise {
 		opts.Cluster.NoAdvertise = true
@@ -949,6 +951,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.StringVar(&opts.Host, "addr", "", "Network host to listen on.")
 	fs.StringVar(&opts.Host, "a", "", "Network host to listen on.")
 	fs.StringVar(&opts.Host, "net", "", "Network host to listen on.")
+	fs.StringVar(&opts.ClientAdvertise, "client_advertise", "", "Client url for discovered servers.")
 	fs.BoolVar(&opts.Debug, "D", false, "Enable Debug logging.")
 	fs.BoolVar(&opts.Debug, "debug", false, "Enable Debug logging.")
 	fs.BoolVar(&opts.Trace, "V", false, "Enable Trace logging.")
@@ -981,8 +984,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.StringVar(&opts.RoutesStr, "routes", "", "Routes to actively solicit a connection.")
 	fs.StringVar(&opts.Cluster.ListenStr, "cluster", "", "Cluster url from which members can solicit routes.")
 	fs.StringVar(&opts.Cluster.ListenStr, "cluster_listen", "", "Cluster url from which members can solicit routes.")
-	fs.StringVar(&opts.Cluster.ClientAdvertiseStr, "cluster_client_advertise", "", "Client url(s) for discovered servers.")
-	fs.StringVar(&opts.Cluster.ClusterAdvertiseStr, "cluster_advertise", "", "Cluster url(s) for discovered servers.")
+	fs.StringVar(&opts.Cluster.RouteAdvertise, "route_advertise", "", "Cluster url(s) for discovered servers.")
 	fs.BoolVar(&opts.Cluster.NoAdvertise, "no_advertise", false, "Advertise known cluster IPs to clients.")
 	fs.IntVar(&opts.Cluster.ConnectRetries, "connect_retries", 0, "For implicit routes, number of connect retries")
 	fs.BoolVar(&showTLSHelp, "help_tls", false, "TLS help.")

--- a/server/opts.go
+++ b/server/opts.go
@@ -30,6 +30,7 @@ type ClusterOpts struct {
 	TLSTimeout     float64     `json:"-"`
 	TLSConfig      *tls.Config `json:"-"`
 	ListenStr      string      `json:"-"`
+	AdvertiseStr   string      `json:"-"`
 	NoAdvertise    bool        `json:"-"`
 	ConnectRetries int         `json:"-"`
 }
@@ -387,6 +388,8 @@ func parseCluster(cm map[string]interface{}, opts *Options) error {
 			opts.Cluster.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
 			opts.Cluster.TLSConfig.RootCAs = opts.Cluster.TLSConfig.ClientCAs
 			opts.Cluster.TLSTimeout = tc.Timeout
+		case "cluster_advertise":
+			opts.Cluster.AdvertiseStr = mv.(string)
 		case "no_advertise":
 			opts.Cluster.NoAdvertise = mv.(bool)
 		case "connect_retries":
@@ -753,6 +756,9 @@ func MergeOptions(fileOpts, flagOpts *Options) *Options {
 	if flagOpts.Cluster.ListenStr != "" {
 		opts.Cluster.ListenStr = flagOpts.Cluster.ListenStr
 	}
+	if flagOpts.Cluster.AdvertiseStr != "" {
+		opts.Cluster.AdvertiseStr = flagOpts.Cluster.AdvertiseStr
+	}
 	if flagOpts.Cluster.NoAdvertise {
 		opts.Cluster.NoAdvertise = true
 	}
@@ -974,6 +980,7 @@ func ConfigureOptions(fs *flag.FlagSet, args []string, printVersion, printHelp, 
 	fs.StringVar(&opts.RoutesStr, "routes", "", "Routes to actively solicit a connection.")
 	fs.StringVar(&opts.Cluster.ListenStr, "cluster", "", "Cluster url from which members can solicit routes.")
 	fs.StringVar(&opts.Cluster.ListenStr, "cluster_listen", "", "Cluster url from which members can solicit routes.")
+	fs.StringVar(&opts.Cluster.AdvertiseStr, "cluster_advertise", "", "Cluster URL sent on info for use with proxied connections.")
 	fs.BoolVar(&opts.Cluster.NoAdvertise, "no_advertise", false, "Advertise known cluster IPs to clients.")
 	fs.IntVar(&opts.Cluster.ConnectRetries, "connect_retries", 0, "For implicit routes, number of connect retries")
 	fs.BoolVar(&showTLSHelp, "help_tls", false, "TLS help.")
@@ -1171,6 +1178,7 @@ func overrideCluster(opts *Options) error {
 		opts.Cluster.Username = ""
 		opts.Cluster.Password = ""
 	}
+
 	return nil
 }
 

--- a/server/route.go
+++ b/server/route.go
@@ -143,7 +143,9 @@ func (c *client) processRouteInfo(info *Info) {
 		// Send our local subscriptions to this route.
 		s.sendLocalSubsToRoute(c)
 		if sendInfo {
-			// If IP isn't already set on info
+			// The incoming INFO from the route will have IP set
+			// if it has Cluster.Advertise. In that case, use that
+			// otherwise contruct it from the remote TCP address.
 			if info.IP == "" {
 				// Need to get the remote IP address.
 				c.mu.Lock()
@@ -614,6 +616,12 @@ func (s *Server) broadcastUnSubscribe(sub *subscription) {
 }
 
 func (s *Server) routeAcceptLoop(ch chan struct{}) {
+	defer func() {
+		if ch != nil {
+			close(ch)
+		}
+	}()
+
 	// Snapshot server options.
 	opts := s.getOpts()
 
@@ -633,34 +641,16 @@ func (s *Server) routeAcceptLoop(ch chan struct{}) {
 	s.Noticef("Listening for route connections on %s", hp)
 	l, e := net.Listen("tcp", hp)
 	if e != nil {
-		// We need to close this channel to avoid a deadlock
-		close(ch)
 		s.Fatalf("Error listening on router port: %d - %v", opts.Cluster.Port, e)
 		return
 	}
 
+	s.mu.Lock()
 	// Check for TLSConfig
 	tlsReq := opts.Cluster.TLSConfig != nil
-	// Configure Cluster Advertise Address
-	host := opts.Cluster.Host
-	port = l.Addr().(*net.TCPAddr).Port
-	ip := ""
-	if opts.Cluster.RouteAdvertise != "" {
-		advHost, advPort, err := parseHostPort(opts.Cluster.RouteAdvertise, port)
-		if err != nil {
-			s.Errorf("setting RouteAdvertise failed %v", err)
-		} else {
-			host = advHost
-			port = advPort
-		}
-		ip = fmt.Sprintf("nats-route://%s/", net.JoinHostPort(advHost, strconv.Itoa(advPort)))
-	}
 	info := Info{
 		ID:                s.info.ID,
 		Version:           s.info.Version,
-		Host:              host,
-		Port:              port,
-		IP:                ip,
 		AuthRequired:      false,
 		TLSRequired:       tlsReq,
 		SSLRequired:       tlsReq,
@@ -668,20 +658,33 @@ func (s *Server) routeAcceptLoop(ch chan struct{}) {
 		MaxPayload:        s.info.MaxPayload,
 		ClientConnectURLs: clientConnectURLs,
 	}
+	// If we have selected a random port...
+	if port == 0 {
+		// Write resolved port back to options.
+		opts.Cluster.Port = l.Addr().(*net.TCPAddr).Port
+	}
+	// Keep track of actual listen port. This will be needed in case of
+	// config reload.
+	s.clusterActualPort = opts.Cluster.Port
 	// Check for Auth items
 	if opts.Cluster.Username != "" {
 		info.AuthRequired = true
 	}
 	s.routeInfo = info
-	s.generateRouteInfoJSON()
-
+	// Possibly override Host/Port and set IP based on Cluster.Advertise
+	if err := s.setRouteInfoHostPortAndIP(); err != nil {
+		s.Fatalf("Error setting route INFO with Cluster.Advertise value of %s, err=%v", s.opts.Cluster.Advertise, err)
+		l.Close()
+		s.mu.Unlock()
+		return
+	}
 	// Setup state that can enable shutdown
-	s.mu.Lock()
 	s.routeListener = l
 	s.mu.Unlock()
 
 	// Let them know we are up
 	close(ch)
+	ch = nil
 
 	tmpDelay := ACCEPT_MIN_SLEEP
 
@@ -709,6 +712,26 @@ func (s *Server) routeAcceptLoop(ch chan struct{}) {
 	}
 	s.Debugf("Router accept loop exiting..")
 	s.done <- true
+}
+
+// Similar to setInfoHostPortAndGenerateJSON, but for routeInfo.
+func (s *Server) setRouteInfoHostPortAndIP() error {
+	if s.opts.Cluster.Advertise != "" {
+		advHost, advPort, err := parseHostPort(s.opts.Cluster.Advertise, s.opts.Cluster.Port)
+		if err != nil {
+			return err
+		}
+		s.routeInfo.Host = advHost
+		s.routeInfo.Port = advPort
+		s.routeInfo.IP = fmt.Sprintf("nats-route://%s/", net.JoinHostPort(advHost, strconv.Itoa(advPort)))
+	} else {
+		s.routeInfo.Host = s.opts.Cluster.Host
+		s.routeInfo.Port = s.opts.Cluster.Port
+		s.routeInfo.IP = ""
+	}
+	// (re)generate the routeInfoJSON byte array
+	s.generateRouteInfoJSON()
+	return nil
 }
 
 // StartRouting will start the accept loop on the cluster host:port

--- a/server/route.go
+++ b/server/route.go
@@ -646,7 +646,7 @@ func (s *Server) routeAcceptLoop(ch chan struct{}) {
 	port = l.Addr().(*net.TCPAddr).Port
 	ip := ""
 	if opts.Cluster.RouteAdvertise != "" {
-		advHost, advPort, err := parseHostPort(opts.Cluster.RouteAdvertise, strconv.Itoa(port))
+		advHost, advPort, err := parseHostPort(opts.Cluster.RouteAdvertise, port)
 		if err != nil {
 			s.Errorf("setting RouteAdvertise failed %v", err)
 		} else {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -249,7 +249,7 @@ func TestClientAdvertiseConnectURL(t *testing.T) {
 	s.Shutdown()
 
 	opts = DefaultOptions()
-	opts.Cluster.Port = 0
+	opts.Port = 0
 	opts.ClientAdvertise = "nats.example.com:7777"
 	s = New(opts)
 	if s.info.Host != "nats.example.com" && s.info.Port != 7777 {
@@ -257,7 +257,25 @@ func TestClientAdvertiseConnectURL(t *testing.T) {
 			s.info.Host, s.info.Port)
 	}
 	s.Shutdown()
+}
 
+func TestClientAdvertiseErrorOnStartup(t *testing.T) {
+	opts := DefaultOptions()
+	// Set invalid address
+	opts.ClientAdvertise = "addr:::123"
+	s := New(opts)
+	defer s.Shutdown()
+	dl := &DummyLogger{}
+	s.SetLogger(dl, false, false)
+
+	// Expect this to return due to failure
+	s.Start()
+	dl.Lock()
+	msg := dl.msg
+	dl.Unlock()
+	if !strings.Contains(msg, "ClientAdvertise") {
+		t.Fatalf("Unexpected error: %v", msg)
+	}
 }
 
 func TestNoDeadlockOnStartFailure(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -213,48 +213,40 @@ func TestGetConnectURLs(t *testing.T) {
 	}
 }
 
-func TestClusterClientAdvertiseConnectURL(t *testing.T) {
+func TestClientAdvertiseConnectURL(t *testing.T) {
 	opts := DefaultOptions()
 	opts.Port = 4222
-	opts.Cluster.ClientAdvertiseStr = "nats.example.com"
-
+	opts.ClientAdvertise = "nats.example.com"
 	s := New(opts)
+	defer s.Shutdown()
 
 	urls := s.getClientConnectURLs()
-
 	if len(urls) != 1 {
-		t.Fatalf("Expected to get one url, got none: %v with Cluster.AdvertiseStr %v",
-			opts.Host, opts.Cluster.ClientAdvertiseStr)
+		t.Fatalf("Expected to get one url, got none: %v with ClientAdvertise %v",
+			opts.Host, opts.ClientAdvertise)
 	}
-
 	if urls[0] != "nats.example.com:4222" {
 		t.Fatalf("Expected to get '%s', got: '%v'", "nats.example.com:4222", urls[0])
 	}
 	s.Shutdown()
 
-	opts.Cluster.ClientAdvertiseStr = "nats.example.com, nats2.example.com:7777"
-
+	opts.ClientAdvertise = "nats.example.com:7777"
 	s = New(opts)
-
 	urls = s.getClientConnectURLs()
-
-	if len(urls) != 2 {
-		t.Fatalf("Expected to get two urls, got %d: %v", len(urls), opts.Cluster.ClientAdvertiseStr)
+	if len(urls) != 1 {
+		t.Fatalf("Expected to get one url, got none: %v with ClientAdvertise %v",
+			opts.Host, opts.ClientAdvertise)
 	}
-
-	if urls[0] != "nats.example.com:4222" {
-		t.Fatalf("Expected 'nats.example.com:4222', got: '%v'", urls[0])
+	if urls[0] != "nats.example.com:7777" {
+		t.Fatalf("Expected 'nats.example.com:7777', got: '%v'", urls[0])
 	}
-
-	if urls[1] != "nats2.example.com:7777" {
-		t.Fatalf("Expected 'nats2.example.com:7777', got: '%v'", urls[1])
+	if s.info.Host != "nats.example.com" {
+		t.Fatalf("Expected host to be set to nats.example.com")
 	}
-
+	if s.info.Port != 7777 {
+		t.Fatalf("Expected port to be set to 7777")
+	}
 	s.Shutdown()
-}
-
-func TestClusterAdvertiseConnectURL(t *testing.T) {
-
 }
 
 func TestNoDeadlockOnStartFailure(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -213,10 +213,10 @@ func TestGetConnectURLs(t *testing.T) {
 	}
 }
 
-func TestClusterAdvertiseConnectURL(t *testing.T) {
+func TestClusterClientAdvertiseConnectURL(t *testing.T) {
 	opts := DefaultOptions()
 	opts.Port = 4222
-	opts.Cluster.AdvertiseStr = "nats.example.com"
+	opts.Cluster.ClientAdvertiseStr = "nats.example.com"
 
 	s := New(opts)
 
@@ -224,7 +224,7 @@ func TestClusterAdvertiseConnectURL(t *testing.T) {
 
 	if len(urls) != 1 {
 		t.Fatalf("Expected to get one url, got none: %v with Cluster.AdvertiseStr %v",
-			opts.Host, opts.Cluster.AdvertiseStr)
+			opts.Host, opts.Cluster.ClientAdvertiseStr)
 	}
 
 	if urls[0] != "nats.example.com:4222" {
@@ -232,14 +232,14 @@ func TestClusterAdvertiseConnectURL(t *testing.T) {
 	}
 	s.Shutdown()
 
-	opts.Cluster.AdvertiseStr = "nats.example.com, nats2.example.com:7777"
+	opts.Cluster.ClientAdvertiseStr = "nats.example.com, nats2.example.com:7777"
 
 	s = New(opts)
 
 	urls = s.getClientConnectURLs()
 
 	if len(urls) != 2 {
-		t.Fatalf("Expected to get two urls, got %d: %v", len(urls), opts.Cluster.AdvertiseStr)
+		t.Fatalf("Expected to get two urls, got %d: %v", len(urls), opts.Cluster.ClientAdvertiseStr)
 	}
 
 	if urls[0] != "nats.example.com:4222" {
@@ -251,6 +251,10 @@ func TestClusterAdvertiseConnectURL(t *testing.T) {
 	}
 
 	s.Shutdown()
+}
+
+func TestClusterAdvertiseConnectURL(t *testing.T) {
+
 }
 
 func TestNoDeadlockOnStartFailure(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -247,6 +247,17 @@ func TestClientAdvertiseConnectURL(t *testing.T) {
 		t.Fatalf("Expected port to be set to 7777")
 	}
 	s.Shutdown()
+
+	opts = DefaultOptions()
+	opts.Cluster.Port = 0
+	opts.ClientAdvertise = "nats.example.com:7777"
+	s = New(opts)
+	if s.info.Host != "nats.example.com" && s.info.Port != 7777 {
+		t.Fatalf("Expected Client Advertise Host:Port to be nats.example.com:7777, got: %s:%d",
+			s.info.Host, s.info.Port)
+	}
+	s.Shutdown()
+
 }
 
 func TestNoDeadlockOnStartFailure(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -213,6 +213,46 @@ func TestGetConnectURLs(t *testing.T) {
 	}
 }
 
+func TestClusterAdvertiseConnectURL(t *testing.T) {
+	opts := DefaultOptions()
+	opts.Port = 4222
+	opts.Cluster.AdvertiseStr = "nats.example.com"
+
+	s := New(opts)
+
+	urls := s.getClientConnectURLs()
+
+	if len(urls) != 1 {
+		t.Fatalf("Expected to get one url, got none: %v with Cluster.AdvertiseStr %v",
+			opts.Host, opts.Cluster.AdvertiseStr)
+	}
+
+	if urls[0] != "nats.example.com:4222" {
+		t.Fatalf("Expected to get '%s', got: '%v'", "nats.example.com:4222", urls[0])
+	}
+	s.Shutdown()
+
+	opts.Cluster.AdvertiseStr = "nats.example.com, nats2.example.com:7777"
+
+	s = New(opts)
+
+	urls = s.getClientConnectURLs()
+
+	if len(urls) != 2 {
+		t.Fatalf("Expected to get two urls, got %d: %v", len(urls), opts.Cluster.AdvertiseStr)
+	}
+
+	if urls[0] != "nats.example.com:4222" {
+		t.Fatalf("Expected 'nats.example.com:4222', got: '%v'", urls[0])
+	}
+
+	if urls[1] != "nats2.example.com:7777" {
+		t.Fatalf("Expected 'nats2.example.com:7777', got: '%v'", urls[1])
+	}
+
+	s.Shutdown()
+}
+
 func TestNoDeadlockOnStartFailure(t *testing.T) {
 	opts := DefaultOptions()
 	opts.Host = "x.x.x.x" // bad host

--- a/server/util.go
+++ b/server/util.go
@@ -3,6 +3,10 @@
 package server
 
 import (
+	"errors"
+	"net"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/nats-io/nuid"
@@ -67,4 +71,25 @@ func parseInt64(d []byte) (n int64) {
 func secondsToDuration(seconds float64) time.Duration {
 	ttl := seconds * float64(time.Second)
 	return time.Duration(ttl)
+}
+
+// Parse a host/port string with an optional default port
+func parseHostPort(hostPort string, defaultPort string) (host string, port int, err error) {
+	if hostPort != "" {
+		host, sPort, err := net.SplitHostPort(hostPort)
+		switch err.(type) {
+		case *net.AddrError:
+			// try appending the current port
+			host, sPort, err = net.SplitHostPort(hostPort + ":" + defaultPort)
+		}
+		if err != nil {
+			return "", -1, err
+		}
+		port, err = strconv.Atoi(strings.TrimSpace(sPort))
+		if err != nil {
+			return "", -1, err
+		}
+		return strings.TrimSpace(host), port, nil
+	}
+	return "", -1, errors.New("No hostport specified")
 }

--- a/server/util.go
+++ b/server/util.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -74,13 +75,13 @@ func secondsToDuration(seconds float64) time.Duration {
 }
 
 // Parse a host/port string with an optional default port
-func parseHostPort(hostPort string, defaultPort string) (host string, port int, err error) {
+func parseHostPort(hostPort string, defaultPort int) (host string, port int, err error) {
 	if hostPort != "" {
 		host, sPort, err := net.SplitHostPort(hostPort)
 		switch err.(type) {
 		case *net.AddrError:
 			// try appending the current port
-			host, sPort, err = net.SplitHostPort(hostPort + ":" + defaultPort)
+			host, sPort, err = net.SplitHostPort(fmt.Sprintf("%s:%d", hostPort, defaultPort))
 		}
 		if err != nil {
 			return "", -1, err

--- a/server/util.go
+++ b/server/util.go
@@ -74,7 +74,8 @@ func secondsToDuration(seconds float64) time.Duration {
 	return time.Duration(ttl)
 }
 
-// Parse a host/port string with an optional default port
+// Parse a host/port string with a default port to use
+// if none (or 0 or -1) is specified in `hostPort` string.
 func parseHostPort(hostPort string, defaultPort int) (host string, port int, err error) {
 	if hostPort != "" {
 		host, sPort, err := net.SplitHostPort(hostPort)
@@ -89,6 +90,9 @@ func parseHostPort(hostPort string, defaultPort int) (host string, port int, err
 		port, err = strconv.Atoi(strings.TrimSpace(sPort))
 		if err != nil {
 			return "", -1, err
+		}
+		if port == 0 || port == -1 {
+			port = defaultPort
 		}
 		return strings.TrimSpace(host), port, nil
 	}

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -30,6 +30,42 @@ func TestParseSInt64(t *testing.T) {
 	}
 }
 
+func TestParseHostPort(t *testing.T) {
+	check := func(hostPort string, defaultPort int, expectedHost string, expectedPort int, expectedErr bool) {
+		h, p, err := parseHostPort(hostPort, defaultPort)
+		if expectedErr {
+			if err == nil {
+				stackFatalf(t, "Expected an error, did not get one")
+			}
+			// expected error, so we are done
+			return
+		}
+		if !expectedErr && err != nil {
+			stackFatalf(t, "Unexpected error: %v", err)
+		}
+		if expectedHost != h {
+			stackFatalf(t, "Expected host %q, got %q", expectedHost, h)
+		}
+		if expectedPort != p {
+			stackFatalf(t, "Expected port %d, got %d", expectedPort, p)
+		}
+	}
+	check("addr:1234", 5678, "addr", 1234, false)
+	check(" addr:1234 ", 5678, "addr", 1234, false)
+	check(" addr : 1234 ", 5678, "addr", 1234, false)
+	check("addr", 5678, "addr", 5678, false)
+	check(" addr ", 5678, "addr", 5678, false)
+	check("addr:-1", 5678, "addr", 5678, false)
+	check(" addr:-1 ", 5678, "addr", 5678, false)
+	check(" addr : -1 ", 5678, "addr", 5678, false)
+	check("addr:0", 5678, "addr", 5678, false)
+	check(" addr:0 ", 5678, "addr", 5678, false)
+	check(" addr : 0 ", 5678, "addr", 5678, false)
+	check("addr:addr", 0, "", 0, true)
+	check("addr:::1234", 0, "", 0, true)
+	check("", 0, "", 0, true)
+}
+
 func BenchmarkParseInt(b *testing.B) {
 	b.SetBytes(1)
 	n := "12345678"


### PR DESCRIPTION
Resolves #447 

### Changes proposed in this pull request: 
- Adds `client_advertise` and `cluster_advertise` config item
- Updates Host and Port in server INFO message
- Updates Host, Port and IP in route INFO message
- If `client_advertise` is set, INFO message's ClientConnectURLs will contain that address

To Do:

 - [X] Advertise Support for Implicit Route Addresses.
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [ ] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

/cc @nats-io/core
