### PR TITLE
[ADDED] Monitor endpoints as server methods (Varz(), etc..)

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -466,8 +466,8 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 </html>`)
 }
 
-// HandleVarz will process HTTP requests for server information.
-func (s *Server) HandleVarz(w http.ResponseWriter, r *http.Request) {
+// Varz returns a Varz struct containing the server information.
+func (s *Server) Varz() *Varz {
 	// Snapshot server options.
 	opts := s.getOpts()
 
@@ -499,6 +499,12 @@ func (s *Server) HandleVarz(w http.ResponseWriter, r *http.Request) {
 	}
 	s.mu.Unlock()
 
+	return v
+}
+
+// HandleVarz will process HTTP requests for server information.
+func (s *Server) HandleVarz(w http.ResponseWriter, r *http.Request) {
+	v := s.Varz()
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		s.Errorf("Error marshaling response to /varz request: %v", err)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -35,6 +35,26 @@ type Connz struct {
 	Conns    []ConnInfo `json:"connections"`
 }
 
+// ConnzOptions are the options passed to Connz()
+type ConnzOptions struct {
+	// Sort indicates how the results will be sorted. Check SortOpt for possible values.
+	// Only the sort by connection ID (ByCid) is ascending, all others are descending.
+	Sort SortOpt `json:"sort"`
+
+	// Username indicates if user names should be included in the results.
+	Username bool `json:"auth"`
+
+	// Subscriptions indicates if subscriptions should be included in the results.
+	Subscriptions bool `json:"subscriptions"`
+
+	// Offset is used for pagination. Connz() only returns connections starting at this
+	// offset from the global results.
+	Offset int `json:"offset"`
+
+	// Limit is the maximum number of connections that should be returned by Connz().
+	Limit int `json:"limit"`
+}
+
 // ConnInfo has detailed information on a per connection basis.
 type ConnInfo struct {
 	Cid            uint64    `json:"cid"`
@@ -64,36 +84,46 @@ const DefaultConnListSize = 1024
 
 const defaultStackBufSize = 10000
 
-// HandleConnz process HTTP requests for connection information.
-func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
-	sortOpt := SortOpt(r.URL.Query().Get("sort"))
+// Connz returns a Connz struct containing inormation about connections.
+func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
+	var (
+		sortOpt = ByCid
+		auth    bool
+		subs    bool
+		offset  int
+		limit   = DefaultConnListSize
+	)
 
-	// If no sort option given or sort is by uptime, then sort by cid
-	if sortOpt == "" || sortOpt == byUptime {
-		sortOpt = byCid
-	} else if !sortOpt.IsValid() {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(fmt.Sprintf("Invalid sorting option: %s", sortOpt)))
-		return
+	if opts != nil {
+		// If no sort option given or sort is by uptime, then sort by cid
+		if opts.Sort == "" || opts.Sort == ByUptime {
+			sortOpt = ByCid
+		} else {
+			sortOpt = opts.Sort
+			if !sortOpt.IsValid() {
+				return nil, fmt.Errorf("Invalid sorting option: %s", sortOpt)
+			}
+		}
+		auth = opts.Username
+		subs = opts.Subscriptions
+		offset = opts.Offset
+		if offset < 0 {
+			offset = 0
+		}
+		limit = opts.Limit
+		if limit <= 0 {
+			limit = DefaultConnListSize
+		}
 	}
 
-	c := &Connz{}
-	c.Now = time.Now()
-
-	auth, _ := strconv.Atoi(r.URL.Query().Get("auth"))
-	subs, _ := strconv.Atoi(r.URL.Query().Get("subs"))
-	c.Offset, _ = strconv.Atoi(r.URL.Query().Get("offset"))
-	if c.Offset < 0 {
-		c.Offset = 0
-	}
-	c.Limit, _ = strconv.Atoi(r.URL.Query().Get("limit"))
-	if c.Limit <= 0 {
-		c.Limit = DefaultConnListSize
+	c := &Connz{
+		Offset: offset,
+		Limit:  limit,
+		Now:    time.Now(),
 	}
 
 	// Walk the list
 	s.mu.Lock()
-	s.httpReqStats[ConnzPath]++
 	tlsRequired := s.info.TLSRequired
 
 	// copy the server id for monitoring
@@ -109,23 +139,23 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 	for _, client := range s.clients {
 		client.mu.Lock()
 		switch sortOpt {
-		case byCid:
+		case ByCid:
 			pairs[i] = Pair{Key: client, Val: int64(client.cid)}
-		case bySubs:
+		case BySubs:
 			pairs[i] = Pair{Key: client, Val: int64(len(client.subs))}
-		case byPending:
+		case ByPending:
 			pairs[i] = Pair{Key: client, Val: int64(client.bw.Buffered())}
-		case byOutMsgs:
+		case ByOutMsgs:
 			pairs[i] = Pair{Key: client, Val: client.outMsgs}
-		case byInMsgs:
+		case ByInMsgs:
 			pairs[i] = Pair{Key: client, Val: atomic.LoadInt64(&client.inMsgs)}
-		case byOutBytes:
+		case ByOutBytes:
 			pairs[i] = Pair{Key: client, Val: client.outBytes}
-		case byInBytes:
+		case ByInBytes:
 			pairs[i] = Pair{Key: client, Val: atomic.LoadInt64(&client.inBytes)}
-		case byLast:
+		case ByLast:
 			pairs[i] = Pair{Key: client, Val: client.last.UnixNano()}
-		case byIdle:
+		case ByIdle:
 			pairs[i] = Pair{Key: client, Val: c.Now.Sub(client.last).Nanoseconds()}
 		}
 		client.mu.Unlock()
@@ -134,7 +164,7 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 	s.mu.Unlock()
 
 	if totalClients > 0 {
-		if sortOpt == byCid {
+		if sortOpt == ByCid {
 			// Return in ascending order
 			sort.Sort(pairs)
 		} else {
@@ -193,21 +223,21 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 		// still look sorted even if the value has changed since sort occurred.
 		sortValue := pair.Val
 		switch sortOpt {
-		case bySubs:
+		case BySubs:
 			ci.NumSubs = uint32(sortValue)
-		case byPending:
+		case ByPending:
 			ci.Pending = int(sortValue)
-		case byOutMsgs:
+		case ByOutMsgs:
 			ci.OutMsgs = sortValue
-		case byInMsgs:
+		case ByInMsgs:
 			ci.InMsgs = sortValue
-		case byOutBytes:
+		case ByOutBytes:
 			ci.OutBytes = sortValue
-		case byInBytes:
+		case ByInBytes:
 			ci.InBytes = sortValue
-		case byLast:
+		case ByLast:
 			ci.LastActivity = time.Unix(0, sortValue)
-		case byIdle:
+		case ByIdle:
 			ci.Idle = myUptime(time.Duration(sortValue))
 		}
 
@@ -229,7 +259,7 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Fill in subscription data if requested.
-		if subs == 1 {
+		if subs {
 			sublist := make([]*subscription, 0, len(client.subs))
 			for _, sub := range client.subs {
 				sublist = append(sublist, sub)
@@ -238,14 +268,42 @@ func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Fill in user if auth requested.
-		if auth == 1 {
+		if auth {
 			ci.AuthorizedUser = client.opts.Username
 		}
 
 		client.mu.Unlock()
 		i++
 	}
+	return c, nil
+}
 
+// HandleConnz process HTTP requests for connection information.
+func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
+	sortOpt := SortOpt(r.URL.Query().Get("sort"))
+	auth, _ := strconv.Atoi(r.URL.Query().Get("auth"))
+	subs, _ := strconv.Atoi(r.URL.Query().Get("subs"))
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+
+	connzOpts := &ConnzOptions{
+		Sort:          sortOpt,
+		Username:      auth == 1,
+		Subscriptions: subs == 1,
+		Offset:        offset,
+		Limit:         limit,
+	}
+
+	s.mu.Lock()
+	s.httpReqStats[ConnzPath]++
+	s.mu.Unlock()
+
+	c, err := s.Connz(connzOpts)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
 	b, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
 		s.Errorf("Error marshaling response to /connz request: %v", err)
@@ -268,12 +326,22 @@ type Subsz struct {
 	*SublistStats
 }
 
+// SubszOptions are the options passed to Subsz.
+// As of now, there are no options defined.
+type SubszOptions struct{}
+
 // Routez represents detailed information on current client connections.
 type Routez struct {
 	ID        string       `json:"server_id"`
 	Now       time.Time    `json:"now"`
 	NumRoutes int          `json:"num_routes"`
 	Routes    []*RouteInfo `json:"routes"`
+}
+
+// RoutezOptions are options passed to Routez
+type RoutezOptions struct {
+	// Subscriptions indicates that Routez will return a route's subscriptions
+	Subscriptions bool `json:"subscriptions"`
 }
 
 // RouteInfo has detailed information on a per connection basis.
@@ -294,15 +362,14 @@ type RouteInfo struct {
 }
 
 // Routez returns a Routez struct containing inormation about routes.
-// If `subs` is equal to 1, the routes will contain the list of subscriptions.
-func (s *Server) Routez(subs int) *Routez {
+func (s *Server) Routez(routezOpts *RoutezOptions) (*Routez, error) {
 	rs := &Routez{Routes: []*RouteInfo{}}
 	rs.Now = time.Now()
 
+	subs := routezOpts != nil && routezOpts.Subscriptions
+
 	// Walk the list
 	s.mu.Lock()
-
-	s.httpReqStats[RoutezPath]++
 	rs.NumRoutes = len(s.routes)
 
 	// copy the server id for monitoring
@@ -322,7 +389,7 @@ func (s *Server) Routez(subs int) *Routez {
 			NumSubs:      uint32(len(r.subs)),
 		}
 
-		if subs == 1 {
+		if subs {
 			sublist := make([]*subscription, 0, len(r.subs))
 			for _, sub := range r.subs {
 				sublist = append(sublist, sub)
@@ -339,14 +406,23 @@ func (s *Server) Routez(subs int) *Routez {
 		rs.Routes = append(rs.Routes, ri)
 	}
 	s.mu.Unlock()
-	return rs
+	return rs, nil
 }
 
 // HandleRoutez process HTTP requests for route information.
 func (s *Server) HandleRoutez(w http.ResponseWriter, r *http.Request) {
 	subs, _ := strconv.Atoi(r.URL.Query().Get("subs"))
-	rs := s.Routez(subs)
+	var opts *RoutezOptions
+	if subs == 1 {
+		opts = &RoutezOptions{Subscriptions: true}
+	}
 
+	s.mu.Lock()
+	s.httpReqStats[RoutezPath]++
+	s.mu.Unlock()
+
+	// As of now, no error is ever returned.
+	rs, _ := s.Routez(opts)
 	b, err := json.MarshalIndent(rs, "", "  ")
 	if err != nil {
 		s.Errorf("Error marshaling response to /routez request: %v", err)
@@ -357,17 +433,18 @@ func (s *Server) HandleRoutez(w http.ResponseWriter, r *http.Request) {
 }
 
 // Subsz returns a Subsz struct containing subjects statistics
-func (s *Server) Subsz() *Subsz {
-	s.mu.Lock()
-	s.httpReqStats[SubszPath]++
-	s.mu.Unlock()
-
-	return &Subsz{s.sl.Stats()}
+func (s *Server) Subsz(subszOpts *SubszOptions) (*Subsz, error) {
+	return &Subsz{s.sl.Stats()}, nil
 }
 
 // HandleSubsz processes HTTP requests for subjects stats.
 func (s *Server) HandleSubsz(w http.ResponseWriter, r *http.Request) {
-	st := s.Subsz()
+	s.mu.Lock()
+	s.httpReqStats[SubszPath]++
+	s.mu.Unlock()
+
+	// As of now, no error is ever returned
+	st, _ := s.Subsz(nil)
 	b, err := json.MarshalIndent(st, "", "  ")
 	if err != nil {
 		s.Errorf("Error marshaling response to /subscriptionsz request: %v", err)
@@ -422,6 +499,10 @@ type Varz struct {
 	HTTPReqStats     map[string]uint64 `json:"http_req_stats"`
 	ConfigLoadTime   time.Time         `json:"config_load_time"`
 }
+
+// VarzOptions are the options passed to Varz().
+// Currently, there are no options defined.
+type VarzOptions struct{}
 
 func myUptime(d time.Duration) string {
 	// Just use total seconds for uptime, and display days / years
@@ -478,7 +559,7 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 }
 
 // Varz returns a Varz struct containing the server information.
-func (s *Server) Varz() *Varz {
+func (s *Server) Varz(varzOpts *VarzOptions) (*Varz, error) {
 	// Snapshot server options.
 	opts := s.getOpts()
 
@@ -501,7 +582,6 @@ func (s *Server) Varz() *Varz {
 	v.SlowConsumers = atomic.LoadInt64(&s.slowConsumers)
 	v.Subscriptions = s.sl.Count()
 	v.ConfigLoadTime = s.configTime
-	s.httpReqStats[VarzPath]++
 	// Need a copy here since s.httpReqStas can change while doing
 	// the marshaling down below.
 	v.HTTPReqStats = make(map[string]uint64, len(s.httpReqStats))
@@ -510,12 +590,17 @@ func (s *Server) Varz() *Varz {
 	}
 	s.mu.Unlock()
 
-	return v
+	return v, nil
 }
 
 // HandleVarz will process HTTP requests for server information.
 func (s *Server) HandleVarz(w http.ResponseWriter, r *http.Request) {
-	v := s.Varz()
+	s.mu.Lock()
+	s.httpReqStats[VarzPath]++
+	s.mu.Unlock()
+
+	// As of now, no error is ever returned
+	v, _ := s.Varz(nil)
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		s.Errorf("Error marshaling response to /varz request: %v", err)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -278,13 +278,39 @@ func (s *Server) Connz(opts *ConnzOptions) (*Connz, error) {
 	return c, nil
 }
 
+func decodeInt(w http.ResponseWriter, r *http.Request, param string) (int, error) {
+	str := r.URL.Query().Get(param)
+	if str == "" {
+		return 0, nil
+	}
+	val, err := strconv.Atoi(str)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(fmt.Sprintf("Error decoding %s: %v", param, err)))
+		return 0, err
+	}
+	return val, nil
+}
+
 // HandleConnz process HTTP requests for connection information.
 func (s *Server) HandleConnz(w http.ResponseWriter, r *http.Request) {
 	sortOpt := SortOpt(r.URL.Query().Get("sort"))
-	auth, _ := strconv.Atoi(r.URL.Query().Get("auth"))
-	subs, _ := strconv.Atoi(r.URL.Query().Get("subs"))
-	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
-	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	auth, err := decodeInt(w, r, "auth")
+	if err != nil {
+		return
+	}
+	subs, err := decodeInt(w, r, "subs")
+	if err != nil {
+		return
+	}
+	offset, err := decodeInt(w, r, "offset")
+	if err != nil {
+		return
+	}
+	limit, err := decodeInt(w, r, "limit")
+	if err != nil {
+		return
+	}
 
 	connzOpts := &ConnzOptions{
 		Sort:          sortOpt,
@@ -411,7 +437,10 @@ func (s *Server) Routez(routezOpts *RoutezOptions) (*Routez, error) {
 
 // HandleRoutez process HTTP requests for route information.
 func (s *Server) HandleRoutez(w http.ResponseWriter, r *http.Request) {
-	subs, _ := strconv.Atoi(r.URL.Query().Get("subs"))
+	subs, err := decodeInt(w, r, "subs")
+	if err != nil {
+		return
+	}
 	var opts *RoutezOptions
 	if subs == 1 {
 		opts = &RoutezOptions{Subscriptions: true}

--- a/server/monitor_sort_opts.go
+++ b/server/monitor_sort_opts.go
@@ -5,23 +5,24 @@ package server
 // SortOpt is a helper type to sort by ConnInfo values
 type SortOpt string
 
+// Possible sort options
 const (
-	byCid      SortOpt = "cid"
-	bySubs     SortOpt = "subs"
-	byPending  SortOpt = "pending"
-	byOutMsgs  SortOpt = "msgs_to"
-	byInMsgs   SortOpt = "msgs_from"
-	byOutBytes SortOpt = "bytes_to"
-	byInBytes  SortOpt = "bytes_from"
-	byLast     SortOpt = "last"
-	byIdle     SortOpt = "idle"
-	byUptime   SortOpt = "uptime"
+	ByCid      SortOpt = "cid"        // By connection ID
+	BySubs     SortOpt = "subs"       // By number of subscriptions
+	ByPending  SortOpt = "pending"    // By amount of data in bytes waiting to be sent to client
+	ByOutMsgs  SortOpt = "msgs_to"    // By number of messages sent
+	ByInMsgs   SortOpt = "msgs_from"  // By number of messages received
+	ByOutBytes SortOpt = "bytes_to"   // By amount of bytes sent
+	ByInBytes  SortOpt = "bytes_from" // By amount of bytes received
+	ByLast     SortOpt = "last"       // By the last activity
+	ByIdle     SortOpt = "idle"       // By the amount of inactivity
+	ByUptime   SortOpt = "uptime"     // By the amount of time connections exist
 )
 
 // IsValid determines if a sort option is valid
 func (s SortOpt) IsValid() bool {
 	switch s {
-	case "", byCid, bySubs, byPending, byOutMsgs, byInMsgs, byOutBytes, byInBytes, byLast, byIdle, byUptime:
+	case "", ByCid, BySubs, ByPending, ByOutMsgs, ByInMsgs, ByOutBytes, ByInBytes, ByLast, ByIdle, ByUptime:
 		return true
 	default:
 		return false

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -100,7 +100,7 @@ func TestNoMonitorPort(t *testing.T) {
 	}
 }
 
-func TestVarz(t *testing.T) {
+func TestHandleVarz(t *testing.T) {
 	s := runMonitorServer()
 	defer s.Shutdown()
 
@@ -185,6 +185,45 @@ func TestVarz(t *testing.T) {
 		t.Fatalf("Expected application/javascript content-type, got %s\n", ct)
 	}
 	defer respj.Body.Close()
+}
+
+func TestVarz(t *testing.T) {
+	s := runMonitorServer()
+	defer s.Shutdown()
+
+	v := s.Varz()
+
+	// Do some sanity checks on values
+	if time.Since(v.Start) > 10*time.Second {
+		t.Fatal("Expected start time to be within 10 seconds.")
+	}
+
+	nc := createClientConnSubscribeAndPublish(t, s)
+	defer nc.Close()
+
+	v = s.Varz()
+
+	if v.Connections != 1 {
+		t.Fatalf("Expected Connections of 1, got %v\n", v.Connections)
+	}
+	if v.TotalConnections < 1 {
+		t.Fatalf("Expected Total Connections of at least 1, got %v\n", v.TotalConnections)
+	}
+	if v.InMsgs != 1 {
+		t.Fatalf("Expected InMsgs of 1, got %v\n", v.InMsgs)
+	}
+	if v.OutMsgs != 1 {
+		t.Fatalf("Expected OutMsgs of 1, got %v\n", v.OutMsgs)
+	}
+	if v.InBytes != 5 {
+		t.Fatalf("Expected InBytes of 5, got %v\n", v.InBytes)
+	}
+	if v.OutBytes != 5 {
+		t.Fatalf("Expected OutBytes of 5, got %v\n", v.OutBytes)
+	}
+	if v.Subscriptions != 1 {
+		t.Fatalf("Expected Subscriptions of 1, got %v\n", v.Subscriptions)
+	}
 }
 
 func TestConnz(t *testing.T) {


### PR DESCRIPTION
Fixes #612 by adding a new Varz method to the Server. This can be used
by processes embedding gnatsd to access the Varz struct without relying
on the HTTP API. This starts with just Varz but the same pattern could
be expanded to other monitoring APIs in the future.

@nats-io/core
cc @ripienaar
