### PR TITLE
[ADDED] Add reply permissions for users

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -50,6 +50,7 @@ func (u *User) clone() *User {
 type Permissions struct {
 	Publish   []string `json:"publish"`
 	Subscribe []string `json:"subscribe"`
+	Reply     []string `json:"reply"`
 }
 
 // clone performs a deep copy of the Permissions struct, returning a new clone
@@ -66,6 +67,10 @@ func (p *Permissions) clone() *Permissions {
 	if p.Subscribe != nil {
 		clone.Subscribe = make([]string, len(p.Subscribe))
 		copy(clone.Subscribe, p.Subscribe)
+	}
+	if p.Reply != nil {
+		clone.Reply = make([]string, len(p.Reply))
+		copy(clone.Reply, p.Reply)
 	}
 	return clone
 }

--- a/server/configs/authorization.conf
+++ b/server/configs/authorization.conf
@@ -10,6 +10,7 @@ authorization {
     publish = "*"
     subscribe = ">"
   }
+
   # Can do requests on foo or bar, and subscribe to anything
   # that is a response to an _INBOX.
   #
@@ -17,6 +18,12 @@ authorization {
   req_pub_user = {
     publish = ["req.foo", "req.bar"]
     subscribe = "_INBOX.>"
+  }
+
+  # Can subscribe to foo and reply to requests, but can't do anything else
+  sub_reply_user = {
+    subscribe = "foo"
+    reply = "foo"
   }
 
   # Setup a default user that can subscribe to anything, but has
@@ -32,6 +39,7 @@ authorization {
   users = [
     {user: alice, password: foo, permissions: $super_user}
     {user: bob,   password: bar, permissions: $req_pub_user}
+    {user: brian, password: bab, permissions: $sub_reply_user}
     {user: susan, password: baz}
   ]
 }

--- a/server/opts.go
+++ b/server/opts.go
@@ -506,6 +506,12 @@ func parseUserPermissions(pm map[string]interface{}) (*Permissions, error) {
 				return nil, err
 			}
 			p.Subscribe = subjects
+		case "reply":
+			subjects, err := parseSubjects(v)
+			if err != nil {
+				return nil, err
+			}
+			p.Reply = subjects
 		default:
 			return nil, fmt.Errorf("Unknown field %s parsing permissions", k)
 		}

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -537,8 +537,8 @@ func TestAuthorizationConfig(t *testing.T) {
 	}
 	processOptions(opts)
 	lu := len(opts.Users)
-	if lu != 3 {
-		t.Fatalf("Expected 3 users, got %d\n", lu)
+	if lu != 4 {
+		t.Fatalf("Expected 4 users, got %d\n", lu)
 	}
 	// Build a map
 	mu := make(map[string]*User)
@@ -585,6 +585,37 @@ func TestAuthorizationConfig(t *testing.T) {
 	}
 	if bob.Permissions == nil {
 		t.Fatalf("Expected Bob's permissions to be non-nil\n")
+	}
+
+	// Brian
+	brian, ok := mu["brian"]
+	if !ok {
+		t.Fatalf("Expected to see user Brian\n")
+	}
+	if brian.Permissions == nil {
+		t.Fatalf("Expected Brian's permissions to be non-nil\n")
+	}
+	numPub := len(brian.Permissions.Publish)
+	if numPub > 0 {
+		t.Fatalf("Expected Brian's publish permissions to be empty, found %d elements", numPub)
+	}
+	numSub := len(brian.Permissions.Subscribe)
+	if numSub != 1 {
+		t.Fatalf("Expected Brian's subscribe permissions to have 1 element, found %d elements",
+			numSub)
+	}
+	subPerm = brian.Permissions.Subscribe[0]
+	if subPerm != "foo" {
+		t.Fatalf("Expected Brian's subscribe permissions to be 'foo', found %q", subPerm)
+	}
+	numReply := len(brian.Permissions.Reply)
+	if numReply != 1 {
+		t.Fatalf("Expected Brian's reply permissions to have 1 element, found %d elements",
+			numReply)
+	}
+	replyPerm := brian.Permissions.Reply[0]
+	if replyPerm != "foo" {
+		t.Fatalf("Expected Brian's reply permissions to be 'foo', found %q", replyPerm)
 	}
 
 	// Susan

--- a/test/bench_results.txt
+++ b/test/bench_results.txt
@@ -1,3 +1,29 @@
+2017 iMac Pro 3Ghz (Turbo 4Ghz) 10-Core Skylake
+OSX High Sierra 10.13.2
+
+===================
+Go version go1.9.2
+===================
+
+Benchmark_____Pub0b_Payload-20    	30000000	        55.1 ns/op	 199.78 MB/s
+Benchmark_____Pub8b_Payload-20    	30000000	        55.8 ns/op	 340.21 MB/s
+Benchmark____Pub32b_Payload-20    	20000000	        63.4 ns/op	 694.34 MB/s
+Benchmark___Pub128B_Payload-20    	20000000	        79.8 ns/op	1766.47 MB/s
+Benchmark___Pub256B_Payload-20    	20000000	        98.1 ns/op	2741.51 MB/s
+Benchmark_____Pub1K_Payload-20    	 5000000	       283 ns/op	3660.72 MB/s
+Benchmark_____Pub4K_Payload-20    	 1000000	      1395 ns/op	2945.30 MB/s
+Benchmark_____Pub8K_Payload-20    	  500000	      2846 ns/op	2882.35 MB/s
+Benchmark_AuthPub0b_Payload-20    	10000000	       126 ns/op	  86.82 MB/s
+Benchmark____________PubSub-20    	10000000	       135 ns/op
+Benchmark____PubSubTwoConns-20    	10000000	       136 ns/op
+Benchmark____PubTwoQueueSub-20    	10000000	       152 ns/op
+Benchmark___PubFourQueueSub-20    	10000000	       152 ns/op
+Benchmark__PubEightQueueSub-20    	10000000	       152 ns/op
+Benchmark___RoutedPubSub_0b-20    	 5000000	       385 ns/op
+Benchmark___RoutedPubSub_1K-20    	 1000000	      1076 ns/op
+Benchmark_RoutedPubSub_100K-20    	   20000	     78501 ns/op
+
+
 2015 iMac5k 4Ghz i7 Haswell
 OSX El Capitan 10.11.3
 


### PR DESCRIPTION
These changes make the addition of "reply" permissions for users, which enables a user to reply to messages received from a particular topic, without giving them permission to publish messages to any inbox.

My use case is an IOT-like scenario in which I have code running across many (untrusted) machines in many different locations. I need this code to be able to reply to requests it receives, without having the ability to publish any other messages. These clients should only have the ability to send a single reply to the reply inbox, and any further attempts to publish to that inbox are rejected.

Internally, when a request is delivered to a subscriber who has reply permissions for the current subject, it adds a temporary publish permission to the receiving client. When a reply is sent by the receiving client, it accepts the message and removes the temporary publish permission, so that any further messages are rejected.

As per PR requirements - this is my original work and agree to it being licensed under the project's MIT license.
 
/cc @nats-io/core
