### PR TITLE
[ADDED] Print release's GitCommit in the banner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Derek Collison <derek@apcera.com>
 COPY . /go/src/github.com/nats-io/gnatsd
 WORKDIR /go/src/github.com/nats-io/gnatsd
 
-RUN CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/gnatsd/version.GITCOMMIT=`git rev-parse --short HEAD`"
+RUN CGO_ENABLED=0 go install -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/gnatsd/server.GITHASH=`git rev-parse --short HEAD`"
 
 EXPOSE 4222 8222
 ENTRYPOINT ["gnatsd"]

--- a/Dockerfile.all
+++ b/Dockerfile.all
@@ -5,10 +5,10 @@ MAINTAINER Ivan Kozlovic <ivan.kozlovic@apcera.com>
 COPY . /go/src/github.com/nats-io/gnatsd
 WORKDIR /go/src/github.com/nats-io/gnatsd
 
-RUN CGO_ENABLED=0 GOOS=linux   GOARCH=amd64         go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/gnatsd/version.GITCOMMIT=`git rev-parse --short HEAD`" -o pkg/linux-amd64/gnatsd
-RUN CGO_ENABLED=0 GOOS=linux   GOARCH=arm   GOARM=7 go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/gnatsd/version.GITCOMMIT=`git rev-parse --short HEAD`" -o pkg/linux-arm7/gnatsd
-RUN CGO_ENABLED=0 GOOS=linux   GOARCH=arm64         go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/gnatsd/version.GITCOMMIT=`git rev-parse --short HEAD`" -o pkg/linux-arm64/gnatsd
-RUN CGO_ENABLED=0 GOOS=windows GOARCH=amd64         go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/gnatsd/version.GITCOMMIT=`git rev-parse --short HEAD`" -o pkg/win-amd64/gnatsd.exe
+RUN CGO_ENABLED=0 GOOS=linux   GOARCH=amd64         go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/gnatsd/server.GITHASH=`git rev-parse --short HEAD`" -o pkg/linux-amd64/gnatsd
+RUN CGO_ENABLED=0 GOOS=linux   GOARCH=arm   GOARM=7 go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/gnatsd/server.GITHASH=`git rev-parse --short HEAD`" -o pkg/linux-arm7/gnatsd
+RUN CGO_ENABLED=0 GOOS=linux   GOARCH=arm64         go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/gnatsd/server.GITHASH=`git rev-parse --short HEAD`" -o pkg/linux-arm64/gnatsd
+RUN CGO_ENABLED=0 GOOS=windows GOARCH=amd64         go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/gnatsd/server.GITHASH=`git rev-parse --short HEAD`" -o pkg/win-amd64/gnatsd.exe
 
 ENTRYPOINT ["go"]
 CMD ["version"]

--- a/server/const.go
+++ b/server/const.go
@@ -17,6 +17,11 @@ const (
 	CommandReload = Command("reload")
 )
 
+var (
+	// GITHASH injected at build
+	GITHASH string
+)
+
 const (
 	// VERSION is the current version for the server.
 	VERSION = "1.0.4"

--- a/server/server.go
+++ b/server/server.go
@@ -29,6 +29,7 @@ import (
 type Info struct {
 	ID                string   `json:"server_id"`
 	Version           string   `json:"version"`
+	GitHash           string   `json:"git_hash"`
 	GoVersion         string   `json:"go"`
 	Host              string   `json:"host"`
 	Port              int      `json:"port"`
@@ -112,6 +113,7 @@ func New(opts *Options) *Server {
 	info := Info{
 		ID:                genID(),
 		Version:           VERSION,
+		GitHash:           GITHASH,
 		GoVersion:         runtime.Version(),
 		Host:              opts.Host,
 		Port:              opts.Port,
@@ -241,6 +243,7 @@ func (s *Server) logPid() error {
 func (s *Server) Start() {
 	s.Noticef("Starting nats-server version %s", VERSION)
 	s.Debugf("Go build version %s", s.info.GoVersion)
+	s.Debugf("GIT hash [%s]", GITHASH)
 
 	// Avoid RACE between Start() and Shutdown()
 	s.mu.Lock()


### PR DESCRIPTION
Added g/n/gnatsd.GITHASH variable to server. This enables via linker flags to add a value during the build process that is exposed on the server log (if debug) and on /varz.

```-ldflags "-s -w -X github.com/nats-io/gnatsd/server.GITHASH=`git rev-parse --short HEAD`"```

Note that the docker files were injecting a value via the same mechanism that was never exposed ```github.com/nats-io/gnatsd/version.GITCOMMIT```
