### PR TITLE
Update Go versions in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-- 1.7.x
-- 1.8.5
-- 1.9.2
+- 1.8.x
+- 1.9.x
+- 1.10.x
 install:
 - go get github.com/nats-io/go-nats
 - go get github.com/mattn/goveralls


### PR DESCRIPTION
Drop 1.7 and add 1.10. However leave 1.9 for releases for now in case we have a release soon since 1.10.1 is just around the corner fixing some security issues in 1.10
