### PR TITLE
[ADDED] Notification to clients when servers leave the cluster

### DIFF
--- a/server/reload.go
+++ b/server/reload.go
@@ -237,6 +237,11 @@ func (c *clusterOption) Apply(server *Server) {
 	server.routeInfo.SSLRequired = tlsRequired
 	server.routeInfo.TLSVerify = tlsRequired
 	server.routeInfo.AuthRequired = c.newValue.Username != ""
+	if c.newValue.NoAdvertise {
+		server.routeInfo.ClientConnectURLs = nil
+	} else {
+		server.routeInfo.ClientConnectURLs = server.clientConnectURLs
+	}
 	server.setRouteInfoHostPortAndIP()
 	server.mu.Unlock()
 	server.Noticef("Reloaded: cluster")

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -626,7 +626,6 @@ func TestClientConnectToRoutePort(t *testing.T) {
 	// cluster's Host to localhost so it works on Windows too, since on
 	// Windows, a client can't use 0.0.0.0 in a connect.
 	opts.Cluster.Host = "localhost"
-	opts.Cluster.NoAdvertise = true
 	s := RunServer(opts)
 	defer s.Shutdown()
 
@@ -648,6 +647,20 @@ func TestClientConnectToRoutePort(t *testing.T) {
 		defer nc.Close()
 		if nc.ConnectedUrl() != clientURL {
 			t.Fatalf("Expected client to be connected to %v, got %v", clientURL, nc.ConnectedUrl())
+		}
+	}
+
+	s.Shutdown()
+	// Try again with NoAdvertise and this time, the client should fail to connect.
+	opts.Cluster.NoAdvertise = true
+	s = RunServer(opts)
+	defer s.Shutdown()
+
+	for i := 0; i < total; i++ {
+		nc, err := nats.Connect(url)
+		if err == nil {
+			nc.Close()
+			t.Fatal("Expected error on connect, got none")
 		}
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -153,7 +153,9 @@ func TestGetConnectURLs(t *testing.T) {
 		s := New(opts)
 		defer s.Shutdown()
 
+		s.mu.Lock()
 		urls := s.getClientConnectURLs()
+		s.mu.Unlock()
 		if len(urls) == 0 {
 			t.Fatalf("Expected to get a list of urls, got none for listen addr: %v", opts.Host)
 		}
@@ -189,7 +191,9 @@ func TestGetConnectURLs(t *testing.T) {
 		s := New(opts)
 		defer s.Shutdown()
 
+		s.mu.Lock()
 		urls := s.getClientConnectURLs()
+		s.mu.Unlock()
 		if len(urls) != 1 {
 			t.Fatalf("Expected one URL, got %v", urls)
 		}
@@ -220,7 +224,9 @@ func TestClientAdvertiseConnectURL(t *testing.T) {
 	s := New(opts)
 	defer s.Shutdown()
 
+	s.mu.Lock()
 	urls := s.getClientConnectURLs()
+	s.mu.Unlock()
 	if len(urls) != 1 {
 		t.Fatalf("Expected to get one url, got none: %v with ClientAdvertise %v",
 			opts.Host, opts.ClientAdvertise)
@@ -232,7 +238,9 @@ func TestClientAdvertiseConnectURL(t *testing.T) {
 
 	opts.ClientAdvertise = "nats.example.com:7777"
 	s = New(opts)
+	s.mu.Lock()
 	urls = s.getClientConnectURLs()
+	s.mu.Unlock()
 	if len(urls) != 1 {
 		t.Fatalf("Expected to get one url, got none: %v with ClientAdvertise %v",
 			opts.Host, opts.ClientAdvertise)

--- a/test/monitor_test.go
+++ b/test/monitor_test.go
@@ -98,7 +98,7 @@ func TestNoMonitorPort(t *testing.T) {
 func testEndpointDataRace(endpoint string, t *testing.T) {
 	var doneWg sync.WaitGroup
 
-	url := fmt.Sprintf("http://localhost:%d/", MONITOR_PORT)
+	url := fmt.Sprintf("http://127.0.0.1:%d/", MONITOR_PORT)
 
 	// Poll as fast as we can, while creating connections, publishing,
 	// and subscribing.


### PR DESCRIPTION
Until now, a server would only notify clients of servers that join
the cluster. More than that, a server would send ot its clients only
information if new servers were added.
This PR changes this by sending to clients that support async INFO
the list of URLs for all servers in the cluster any time that there
is a change (joining or leaving the cluster).
As of now, clients will not be affected by the change (and will not
take benefit of this: removing servers from their server pool). This
will be addressed in each supported client once this is merged.
