### PR TITLE
[FIXED] Cluster toplogy change possibly not sent to clients

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -564,6 +564,9 @@ func (s *Server) addRoute(c *client, info *Info) (bool, bool) {
 		remote.mu.Lock()
 		// r will be not nil if c.route.didSolicit was true
 		if r != nil {
+			// If we upgrade to solicited, we still want to keep the remote's
+			// connectURLs. So transfer those.
+			r.connectURLs = remote.route.connectURLs
 			remote.route = r
 		}
 		// This is to mitigate the issue where both sides add the route

--- a/server/server.go
+++ b/server/server.go
@@ -255,10 +255,11 @@ func (s *Server) logPid() error {
 func (s *Server) Start() {
 	s.Noticef("Starting nats-server version %s", VERSION)
 	s.Debugf("Go build version %s", s.info.GoVersion)
-	if gitCommit == "" {
-		gitCommit = "not set"
+	gc := gitCommit
+	if gc == "" {
+		gc = "not set"
 	}
-	s.Noticef("Git commit [%s]", gitCommit)
+	s.Noticef("Git commit [%s]", gc)
 
 	// Avoid RACE between Start() and Shutdown()
 	s.mu.Lock()


### PR DESCRIPTION
When a server accepts a route, it will keep track of that server
`connectURLs` array. However, if the server was creating a route
to that other server at the same time, it will promote the route
as a solicited one. The content of that array was not transfered,
which means that on a disconnect, it was possible that the cluster
topology change was not properly sent to clients.
