### PR TITLE
Additional fix to #631

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -79,13 +79,6 @@ func (cf *clientFlag) setIfNotSet(c clientFlag) bool {
 	return false
 }
 
-// Commenting out for now otherwise megacheck complains.
-// We may need that in the future.
-// clear unset the flag (would be equivalent to set the boolean to false)
-// func (cf *clientFlag) clear(c clientFlag) {
-// 	*cf &= ^c
-// }
-
 type client struct {
 	// Here first because of use of atomics, and memory alignment.
 	stats


### PR DESCRIPTION
This is the result of flapping tests in go-nats that were caused
by a defect (see PR https://github.com/nats-io/go-nats/pull/348).
However, during debugging, I realize that there were also things
that were not quite right in the server side. This change should
make it the notification of cluster topology changes to clients
more robust.
