### PR TITLE
Restore DefaultTestOptions port to 4222

### DIFF
--- a/test/gosrv_test.go
+++ b/test/gosrv_test.go
@@ -11,7 +11,9 @@ import (
 
 func TestSimpleGoServerShutdown(t *testing.T) {
 	base := runtime.NumGoroutine()
-	s := RunDefaultServer()
+	opts := DefaultTestOptions
+	opts.Port = -1
+	s := RunServer(&opts)
 	s.Shutdown()
 	time.Sleep(100 * time.Millisecond)
 	delta := (runtime.NumGoroutine() - base)
@@ -22,7 +24,9 @@ func TestSimpleGoServerShutdown(t *testing.T) {
 
 func TestGoServerShutdownWithClients(t *testing.T) {
 	base := runtime.NumGoroutine()
-	s := RunDefaultServer()
+	opts := DefaultTestOptions
+	opts.Port = -1
+	s := RunServer(&opts)
 	addr := s.Addr().(*net.TCPAddr)
 	for i := 0; i < 50; i++ {
 		createClientConn(t, "localhost", addr.Port)
@@ -39,7 +43,9 @@ func TestGoServerShutdownWithClients(t *testing.T) {
 }
 
 func TestGoServerMultiShutdown(t *testing.T) {
-	s := RunDefaultServer()
+	opts := DefaultTestOptions
+	opts.Port = -1
+	s := RunServer(&opts)
 	s.Shutdown()
 	s.Shutdown()
 }

--- a/test/test.go
+++ b/test/test.go
@@ -26,7 +26,7 @@ type tLogger interface {
 // DefaultTestOptions are default options for the unit tests.
 var DefaultTestOptions = server.Options{
 	Host:           "localhost",
-	Port:           -1,
+	Port:           4222,
 	NoLog:          true,
 	NoSigs:         true,
 	MaxControlLine: 256,


### PR DESCRIPTION
This is used by RunDefaultServer() and some external projects tests
may rely on the fact that this runs on the default port.

Our tests that want to use ephemeral ports to avoid port conflicts
should be updated to not use these default options and/or RunDefaultServer().
