### PR TITLE
[IMPROVED] Better attempt at delivering messages to queue subscriptions

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1159,9 +1159,9 @@ func (c *client) processMsg(msg []byte) {
 			// we didn't make a delivery attempt, because either a subscriber limit
 			// was exceeded or a subscription is already gone.
 			// So, let the code below find yet another matching subscription.
-			// We are at risk that a message might go forth and back
-			// between routes during these attempts, but at the end
-			// it shall either be delivered (at most once) or drop.
+			// We are at risk that a message might go back and forth between routes
+			// during these attempts, but at the end it shall either be delivered
+			// (at most once) or dropped.
 		}
 	}
 
@@ -1208,8 +1208,8 @@ func (c *client) processMsg(msg []byte) {
 		}
 	}
 
-	// Now process any queue subs we have if not a route.
-	// ... Or if it's a route and we need to resend.
+	// Now process any queue subs we have if not a route...
+	// or if we did not make a delivery attempt yet.
 	if isRouteQsub || !isRoute {
 		// Check to see if we have our own rand yet. Global rand
 		// has contention with lots of clients, etc.
@@ -1219,9 +1219,8 @@ func (c *client) processMsg(msg []byte) {
 		// Process queue subs
 		for i := 0; i < len(r.qsubs); i++ {
 			qsubs := r.qsubs[i]
-			// Iterate over all subscribed clients starting at a random index
-			// until we find one that's able to deliver a message.
-			// Drop a message on the floor if there are noone.
+			// Find a subscription that is able to deliver this message
+			// starting at a random index.
 			startIndex := c.cache.prand.Intn(len(qsubs))
 			for i := 0; i < len(qsubs); i++ {
 				index := (startIndex + i) % len(qsubs)

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -857,4 +858,72 @@ func TestServerPoolUpdatedWhenRouteGoesAway(t *testing.T) {
 	// The implicit server that we just shutdown should have been removed from the pool
 	checkPool(expected)
 	nc.Close()
+}
+
+func TestRoutedQueueUnsubscribe(t *testing.T) {
+	optsA, _ := ProcessConfigFile("./configs/seed.conf")
+	optsA.NoSigs, optsA.NoLog = true, true
+	srvA := RunServer(optsA)
+	defer srvA.Shutdown()
+
+	srvARouteURL := fmt.Sprintf("nats://%s:%d", optsA.Cluster.Host, srvA.ClusterAddr().Port)
+	optsB := nextServerOpts(optsA)
+	optsB.Routes = RoutesFromStr(srvARouteURL)
+
+	srvB := RunServer(optsB)
+	defer srvB.Shutdown()
+
+	// Wait for these 2 to connect to each other
+	checkClusterFormed(t, srvA, srvB)
+
+	// Have a client connection to each server
+	ncA, err := nats.Connect(fmt.Sprintf("nats://%s:%d", optsA.Host, optsA.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer ncA.Close()
+	ncB, err := nats.Connect(fmt.Sprintf("nats://%s:%d", optsB.Host, optsB.Port))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer ncB.Close()
+
+	received := int32(0)
+	cb := func(m *nats.Msg) {
+		atomic.AddInt32(&received, 1)
+	}
+
+	// Create 50 queue subs with auto-unsubscribe to each server.
+	cons := []*nats.Conn{ncA, ncB}
+	for _, c := range cons {
+		for i := 0; i < 50; i++ {
+			qsub, err := c.QueueSubscribe("foo", "bar", cb)
+			if err != nil {
+				t.Fatalf("Error on subscribe: %v", err)
+			}
+			if err := qsub.AutoUnsubscribe(1); err != nil {
+				t.Fatalf("Error on auto-unsubscribe: %v", err)
+			}
+		}
+		c.Flush()
+	}
+
+	total := 100
+	// Now send messages from each server
+	for i := 0; i < total; i++ {
+		c := cons[i%2]
+		c.Publish("foo", []byte("hello"))
+	}
+	for _, c := range cons {
+		c.Flush()
+	}
+
+	timeout := time.Now().Add(2 * time.Second)
+	for time.Now().Before(timeout) {
+		if atomic.LoadInt32(&received) == int32(total) {
+			return
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+	t.Fatalf("Should have received %v messages, got %v", total, atomic.LoadInt32(&received))
 }

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -389,9 +389,9 @@ func TestRouteQueueSemantics(t *testing.T) {
 	// Queue group one.
 	routeSend("MSG foo QRSID:1:2 2\r\nok\r\n")
 	// Invlaid queue sid.
-	routeSend("MSG foo QRSID 2\r\nok\r\n")
-	routeSend("MSG foo QRSID:1 2\r\nok\r\n")
-	routeSend("MSG foo QRSID:1: 2\r\nok\r\n")
+	routeSend("MSG foo QRSID 2\r\nok\r\n")    // cid and sid missing
+	routeSend("MSG foo QRSID:1 2\r\nok\r\n")  // cid not terminated with ':'
+	routeSend("MSG foo QRSID:1: 2\r\nok\r\n") // cid==1 but sid missing. It needs to be at least one character.
 
 	// Use ping roundtrip to make sure its processed.
 	routeSend("PING\r\n")


### PR DESCRIPTION
This PR is based out of #633. It imroves parsing QRSID so that the
TestRouteQueueSemantics test now passes (when dealing with malformed
QRSID).
A test similar to what is reported in #632 was also added. This
test however, uncovers a race condition that will be fixed in a
separate PR.

Resolves #632