### PR TITLE
[FIXED] Close old log files when reloading (log rotation)

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -78,14 +78,15 @@ func NewFileLogger(filename string, time, debug, trace, pid bool) *Logger {
 	return l
 }
 
-// Close cleans up any resources with the server's logger implementation.
-func (l *Logger) Close() {
-	if l.logFile != nil {
-		if err := l.logFile.Close(); err != nil {
-			l.Noticef("couldn't close log file on restart:  %v", err)
-		}
+// Close implements the io.Closer interface to clean up
+// resources in the server's logger implementation.
+// Caller must ensure threadsafety.
+func (l *Logger) Close() error {
+	if f := l.logFile; f != nil {
 		l.logFile = nil
+		return f.Close()
 	}
+	return nil
 }
 
 // Generate the pid prefix string

--- a/logger/log.go
+++ b/logger/log.go
@@ -19,6 +19,7 @@ type Logger struct {
 	fatalLabel string
 	debugLabel string
 	traceLabel string
+	logFile    *os.File // file pointer for the file logger.
 }
 
 // NewStdLogger creates a logger with output directed to Stderr
@@ -67,13 +68,24 @@ func NewFileLogger(filename string, time, debug, trace, pid bool) *Logger {
 	}
 
 	l := &Logger{
-		logger: log.New(f, pre, flags),
-		debug:  debug,
-		trace:  trace,
+		logger:  log.New(f, pre, flags),
+		debug:   debug,
+		trace:   trace,
+		logFile: f,
 	}
 
 	setPlainLabelFormats(l)
 	return l
+}
+
+// Close cleans up any resources with the server's logger implementation.
+func (l *Logger) Close() {
+	if l.logFile != nil {
+		if err := l.logFile.Close(); err != nil {
+			l.Noticef("couldn't close log file on restart:  %v", err)
+		}
+		l.logFile = nil
+	}
 }
 
 // Generate the pid prefix string

--- a/server/configs/reload/file_rotate.conf
+++ b/server/configs/reload/file_rotate.conf
@@ -1,0 +1,4 @@
+# Copyright 2018 Authors
+listen:   localhost:-1
+logfile: "log.txt"
+pid_file: "gnatsd.pid"

--- a/server/configs/reload/file_rotate1.conf
+++ b/server/configs/reload/file_rotate1.conf
@@ -1,0 +1,4 @@
+# Copyright 2018 Authors
+listen:   localhost:-1
+logfile: "log1.txt"
+pid_file: "gnatsd1.pid"

--- a/server/log.go
+++ b/server/log.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"sync/atomic"
 
-	"github.com/nats-io/gnatsd/logger"
+	srvlog "github.com/nats-io/gnatsd/logger"
 )
 
 // Logger interface of the NATS Server
@@ -45,11 +45,11 @@ func (s *Server) ConfigureLogger() {
 	}
 
 	if opts.LogFile != "" {
-		log = logger.NewFileLogger(opts.LogFile, opts.Logtime, opts.Debug, opts.Trace, true)
+		log = srvlog.NewFileLogger(opts.LogFile, opts.Logtime, opts.Debug, opts.Trace, true)
 	} else if opts.RemoteSyslog != "" {
-		log = logger.NewRemoteSysLogger(opts.RemoteSyslog, opts.Debug, opts.Trace)
+		log = srvlog.NewRemoteSysLogger(opts.RemoteSyslog, opts.Debug, opts.Trace)
 	} else if syslog {
-		log = logger.NewSysLogger(opts.Debug, opts.Trace)
+		log = srvlog.NewSysLogger(opts.Debug, opts.Trace)
 	} else {
 		colors := true
 		// Check to see if stderr is being redirected and if so turn off color
@@ -58,7 +58,7 @@ func (s *Server) ConfigureLogger() {
 		if err != nil || (stat.Mode()&os.ModeCharDevice) == 0 {
 			colors = false
 		}
-		log = logger.NewStdLogger(opts.Logtime, opts.Debug, opts.Trace, colors, true)
+		log = srvlog.NewStdLogger(opts.Logtime, opts.Debug, opts.Trace, colors, true)
 	}
 
 	s.SetLogger(log, opts.Debug, opts.Trace)
@@ -76,8 +76,15 @@ func (s *Server) SetLogger(logger Logger, debugFlag, traceFlag bool) {
 	} else {
 		atomic.StoreInt32(&s.logging.trace, 0)
 	}
-
 	s.logging.Lock()
+	if s.logging.logger != nil {
+		// if we are the server's logger, call its Close function, but check
+		// the type because this could be a logger from another process
+		// embedding the NATS server, a SysLogger, or a dummy test logger.
+		if l, ok := s.logging.logger.(*srvlog.Logger); ok {
+			l.Close()
+		}
+	}
 	s.logging.logger = logger
 	s.logging.Unlock()
 }
@@ -102,7 +109,7 @@ func (s *Server) ReOpenLogFile() {
 	if opts.LogFile == "" {
 		s.Noticef("File log re-open ignored, not a file logger")
 	} else {
-		fileLog := logger.NewFileLogger(opts.LogFile,
+		fileLog := srvlog.NewFileLogger(opts.LogFile,
 			opts.Logtime, opts.Debug, opts.Trace, true)
 		s.SetLogger(fileLog, opts.Debug, opts.Trace)
 		s.Noticef("File log re-opened")

--- a/server/log.go
+++ b/server/log.go
@@ -84,7 +84,7 @@ func (s *Server) SetLogger(logger Logger, debugFlag, traceFlag bool) {
 		// test logger that may not implement that interface.
 		if l, ok := s.logging.logger.(io.Closer); ok {
 			if err := l.Close(); err != nil {
-				s.Noticef("error closing logger: %v", err)
+				s.Noticef("Error closing logger: %v", err)
 			}
 		}
 	}

--- a/server/log.go
+++ b/server/log.go
@@ -84,7 +84,7 @@ func (s *Server) SetLogger(logger Logger, debugFlag, traceFlag bool) {
 		// test logger that may not implement that interface.
 		if l, ok := s.logging.logger.(io.Closer); ok {
 			if err := l.Close(); err != nil {
-				s.Noticef("Error closing logger: %v", err)
+				s.Errorf("Error closing logger: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
 - [X] Resolves #630
 - [X] Tests added
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [MIT license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

As described in issue #630, when rotating log files with a reload, windows would keep files open causing issues.  This fix closes open log files when creating a new logger.  I also renamed the logger import for readability.

Before the fix, windows systems would fail reporting:  _“The process cannot access the file because it is being used by another process.”_

/cc @nats-io/core
