### PR TITLE
Proposal: Improve compatibility with JSON in configuration

### DIFF
--- a/conf/lex.go
+++ b/conf/lex.go
@@ -73,6 +73,9 @@ const (
 	sqStringStart     = '\''
 	sqStringEnd       = '\''
 	optValTerm        = ';'
+	topOptStart       = '{'
+	topOptValTerm     = ','
+	topOptTerm        = '}'
 	blockStart        = '('
 	blockEnd          = ')'
 )
@@ -234,6 +237,8 @@ func lexTop(lx *lexer) stateFn {
 	}
 
 	switch r {
+	case topOptStart:
+		return lexSkip(lx, lexTop)
 	case commentHashStart:
 		lx.push(lexTop)
 		return lexCommentStart
@@ -280,7 +285,7 @@ func lexTopValueEnd(lx *lexer) stateFn {
 		fallthrough
 	case isWhitespace(r):
 		return lexTopValueEnd
-	case isNL(r) || r == eof || r == optValTerm:
+	case isNL(r) || r == eof || r == optValTerm || r == topOptValTerm || r == topOptTerm:
 		lx.ignore()
 		return lexTop
 	}


### PR DESCRIPTION
The configuration format from the server is almost already a superset of JSON with exception of the following two cases:

1) trailing commas from values at the top level are not allowed(although they are supported inside of maps)

2) initial and final brackets at the top level section not supported

This change relaxes the two cases above to just skip those tokens so that the config syntax can also support valid JSON objects for configuring the server which might be helpful when generating it programmatically.

 - [X] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

 - Skip initial and final brackets from config syntax
 - Ignore trailing commas at the top level

/cc @nats-io/core
