### PR TITLE
Fix last activity monitoring test

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -769,7 +769,7 @@ func (c *client) processSub(argo []byte) (err error) {
 	c.traceInOp("SUB", argo)
 
 	// Indicate activity.
-	c.cache.subs += 1
+	c.cache.subs++
 
 	// Copy so we do not reference a potentially large buffer
 	arg := make([]byte, len(argo))

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -371,10 +371,6 @@ func TestConnzLastActivity(t *testing.T) {
 		defer nc.Close()
 		nc.Flush()
 
-		nc2 := createClientConnSubscribeAndPublish(t, s)
-		defer nc2.Close()
-		nc2.Flush()
-
 		// Test inside details of each connection
 		ci := pollConz(t, s, mode, url, opts).Conns[0]
 		if len(ci.Subs) != 1 {
@@ -429,8 +425,7 @@ func TestConnzLastActivity(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// Message delivery should trigger as well
-		nc2.Publish("foo", []byte("Hello"))
-		nc2.Flush()
+		nc.Publish("foo", []byte("Hello"))
 		nc.Flush()
 		ci = pollConz(t, s, mode, url, opts).Conns[0]
 		msgLast := ci.LastActivity


### PR DESCRIPTION
This test originally used only 1 connection. It was then modified
to use another connection to check the publishing effect into
the last activity. However, when polling for connz we were using
[0], but that may not necessarily match the connection we were
checking.
I don't think that there was a need for a new connection in this
test, so use a single connection.
