### PR TITLE
[FIXED] Random cluster port displayed as 0 instead of actual value

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -659,12 +659,13 @@ func (s *Server) routeAcceptLoop(ch chan struct{}) {
 	}
 
 	hp := net.JoinHostPort(opts.Cluster.Host, strconv.Itoa(port))
-	s.Noticef("Listening for route connections on %s", hp)
 	l, e := net.Listen("tcp", hp)
 	if e != nil {
 		s.Fatalf("Error listening on router port: %d - %v", opts.Cluster.Port, e)
 		return
 	}
+	s.Noticef("Listening for route connections on %s",
+		net.JoinHostPort(opts.Cluster.Host, strconv.Itoa(l.Addr().(*net.TCPAddr).Port)))
 
 	s.mu.Lock()
 	// Check for TLSConfig


### PR DESCRIPTION
Fix for the message displayed when `--cluster nats://localhost:-1` is specified. The current behavior is to print `localhost:0` rather than the actual port selected.