### PR TITLE
Remove route connection from temp map

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -549,16 +549,17 @@ func (s *Server) addRoute(c *client, info *Info) (bool, bool) {
 	}
 	remote, exists := s.remotes[id]
 	if !exists {
-		// Remove from the temporary map
-		s.grMu.Lock()
-		delete(s.grTmpClients, c.cid)
-		s.grMu.Unlock()
-
 		s.routes[c.cid] = c
 		s.remotes[id] = c
 		c.mu.Lock()
 		c.route.connectURLs = info.ClientConnectURLs
+		cid := c.cid
 		c.mu.Unlock()
+
+		// Remove from the temporary map
+		s.grMu.Lock()
+		delete(s.grTmpClients, cid)
+		s.grMu.Unlock()
 
 		// we don't need to send if the only route is the one we just accepted.
 		sendInfo = len(s.routes) > 1

--- a/server/server.go
+++ b/server/server.go
@@ -950,6 +950,10 @@ func (s *Server) removeClient(c *client) {
 				delete(s.remotes, rID)
 			}
 		}
+		// Remove from temporary map in case it is there.
+		s.grMu.Lock()
+		delete(s.grTmpClients, cid)
+		s.grMu.Unlock()
 	}
 	s.mu.Unlock()
 }


### PR DESCRIPTION
When a route connection is created, the server will keep track
of the client structure in a special map until the route protocol
completes. This is meant so that if the server is shutdown before
the route is registered in routes map, the server can kick out
the connection's readLoop.

The route connection was correctly removed on success, but was
not for route connections that were not registered and dropped.
This was not causing any issue, but for correctness, doing the
removal now when server removes a route connection.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
