### PR TITLE
[ADDED] Route permissions

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -63,6 +63,14 @@ type Permissions struct {
 	Subscribe []string `json:"subscribe"`
 }
 
+// RoutePermissions are similar to user permissions
+// but describe what a server can import/export from and to
+// another server.
+type RoutePermissions struct {
+	Import []string `json:"import"`
+	Export []string `json:"export"`
+}
+
 // clone performs a deep copy of the Permissions struct, returning a new clone
 // with all values copied.
 func (p *Permissions) clone() *Permissions {
@@ -184,7 +192,11 @@ func (s *Server) isRouterAuthorized(c *client) bool {
 	if opts.Cluster.Username != c.opts.Username {
 		return false
 	}
-	return comparePasswords(opts.Cluster.Password, c.opts.Password)
+	if !comparePasswords(opts.Cluster.Password, c.opts.Password) {
+		return false
+	}
+	c.setRoutePermissions(opts.Cluster.Permissions)
+	return true
 }
 
 // removeUnauthorizedSubs removes any subscriptions the client has that are no

--- a/server/client.go
+++ b/server/client.go
@@ -1080,17 +1080,14 @@ func (c *client) processSub(argo []byte) (err error) {
 	if c.typ == ROUTER {
 		if !c.canExport(sub.subject) {
 			c.mu.Unlock()
-			c.Debugf("Ignoring subscription from route on %q due to export permissions", sub.subject)
 			return nil
 		}
-	} else {
-		if !c.canSubscribe(sub.subject) {
-			c.mu.Unlock()
-			c.sendErr(fmt.Sprintf("Permissions Violation for Subscription to %q", sub.subject))
-			c.Errorf("Subscription Violation - User %q, Subject %q, SID %s",
-				c.opts.Username, sub.subject, sub.sid)
-			return nil
-		}
+	} else if !c.canSubscribe(sub.subject) {
+		c.mu.Unlock()
+		c.sendErr(fmt.Sprintf("Permissions Violation for Subscription to %q", sub.subject))
+		c.Errorf("Subscription Violation - User %q, Subject %q, SID %s",
+			c.opts.Username, sub.subject, sub.sid)
+		return nil
 	}
 
 	// We can have two SUB protocols coming from a route due to some

--- a/server/opts.go
+++ b/server/opts.go
@@ -382,9 +382,11 @@ func parseCluster(cm map[string]interface{}, opts *Options) error {
 			opts.Cluster.Password = auth.pass
 			opts.Cluster.AuthTimeout = auth.timeout
 			if auth.defaultPermissions != nil {
-				// For routes:
-				// Import is Publish
-				// Export is Subscribe
+				// Import is whether or not we will send a SUB for interest to the other side.
+				// Export is whether or not we will accept a SUB from the remote for a given subject.
+				// Both only effect interest registration.
+				// The parsing sets Import into Publish and Export into Subscribe, convert
+				// accordingly.
 				opts.Cluster.Permissions = &RoutePermissions{
 					Import: auth.defaultPermissions.Publish,
 					Export: auth.defaultPermissions.Subscribe,

--- a/server/route.go
+++ b/server/route.go
@@ -465,6 +465,50 @@ func (s *Server) forwardNewRouteInfoToKnownServers(info *Info) {
 	}
 }
 
+// If permissions are set for this cluster, this returns true if the
+// given subject has a match in the Import permissions.
+// This is for ROUTER connections only.
+// Lock is held on entry.
+func (c *client) canImport(subject []byte) bool {
+	// For routes:
+	// Import is Publish
+	// Export is Subscribe
+	// So use pubAllowed() here since we want to check Import
+	return c.pubAllowed(subject)
+}
+
+// If permissions are set for this cluster, this returns true if the
+// given subject has a match in the Export permissions.
+// This is for ROUTER connections only.
+// Lock is held on entry
+func (c *client) canExport(subject []byte) bool {
+	// For routes:
+	// Import is Publish
+	// Export is Subscribe
+	// So use canSubscribe() here since we want to check Export
+	return c.canSubscribe(subject)
+}
+
+// Initialize or reset cluster's permissions.
+// This is for ROUTER connections only.
+// Client lock is held on entry
+func (c *client) setRoutePermissions(perms *RoutePermissions) {
+	// Reset if some were set
+	if perms == nil {
+		c.perms = nil
+		return
+	}
+	// Convert route permissions to user permissions.
+	// For routes:
+	// Import is Publish
+	// Export is Subscribe
+	p := &Permissions{
+		Publish:   perms.Import,
+		Subscribe: perms.Export,
+	}
+	c.setPermissions(p)
+}
+
 // This will send local subscription state to a new route connection.
 // FIXME(dlc) - This could be a DOS or perf issue with many clients
 // and large subscription space. Plus buffering in place not a good idea.
@@ -476,6 +520,11 @@ func (s *Server) sendLocalSubsToRoute(route *client) {
 
 	route.mu.Lock()
 	for _, sub := range subs {
+		// Send SUB interest only if subject has a match in import permissions
+		if !route.canImport(sub.subject) {
+			s.Debugf("Not sending subscription interest on %q due to import permission", sub.subject)
+			continue
+		}
 		proto := fmt.Sprintf(subProto, sub.subject, sub.queue, routeSid(sub))
 		route.queueOutbound([]byte(proto))
 		if route.out.pb > int64(route.out.sz*2) {
@@ -519,6 +568,10 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 		// Do this before the TLS code, otherwise, in case of failure
 		// and if route is explicit, it would try to reconnect to 'nil'...
 		r.url = rURL
+
+		// Set permissions associated with the route user (if applicable).
+		// No lock needed since we are already under client lock.
+		c.setRoutePermissions(opts.Cluster.Permissions)
 	}
 
 	// Check for TLS
@@ -777,7 +830,7 @@ func (s *Server) addRoute(c *client, info *Info) (bool, bool) {
 	return !exists, sendInfo
 }
 
-func (s *Server) broadcastInterestToRoutes(proto string) {
+func (s *Server) broadcastInterestToRoutes(sub *subscription, proto string) {
 	var arg []byte
 	if atomic.LoadInt32(&s.logging.trace) == 1 {
 		arg = []byte(proto[:len(proto)-LEN_CR_LF])
@@ -787,6 +840,15 @@ func (s *Server) broadcastInterestToRoutes(proto string) {
 	for _, route := range s.routes {
 		// FIXME(dlc) - Make same logic as deliverMsg
 		route.mu.Lock()
+		// The permission of this cluster applies to all routes, and each
+		// route will have the same `perms`, so check with the first route
+		// and send SUB interest only if subject has a match in import permissions.
+		// If there is no match, we stop here.
+		if !route.canImport(sub.subject) {
+			route.mu.Unlock()
+			s.Debugf("Not sending sub/unsub interest on %q to route due to import permission", sub.subject)
+			break
+		}
 		route.sendProto(protoAsBytes, true)
 		route.mu.Unlock()
 		route.traceOutOp("", arg)
@@ -802,7 +864,7 @@ func (s *Server) broadcastSubscribe(sub *subscription) {
 	}
 	rsid := routeSid(sub)
 	proto := fmt.Sprintf(subProto, sub.subject, sub.queue, rsid)
-	s.broadcastInterestToRoutes(proto)
+	s.broadcastInterestToRoutes(sub, proto)
 }
 
 // broadcastUnSubscribe will forward a client unsubscribe
@@ -820,7 +882,7 @@ func (s *Server) broadcastUnSubscribe(sub *subscription) {
 	}
 	rsid := routeSid(sub)
 	proto := fmt.Sprintf(unsubProto, rsid)
-	s.broadcastInterestToRoutes(proto)
+	s.broadcastInterestToRoutes(sub, proto)
 }
 
 func (s *Server) routeAcceptLoop(ch chan struct{}) {

--- a/test/configs/srv_a_perms.conf
+++ b/test/configs/srv_a_perms.conf
@@ -1,0 +1,25 @@
+# Cluster Server A
+
+listen: 127.0.0.1:5222
+
+cluster {
+  listen: 127.0.0.1:5244
+
+  authorization {
+    user: ruser
+    password: top_secret
+    timeout: 0.5
+    permissions {
+      import: "foo"
+      export: ["bar", "baz"]
+    }
+  }
+
+  # Routes are actively solicited and connected to from this server.
+  # Other servers can connect to us if they supply the correct credentials
+  # in their routes definitions from above.
+
+  routes = [
+    nats-route://ruser:top_secret@127.0.0.1:5246
+  ]
+}


### PR DESCRIPTION
Adds permissions for the cluster. There are Import and Export permissions.

The `client.perms` struct is left unchanged. We simply map Import
and Export semantics to existing Publish and Subscribe ones.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
