### PR TITLE
Fix some tests

### DIFF
--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -1441,18 +1441,7 @@ func TestConfigReloadClusterRemoveSolicitedRoutes(t *testing.T) {
 	srvb.Shutdown()
 
 	// Wait til route is dropped.
-	numRoutes := 0
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if numRoutes = srva.NumRoutes(); numRoutes == 0 {
-			break
-		} else {
-			time.Sleep(100 * time.Millisecond)
-		}
-	}
-	if numRoutes != 0 {
-		t.Fatalf("Expected 0 routes for server A, got %d", numRoutes)
-	}
+	checkNumRoutes(t, srva, 0)
 
 	// Now change config for server A to not solicit a route to server B.
 	createSymlink(t, srvaConfig, "./configs/reload/srv_a_4.conf")
@@ -1466,7 +1455,8 @@ func TestConfigReloadClusterRemoveSolicitedRoutes(t *testing.T) {
 	defer srvb.Shutdown()
 
 	// We should not have a cluster formed here.
-	deadline = time.Now().Add(2 * DEFAULT_ROUTE_RECONNECT)
+	numRoutes := 0
+	deadline := time.Now().Add(2 * DEFAULT_ROUTE_RECONNECT)
 	for time.Now().Before(deadline) {
 		if numRoutes = srva.NumRoutes(); numRoutes != 0 {
 			break

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -14,7 +14,6 @@
 package server
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -28,6 +27,16 @@ import (
 
 	"github.com/nats-io/go-nats"
 )
+
+func checkNumRoutes(t *testing.T, s *Server, expected int) {
+	t.Helper()
+	checkFor(t, 5*time.Second, 15*time.Millisecond, func() error {
+		if nr := s.NumRoutes(); nr != expected {
+			return fmt.Errorf("Expected %v routes, got %v", expected, nr)
+		}
+		return nil
+	})
+}
 
 func TestRouteConfig(t *testing.T) {
 	opts, err := ProcessConfigFile("./configs/cluster.conf")
@@ -134,21 +143,15 @@ func TestClusterAdvertiseErrorOnStartup(t *testing.T) {
 		s.Start()
 		wg.Done()
 	}()
-	msg := ""
-	ok := false
-	timeout := time.Now().Add(2 * time.Second)
-	for time.Now().Before(timeout) {
+	checkFor(t, 2*time.Second, 15*time.Millisecond, func() error {
 		dl.Lock()
-		msg = dl.msg
+		msg := dl.msg
 		dl.Unlock()
 		if strings.Contains(msg, "Cluster.Advertise") {
-			ok = true
-			break
+			return nil
 		}
-	}
-	if !ok {
-		t.Fatalf("Did not get expected error, got %v", msg)
-	}
+		return fmt.Errorf("Did not get expected error, got %v", msg)
+	})
 	s.Shutdown()
 	wg.Wait()
 }
@@ -173,21 +176,15 @@ func TestClientAdvertise(t *testing.T) {
 		t.Fatalf("Error on connect: %v", err)
 	}
 	defer nc.Close()
-	timeout := time.Now().Add(time.Second)
-	good := false
-	for time.Now().Before(timeout) {
+	checkFor(t, time.Second, 15*time.Millisecond, func() error {
 		ds := nc.DiscoveredServers()
 		if len(ds) == 1 {
 			if ds[0] == "nats://me:1" {
-				good = true
-				break
+				return nil
 			}
 		}
-		time.Sleep(15 * time.Millisecond)
-	}
-	if !good {
-		t.Fatalf("Did not get expected discovered servers: %v", nc.DiscoveredServers())
-	}
+		return fmt.Errorf("Did not get expected discovered servers: %v", nc.DiscoveredServers())
+	})
 }
 
 func TestServerRoutesWithClients(t *testing.T) {
@@ -284,27 +281,16 @@ func TestServerRoutesWithAuthAndBCrypt(t *testing.T) {
 
 // Helper function to check that a cluster is formed
 func checkClusterFormed(t *testing.T, servers ...*Server) {
-	// Wait for the cluster to form
-	var err string
+	t.Helper()
 	expectedNumRoutes := len(servers) - 1
-	maxTime := time.Now().Add(10 * time.Second)
-	for time.Now().Before(maxTime) {
-		err = ""
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
 		for _, s := range servers {
 			if numRoutes := s.NumRoutes(); numRoutes != expectedNumRoutes {
-				err = fmt.Sprintf("Expected %d routes for server %q, got %d", expectedNumRoutes, s.ID(), numRoutes)
-				break
+				return fmt.Errorf("Expected %d routes for server %q, got %d", expectedNumRoutes, s.ID(), numRoutes)
 			}
 		}
-		if err != "" {
-			time.Sleep(100 * time.Millisecond)
-		} else {
-			break
-		}
-	}
-	if err != "" {
-		stackFatalf(t, "%s", err)
-	}
+		return nil
+	})
 }
 
 // Helper function to generate next opts to make sure no port conflicts etc.
@@ -485,27 +471,16 @@ func TestChainedSolicitWorks(t *testing.T) {
 
 // Helper function to check that a server (or list of servers) have the
 // expected number of subscriptions.
-func checkExpectedSubs(expected int, servers ...*Server) error {
-	var err string
-	maxTime := time.Now().Add(10 * time.Second)
-	for time.Now().Before(maxTime) {
-		err = ""
+func checkExpectedSubs(t *testing.T, expected int, servers ...*Server) {
+	t.Helper()
+	checkFor(t, 10*time.Second, 10*time.Millisecond, func() error {
 		for _, s := range servers {
 			if numSubs := int(s.NumSubscriptions()); numSubs != expected {
-				err = fmt.Sprintf("Expected %d subscriptions for server %q, got %d", expected, s.ID(), numSubs)
-				break
+				return fmt.Errorf("Expected %d subscriptions for server %q, got %d", expected, s.ID(), numSubs)
 			}
 		}
-		if err != "" {
-			time.Sleep(10 * time.Millisecond)
-		} else {
-			break
-		}
-	}
-	if err != "" {
-		return errors.New(err)
-	}
-	return nil
+		return nil
+	})
 }
 
 func TestTLSChainedSolicitWorks(t *testing.T) {
@@ -546,9 +521,7 @@ func TestTLSChainedSolicitWorks(t *testing.T) {
 	defer srvB.Shutdown()
 
 	checkClusterFormed(t, srvSeed, srvA, srvB)
-	if err := checkExpectedSubs(1, srvA, srvB); err != nil {
-		t.Fatalf("%v", err)
-	}
+	checkExpectedSubs(t, 1, srvA, srvB)
 
 	urlB := fmt.Sprintf("nats://%s:%d/", optsB.Host, srvB.Addr().(*net.TCPAddr).Port)
 
@@ -583,17 +556,7 @@ func TestRouteTLSHandshakeError(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	maxTime := time.Now().Add(1 * time.Second)
-	for time.Now().Before(maxTime) {
-		if srv.NumRoutes() > 0 {
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
-		break
-	}
-	if srv.NumRoutes() > 0 {
-		t.Fatal("Route should have failed")
-	}
+	checkNumRoutes(t, srv, 0)
 }
 
 func TestBlockedShutdownOnRouteAcceptLoopFailure(t *testing.T) {
@@ -826,12 +789,8 @@ func TestServerPoolUpdatedWhenRouteGoesAway(t *testing.T) {
 		// Don't use discovered here, but Servers to have the full list.
 		// Also, there may be cases where the mesh is not formed yet,
 		// so try again on failure.
-		var (
-			ds      []string
-			timeout = time.Now().Add(5 * time.Second)
-		)
-		for time.Now().Before(timeout) {
-			ds = nc.Servers()
+		checkFor(t, 5*time.Second, 50*time.Millisecond, func() error {
+			ds := nc.Servers()
 			if len(ds) == len(expected) {
 				m := make(map[string]struct{}, len(ds))
 				for _, url := range ds {
@@ -845,12 +804,11 @@ func TestServerPoolUpdatedWhenRouteGoesAway(t *testing.T) {
 					}
 				}
 				if ok {
-					return
+					return nil
 				}
 			}
-			time.Sleep(50 * time.Millisecond)
-		}
-		stackFatalf(t, "Expected %v, got %v", expected, ds)
+			return fmt.Errorf("Expected %v, got %v", expected, ds)
+		})
 	}
 	// Verify that we now know about s2
 	checkPool([]string{s1Url, s2Url})
@@ -972,8 +930,7 @@ func TestRoutedQueueAutoUnsubscribe(t *testing.T) {
 		c.Flush()
 	}
 
-	wait := time.Now().Add(10 * time.Second)
-	for time.Now().Before(wait) {
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
 		nbar := atomic.LoadInt32(&rbar)
 		nbaz := atomic.LoadInt32(&rbaz)
 		if nbar == expected && nbaz == expected {
@@ -986,15 +943,14 @@ func TestRoutedQueueAutoUnsubscribe(t *testing.T) {
 			nrqsb := len(srvB.rqsubs)
 			srvB.rqsMu.RUnlock()
 			if nrqsa != 0 || nrqsb != 0 {
-				t.Fatalf("Expected rqs mappings to have cleared, but got A:%d, B:%d\n",
+				return fmt.Errorf("Expected rqs mappings to have cleared, but got A:%d, B:%d",
 					nrqsa, nrqsb)
 			}
-			return
+			return nil
 		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	t.Fatalf("Did not receive all %d queue messages, received %d for 'bar' and %d for 'baz'\n",
-		expected, atomic.LoadInt32(&rbar), atomic.LoadInt32(&rbaz))
+		return fmt.Errorf("Did not receive all %d queue messages, received %d for 'bar' and %d for 'baz'",
+			expected, atomic.LoadInt32(&rbar), atomic.LoadInt32(&rbaz))
+	})
 }
 
 func TestRouteFailedConnRemovedFromTmpMap(t *testing.T) {
@@ -1012,8 +968,16 @@ func TestRouteFailedConnRemovedFromTmpMap(t *testing.T) {
 	// Start this way to increase chance of having the two connect
 	// to each other at the same time. This will cause one of the
 	// route to be dropped.
-	go srvA.Start()
-	go srvB.Start()
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		srvA.Start()
+		wg.Done()
+	}()
+	go func() {
+		srvB.Start()
+		wg.Done()
+	}()
 
 	checkClusterFormed(t, srvA, srvB)
 
@@ -1028,4 +992,8 @@ func TestRouteFailedConnRemovedFromTmpMap(t *testing.T) {
 	}
 	checkMap(srvA)
 	checkMap(srvB)
+
+	srvB.Shutdown()
+	srvA.Shutdown()
+	wg.Wait()
 }

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -25,27 +25,26 @@ import (
 
 // Helper function to check that a cluster is formed
 func checkClusterFormed(t *testing.T, servers ...*server.Server) {
-	// Wait for the cluster to form
-	var err string
+	t.Helper()
 	expectedNumRoutes := len(servers) - 1
-	maxTime := time.Now().Add(5 * time.Second)
-	for time.Now().Before(maxTime) {
-		err = ""
+	checkFor(t, 10*time.Second, 100*time.Millisecond, func() error {
 		for _, s := range servers {
 			if numRoutes := s.NumRoutes(); numRoutes != expectedNumRoutes {
-				err = fmt.Sprintf("Expected %d routes for server %q, got %d", expectedNumRoutes, s.ID(), numRoutes)
-				break
+				return fmt.Errorf("Expected %d routes for server %q, got %d", expectedNumRoutes, s.ID(), numRoutes)
 			}
 		}
-		if err != "" {
-			time.Sleep(100 * time.Millisecond)
-		} else {
-			break
+		return nil
+	})
+}
+
+func checkNumRoutes(t *testing.T, s *server.Server, expected int) {
+	t.Helper()
+	checkFor(t, 5*time.Second, 15*time.Millisecond, func() error {
+		if nr := s.NumRoutes(); nr != expected {
+			return fmt.Errorf("Expected %v routes, got %v", expected, nr)
 		}
-	}
-	if err != "" {
-		t.Fatalf("%s", err)
-	}
+		return nil
+	})
 }
 
 // Helper function to check that a server (or list of servers) have the

--- a/test/route_discovery_test.go
+++ b/test/route_discovery_test.go
@@ -297,37 +297,16 @@ func TestStressSeedSolicitWorks(t *testing.T) {
 
 			serversInfo := []serverInfo{{s1, opts}, {s2, s2Opts}, {s3, s3Opts}, {s4, s4Opts}}
 
-			var err error
-			maxTime := time.Now().Add(5 * time.Second)
-			for time.Now().Before(maxTime) {
+			checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
 				for j := 0; j < len(serversInfo); j++ {
-					err = checkConnected(t, serversInfo, j, true)
-					// If error, start this for loop from beginning
-					if err != nil {
-						// Sleep a bit before the next attempt
-						time.Sleep(100 * time.Millisecond)
-						break
+					if err := checkConnected(t, serversInfo, j, true); err != nil {
+						return err
 					}
 				}
-				// All servers checked ok, we are done, otherwise, try again
-				// until time is up
-				if err == nil {
-					break
-				}
-			}
-			// Report error
-			if err != nil {
-				t.Fatalf("Error: %v", err)
-			}
+				return nil
+			})
 		}()
-		maxTime := time.Now().Add(2 * time.Second)
-		for time.Now().Before(maxTime) {
-			if s1.NumRoutes() > 0 {
-				time.Sleep(10 * time.Millisecond)
-			} else {
-				break
-			}
-		}
+		checkNumRoutes(t, s1, 0)
 	}
 }
 
@@ -436,37 +415,16 @@ func TestStressChainedSolicitWorks(t *testing.T) {
 
 			serversInfo := []serverInfo{{s1, opts}, {s2, s2Opts}, {s3, s3Opts}, {s4, s4Opts}}
 
-			var err error
-			maxTime := time.Now().Add(5 * time.Second)
-			for time.Now().Before(maxTime) {
+			checkFor(t, 5*time.Second, 100*time.Millisecond, func() error {
 				for j := 0; j < len(serversInfo); j++ {
-					err = checkConnected(t, serversInfo, j, false)
-					// If error, start this for loop from beginning
-					if err != nil {
-						// Sleep a bit before the next attempt
-						time.Sleep(100 * time.Millisecond)
-						break
+					if err := checkConnected(t, serversInfo, j, false); err != nil {
+						return err
 					}
 				}
-				// All servers checked ok, we are done, otherwise, try again
-				// until time is up
-				if err == nil {
-					break
-				}
-			}
-			// Report error
-			if err != nil {
-				t.Fatalf("Error: %v", err)
-			}
+				return nil
+			})
 		}()
-		maxTime := time.Now().Add(2 * time.Second)
-		for time.Now().Before(maxTime) {
-			if s1.NumRoutes() > 0 {
-				time.Sleep(10 * time.Millisecond)
-			} else {
-				break
-			}
-		}
+		checkNumRoutes(t, s1, 0)
 	}
 }
 

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -18,7 +18,24 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
+
+func checkFor(t *testing.T, totalWait, sleepDur time.Duration, f func() error) {
+	t.Helper()
+	timeout := time.Now().Add(totalWait)
+	var err error
+	for time.Now().Before(timeout) {
+		err = f()
+		if err == nil {
+			return
+		}
+		time.Sleep(sleepDur)
+	}
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
 
 type dummyLogger struct {
 	sync.Mutex


### PR DESCRIPTION
Add some helpers to check on some state.

I propose that we standardize the use of `checkXXX` as helper functions
to check a state and fail if getting unexpected result after a given timeout.
There is a low-level checkFor() that other helpers will use with the error
function, timeout, etc..

Having those helpers starting with `check` will help developers find an 
existing function instead of ending up creating one.

The place where I added those helpers could change, not sure where to
put them.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
