### PR TITLE
Fixes #686

### DIFF
--- a/server/configs/reload/reload.conf
+++ b/server/configs/reload/reload.conf
@@ -1,5 +1,7 @@
 include 'platform.conf'
 
+port: 2233
+
 # logging options
 debug:         true # enable on reload
 trace:         true # enable on reload

--- a/server/configs/reload/test.conf
+++ b/server/configs/reload/test.conf
@@ -1,3 +1,5 @@
+port: 2233
+
 # logging options
 debug:   false
 trace:   false

--- a/server/configs/tls_ciphers.conf
+++ b/server/configs/tls_ciphers.conf
@@ -25,6 +25,6 @@ tls {
 
 authorization {
   user:     derek
-  password: buckley
+  password: monkey
   timeout:  1
 }

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -54,7 +54,7 @@ func TestConfigReloadUnsupported(t *testing.T) {
 	golden := &Options{
 		ConfigFile:     config,
 		Host:           "0.0.0.0",
-		Port:           4222,
+		Port:           2233,
 		AuthTimeout:    1.0,
 		Debug:          false,
 		Trace:          false,
@@ -144,7 +144,7 @@ func TestConfigReloadInvalidConfig(t *testing.T) {
 	golden := &Options{
 		ConfigFile:     config,
 		Host:           "0.0.0.0",
-		Port:           4222,
+		Port:           2233,
 		AuthTimeout:    1.0,
 		Debug:          false,
 		Trace:          false,
@@ -210,7 +210,7 @@ func TestConfigReload(t *testing.T) {
 	golden := &Options{
 		ConfigFile:     config,
 		Host:           "0.0.0.0",
-		Port:           4222,
+		Port:           2233,
 		AuthTimeout:    1.0,
 		Debug:          false,
 		Trace:          false,

--- a/server/signal_test.go
+++ b/server/signal_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"strings"
 	"syscall"
 	"testing"
@@ -102,6 +103,14 @@ func TestSignalToReloadConfig(t *testing.T) {
 }
 
 func TestProcessSignalNoProcesses(t *testing.T) {
+	pgrepBefore := pgrep
+	pgrep = func() ([]byte, error) {
+		return nil, &exec.ExitError{}
+	}
+	defer func() {
+		pgrep = pgrepBefore
+	}()
+
 	err := ProcessSignal(CommandStop, "")
 	if err == nil {
 		t.Fatal("Expected error")


### PR DESCRIPTION
Allows a server to be running on default listen and monitoring ports and tests can still run successfully and not terminate the existing server.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
