### PR TITLE
[FIXED] Possible cluster `Authorization Error` during config reload

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 		fs.Usage,
 		server.PrintTLSHelpAndDie)
 	if err != nil {
-		server.PrintAndDie(err.Error() + "\n" + usageStr)
+		server.PrintAndDie(err.Error())
 	}
 
 	// Create the server with appropriate options.

--- a/server/reload.go
+++ b/server/reload.go
@@ -656,11 +656,14 @@ func (s *Server) reloadAuthorization() {
 		s.removeUnauthorizedSubs(client)
 	}
 
-	for _, client := range routes {
+	for _, route := range routes {
 		// Disconnect any unauthorized routes.
-		if !s.isRouterAuthorized(client) {
-			client.setRouteNoReconnectOnClose()
-			client.authViolation()
+		// Do this only for route that were accepted, not initiated
+		// because in the later case, we don't have the user name/password
+		// of the remote server.
+		if !route.isSolicitedRoute() && !s.isRouterAuthorized(route) {
+			route.setRouteNoReconnectOnClose()
+			route.authViolation()
 		}
 	}
 }

--- a/server/route.go
+++ b/server/route.go
@@ -1032,7 +1032,7 @@ func (s *Server) reConnectToRoute(rURL *url.URL, rtype RouteType) {
 // Checks to make sure the route is still valid.
 func (s *Server) routeStillValid(rURL *url.URL) bool {
 	for _, ri := range s.getOpts().Routes {
-		if ri == rURL {
+		if ri.String() == rURL.String() {
 			return true
 		}
 	}

--- a/test/test.go
+++ b/test/test.go
@@ -245,8 +245,8 @@ func sendProto(t tLogger, c net.Conn, op string) {
 
 var (
 	infoRe    = regexp.MustCompile(`INFO\s+([^\r\n]+)\r\n`)
-	pingRe    = regexp.MustCompile(`PING\r\n`)
-	pongRe    = regexp.MustCompile(`PONG\r\n`)
+	pingRe    = regexp.MustCompile(`^PING\r\n`)
+	pongRe    = regexp.MustCompile(`^PONG\r\n`)
 	msgRe     = regexp.MustCompile(`(?:(?:MSG\s+([^\s]+)\s+([^\s]+)\s+(([^\s]+)[^\S\r\n]+)?(\d+)\s*\r\n([^\\r\\n]*?)\r\n)+?)`)
 	okRe      = regexp.MustCompile(`\A\+OK\r\n`)
 	errRe     = regexp.MustCompile(`\A\-ERR\s+([^\r\n]+)\r\n`)


### PR DESCRIPTION
When changing something in the cluster, such as Timeout and doing
a config reload, the route could be closed with an `Authorization
Error` report. Moreover, the route would not try to reconnect,
even if specified as an explicit route.

There were 2 issues:
- When checking if a solicited route is still valid, we need to
  check the Routes' URL against the URL that we try to connect
  to but not compare the pointers, but either do a reflect
  deep equal, or compare their String representation (this is
  what I do in the PR).
- We should check route authorization only if this is an accepted
  route, not an explicit one. The reason is that we a server
  explicitly connect to another server, it does not get the remote
  server's username and password. So the check would always fail.

Note: It is possible that a config reload even without any change
in the cluster triggers the code checking if routes are properly
authorized, and that happens if there is TLS specified. When
the reload code checks if config has changed, the TLSConfig
between the old and new seem to indicate a change, eventhough there
is apparently none. Another reload does not detect a change. I
suspect some internal state in TLSConfig that causes the
reflect.DeepEqual() to report a difference.

Note2: This commit also contains fixes to regex that staticcheck
would otherwise complain about (they did not have any special
character), and I have removed printing the usage on startup when
getting an error. The usage is still correctly printed if passing
a parameter that is unknown.

Resolves #719

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
