### PR TITLE
Ensure URLs are compared using reflect.DeepEqual

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -1032,7 +1032,7 @@ func (s *Server) reConnectToRoute(rURL *url.URL, rtype RouteType) {
 // Checks to make sure the route is still valid.
 func (s *Server) routeStillValid(rURL *url.URL) bool {
 	for _, ri := range s.getOpts().Routes {
-		if ri.String() == rURL.String() {
+		if urlsAreEqual(ri, rURL) {
 			return true
 		}
 	}

--- a/server/util.go
+++ b/server/util.go
@@ -17,6 +17,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -108,4 +110,10 @@ func parseHostPort(hostPort string, defaultPort int) (host string, port int, err
 		return strings.TrimSpace(host), port, nil
 	}
 	return "", -1, errors.New("No hostport specified")
+}
+
+// Returns true if URL u1 represents the same URL than u2,
+// false otherwise.
+func urlsAreEqual(u1, u2 *url.URL) bool {
+	return reflect.DeepEqual(u1, u2)
 }

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"math/rand"
+	"net/url"
 	"strconv"
 	"sync"
 	"testing"
@@ -75,6 +76,31 @@ func TestParseHostPort(t *testing.T) {
 	check("addr:addr", 0, "", 0, true)
 	check("addr:::1234", 0, "", 0, true)
 	check("", 0, "", 0, true)
+}
+
+func TestURLsAreEqual(t *testing.T) {
+	check := func(t *testing.T, u1Str, u2Str string, expectedSame bool) {
+		t.Helper()
+		u1, err := url.Parse(u1Str)
+		if err != nil {
+			t.Fatalf("Error parsing url %q: %v", u1Str, err)
+		}
+		u2, err := url.Parse(u2Str)
+		if err != nil {
+			t.Fatalf("Error parsing url %q: %v", u2Str, err)
+		}
+		same := urlsAreEqual(u1, u2)
+		if expectedSame && !same {
+			t.Fatalf("Expected %v and %v to be the same, they were not", u1, u2)
+		} else if !expectedSame && same {
+			t.Fatalf("Expected %v and %v to be different, they were not", u1, u2)
+		}
+	}
+	check(t, "nats://localhost:4222", "nats://localhost:4222", true)
+	check(t, "nats://ivan:pwd@localhost:4222", "nats://ivan:pwd@localhost:4222", true)
+	check(t, "nats://ivan@localhost:4222", "nats://ivan@localhost:4222", true)
+	check(t, "nats://ivan:@localhost:4222", "nats://ivan:@localhost:4222", true)
+	check(t, "nats://host1:4222", "nats://host2:4222", false)
 }
 
 func BenchmarkParseInt(b *testing.B) {


### PR DESCRIPTION
I don't think it is a good thing to compare the pointers and we
should use the DeepEqual instead.
When comparing a solicited route's URL to the URL that was created
during the parsing of the configuration, the pointers maybe the
same and so u1 == u2 would work. However, there are cases where
the URL is built on the fly based on the received route INFO protocol
so I think it is safer to use a function that does a reflect.DeepEqual
instead.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
