### PR TITLE
Update service and syslog code to use variable instead of constant

### DIFF
--- a/logger/syslog.go
+++ b/logger/syslog.go
@@ -31,6 +31,10 @@ type SysLogger struct {
 	trace  bool
 }
 
+// SetSyslogName sets the name to use for the syslog.
+// Currently used only on Windows.
+func SetSyslogName(name string) {}
+
 // GetSysLoggerTag generates the tag name for use in syslog statements. If
 // the executable is linked, the name of the link will be used as the tag,
 // otherwise, the name of the executable is used.  "gnatsd" is the default

--- a/logger/syslog_windows.go
+++ b/logger/syslog_windows.go
@@ -22,9 +22,12 @@ import (
 	"golang.org/x/sys/windows/svc/eventlog"
 )
 
-const (
-	natsEventSource = "NATS-Server"
-)
+var natsEventSource = "NATS-Server"
+
+// SetSyslogName sets the name to use for the system log event source
+func SetSyslogName(name string) {
+	natsEventSource = name
+}
 
 // SysLogger logs to the windows event logger
 type SysLogger struct {

--- a/server/const.go
+++ b/server/const.go
@@ -35,7 +35,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "1.2.0"
+	VERSION = "1.3.0"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/service_windows.go
+++ b/server/service_windows.go
@@ -22,11 +22,17 @@ import (
 )
 
 const (
-	serviceName     = "gnatsd"
 	reopenLogCode   = 128
 	reopenLogCmd    = svc.Cmd(reopenLogCode)
 	acceptReopenLog = svc.Accepted(reopenLogCode)
 )
+
+var serviceName = "gnatsd"
+
+// SetServiceName allows setting a different service name
+func SetServiceName(name string) {
+	serviceName = name
+}
 
 // winServiceWrapper implements the svc.Handler interface for implementing
 // gnatsd as a Windows service.

--- a/server/signal.go
+++ b/server/signal.go
@@ -26,7 +26,12 @@ import (
 	"syscall"
 )
 
-const processName = "gnatsd"
+var processName = "gnatsd"
+
+// SetProcessName allows to change the expected name of the process.
+func SetProcessName(name string) {
+	processName = name
+}
 
 // Signal Handling
 func (s *Server) handleSignals() {
@@ -76,10 +81,10 @@ func ProcessSignal(command Command, pidStr string) error {
 			return err
 		}
 		if len(pids) == 0 {
-			return errors.New("no gnatsd processes running")
+			return fmt.Errorf("no %s processes running", processName)
 		}
 		if len(pids) > 1 {
-			errStr := "multiple gnatsd processes running:\n"
+			errStr := fmt.Sprintf("multiple %s processes running:\n", processName)
 			prefix := ""
 			for _, p := range pids {
 				errStr += fmt.Sprintf("%s%d", prefix, p)


### PR DESCRIPTION
for the process name and service name. This allows the reuse of this
code in NATS Streaming Server by invoking the new setters to
change the service and process names.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
