### PR TITLE
Sublist Shared Cache Improvements

### DIFF
--- a/server/sublist.go
+++ b/server/sublist.go
@@ -42,6 +42,8 @@ var (
 const (
 	// cacheMax is used to bound limit the frontend cache
 	slCacheMax = 1024
+	// If we run a sweeper we will drain to this count.
+	slCacheSweep = 512
 	// plistMin is our lower bounds to create a fast plist for Match.
 	plistMin = 256
 )
@@ -60,8 +62,10 @@ type Sublist struct {
 	cacheHits uint64
 	inserts   uint64
 	removes   uint64
-	cache     map[string]*SublistResult
 	root      *level
+	cache     sync.Map
+	cacheNum  int32
+	ccSweep   int32
 	count     uint32
 }
 
@@ -92,7 +96,7 @@ func newLevel() *level {
 
 // New will create a default sublist
 func NewSublist() *Sublist {
-	return &Sublist{root: newLevel(), cache: make(map[string]*SublistResult)}
+	return &Sublist{root: newLevel()}
 }
 
 // Insert adds a subscription into the sublist
@@ -222,48 +226,57 @@ func (r *SublistResult) addSubToResult(sub *subscription) *SublistResult {
 // entries if needed. Assumes write lock is held.
 func (s *Sublist) addToCache(subject string, sub *subscription) {
 	// If literal we can direct match.
-	if IsValidLiteralSubject(subject) {
-		if r, ok := s.cache[subject]; ok {
-			s.cache[subject] = r.addSubToResult(sub)
+	if subjectIsLiteral(subject) {
+		if v, ok := s.cache.Load(subject); ok {
+			r := v.(*SublistResult)
+			s.cache.Store(subject, r.addSubToResult(sub))
 		}
 		return
 	}
-
-	for k, r := range s.cache {
-		if matchLiteral(k, subject) {
-			s.cache[k] = r.addSubToResult(sub)
+	s.cache.Range(func(k, v interface{}) bool {
+		key := k.(string)
+		r := v.(*SublistResult)
+		if matchLiteral(key, subject) {
+			s.cache.Store(key, r.addSubToResult(sub))
+			return false
 		}
-	}
+		return true
+	})
 }
 
 // removeFromCache will remove the sub from any active cache entries.
 // Assumes write lock is held.
 func (s *Sublist) removeFromCache(subject string, sub *subscription) {
 	// If literal we can direct match.
-	if IsValidLiteralSubject(subject) {
-		delete(s.cache, subject)
+	if subjectIsLiteral(subject) {
+		// Load for accounting
+		if _, ok := s.cache.Load(subject); ok {
+			s.cache.Delete(subject)
+			atomic.AddInt32(&s.cacheNum, -1)
+		}
 		return
 	}
-	for k := range s.cache {
-		if !matchLiteral(k, subject) {
-			continue
+	s.cache.Range(func(k, v interface{}) bool {
+		key := k.(string)
+		if matchLiteral(key, subject) {
+			// Since someone else may be referecing, can't modify the list
+			// safely, just let it re-populate.
+			s.cache.Delete(key)
+			atomic.AddInt32(&s.cacheNum, -1)
 		}
-		// Since someone else may be referecing, can't modify the list
-		// safely, just let it re-populate.
-		delete(s.cache, k)
-	}
+		return true
+	})
 }
 
 // Match will match all entries to the literal subject.
 // It will return a set of results for both normal and queue subscribers.
 func (s *Sublist) Match(subject string) *SublistResult {
-	s.RLock()
 	atomic.AddUint64(&s.matches, 1)
-	rc, ok := s.cache[subject]
-	s.RUnlock()
-	if ok {
+
+	// Check cache first.
+	if r, ok := s.cache.Load(subject); ok {
 		atomic.AddUint64(&s.cacheHits, 1)
-		return rc
+		return r.(*SublistResult)
 	}
 
 	tsa := [32]string{}
@@ -280,21 +293,34 @@ func (s *Sublist) Match(subject string) *SublistResult {
 	// FIXME(dlc) - Make shared pool between sublist and client readLoop?
 	result := &SublistResult{}
 
-	s.Lock()
+	s.RLock()
 	matchLevel(s.root, tokens, result)
+	s.RUnlock()
 
 	// Add to our cache
-	s.cache[subject] = result
-	// Bound the number of entries to sublistMaxCache
-	if len(s.cache) > slCacheMax {
-		for k := range s.cache {
-			delete(s.cache, k)
-			break
-		}
+	s.cache.Store(subject, result)
+	n := atomic.AddInt32(&s.cacheNum, 1)
+
+	if n > slCacheMax && atomic.CompareAndSwapInt32(&s.ccSweep, 0, 1) {
+		go s.reduceCacheCount()
 	}
-	s.Unlock()
 
 	return result
+}
+
+// Remove entries in the cache until we are under the maximum.
+// TODO(dlc) this could be smarter now that its not inline.
+func (s *Sublist) reduceCacheCount() {
+	defer atomic.StoreInt32(&s.ccSweep, 0)
+	// If we are over the cache limit randomly drop until under the limit.
+	s.cache.Range(func(k, v interface{}) bool {
+		s.cache.Delete(k.(string))
+		n := atomic.AddInt32(&s.cacheNum, -1)
+		if n < slCacheSweep {
+			return false
+		}
+		return true
+	})
 }
 
 // This will add in a node's results to the total results.
@@ -545,9 +571,7 @@ func (s *Sublist) Count() uint32 {
 
 // CacheCount returns the number of result sets in the cache.
 func (s *Sublist) CacheCount() int {
-	s.RLock()
-	defer s.RUnlock()
-	return len(s.cache)
+	return int(atomic.LoadInt32(&s.cacheNum))
 }
 
 // Public stats for the sublist
@@ -569,25 +593,30 @@ func (s *Sublist) Stats() *SublistStats {
 
 	st := &SublistStats{}
 	st.NumSubs = s.count
-	st.NumCache = uint32(len(s.cache))
+	st.NumCache = uint32(atomic.LoadInt32(&s.cacheNum))
 	st.NumInserts = s.inserts
 	st.NumRemoves = s.removes
 	st.NumMatches = atomic.LoadUint64(&s.matches)
 	if st.NumMatches > 0 {
 		st.CacheHitRate = float64(atomic.LoadUint64(&s.cacheHits)) / float64(st.NumMatches)
 	}
+
 	// whip through cache for fanout stats, this can be off if cache is full and doing evictions.
 	tot, max := 0, 0
-	for _, r := range s.cache {
+	clen := 0
+	s.cache.Range(func(k, v interface{}) bool {
+		clen += 1
+		r := v.(*SublistResult)
 		l := len(r.psubs) + len(r.qsubs)
 		tot += l
 		if l > max {
 			max = l
 		}
-	}
+		return true
+	})
 	st.MaxFanout = uint32(max)
 	if tot > 0 {
-		st.AvgFanout = float64(tot) / float64(len(s.cache))
+		st.AvgFanout = float64(tot) / float64(clen)
 	}
 	return st
 }
@@ -630,6 +659,20 @@ func visitLevel(l *level, depth int) int {
 		}
 	}
 	return maxDepth
+}
+
+// Determine if the subject has any wildcards. Fast version, does not check for
+// valid subject. Used in caching layer.
+func subjectIsLiteral(subject string) bool {
+	for i, c := range subject {
+		if c == pwc || c == fwc {
+			if (i == 0 || subject[i-1] == btsep) &&
+				(i+1 == len(subject) || subject[i+1] == btsep) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // IsValidSubject returns true if a subject is valid, false otherwise

--- a/server/sublist.go
+++ b/server/sublist.go
@@ -238,7 +238,6 @@ func (s *Sublist) addToCache(subject string, sub *subscription) {
 		r := v.(*SublistResult)
 		if matchLiteral(key, subject) {
 			s.cache.Store(key, r.addSubToResult(sub))
-			return false
 		}
 		return true
 	})

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -495,6 +495,18 @@ func TestSublistMatchLiterals(t *testing.T) {
 	checkBool(matchLiteral("foo.>>>.bar", "foo.>>>.bar"), true, t)
 }
 
+func TestSubjectIsLiteral(t *testing.T) {
+	checkBool(subjectIsLiteral("foo"), true, t)
+	checkBool(subjectIsLiteral("foo.bar"), true, t)
+	checkBool(subjectIsLiteral("*"), false, t)
+	checkBool(subjectIsLiteral(">"), false, t)
+	checkBool(subjectIsLiteral("foo.*"), false, t)
+	checkBool(subjectIsLiteral("foo.>"), false, t)
+	checkBool(subjectIsLiteral("foo.*.>"), false, t)
+	checkBool(subjectIsLiteral("foo.*.bar"), false, t)
+	checkBool(subjectIsLiteral("foo.bar.>"), false, t)
+}
+
 func TestSublistBadSubjectOnRemove(t *testing.T) {
 	bad := "a.b..d"
 	sub := newSub(bad)
@@ -718,9 +730,7 @@ func TestSublistRaceOnMatch(t *testing.T) {
 				}
 			}
 			// Empty cache to maximize chance for race
-			s.Lock()
-			delete(s.cache, "foo.bar")
-			s.Unlock()
+			s.cache.Delete("foo.bar")
 		}
 	}
 	go f()
@@ -902,7 +912,7 @@ func Benchmark_____SublistMatch10kSubsWithNoCache(b *testing.B) {
 		if len(r.psubs) != nsubs {
 			b.Fatalf("Results len is %d, should be %d", len(r.psubs), nsubs)
 		}
-		delete(s.cache, subject)
+		s.cache.Delete(subject)
 	}
 }
 
@@ -1138,10 +1148,14 @@ func Benchmark_SublistCacheContention10kM10kA10kR(b *testing.B) {
 	cacheContentionTest(b, 10*1024, 10*1024, 10*1024)
 }
 
-func Benchmark_prand(b *testing.B) {
-	prand := rand.New(rand.NewSource(time.Now().UnixNano()))
-	b.ResetTimer()
+func Benchmark______________IsValidLiteralSubject(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		prand.Intn(4096)
+		IsValidLiteralSubject("foo.bar.baz.22")
+	}
+}
+
+func Benchmark___________________subjectIsLiteral(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		subjectIsLiteral("foo.bar.baz.22")
 	}
 }

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -313,6 +313,9 @@ func TestSublistCache(t *testing.T) {
 		s.Match(fmt.Sprintf("foo-%d\n", i))
 	}
 
+	// Let cleanup Go routine run.
+	runtime.Gosched()
+
 	if cc := s.CacheCount(); cc > slCacheMax {
 		t.Fatalf("Cache should be constrained by cacheMax, got %d for current count\n", cc)
 	}

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -498,6 +498,7 @@ func TestSublistMatchLiterals(t *testing.T) {
 func TestSubjectIsLiteral(t *testing.T) {
 	checkBool(subjectIsLiteral("foo"), true, t)
 	checkBool(subjectIsLiteral("foo.bar"), true, t)
+	checkBool(subjectIsLiteral("foo*.bar"), true, t)
 	checkBool(subjectIsLiteral("*"), false, t)
 	checkBool(subjectIsLiteral(">"), false, t)
 	checkBool(subjectIsLiteral("foo.*"), false, t)
@@ -741,6 +742,19 @@ func TestSublistRaceOnMatch(t *testing.T) {
 		t.Fatalf(e.Error())
 	default:
 	}
+}
+
+// With new literal fast path make sure wildcards are added properly
+// to the cache.
+func TestSublistAddTopCacheWildcard(t *testing.T) {
+	s := NewSublist()
+	s.Insert(newSub("foo.*"))
+	s.Insert(newSub("foo.bar"))
+	r := s.Match("foo.bar")
+	verifyLen(r.psubs, 2, t)
+	s.Insert(newSub("foo.>"))
+	r = s.Match("foo.bar")
+	verifyLen(r.psubs, 3, t)
 }
 
 // -- Benchmarks Setup --


### PR DESCRIPTION

Sublists have a caching layer that is shared. Most of the extreme performance in NATS comes from the client L1 cache of the sublist which has no contention. This works well as long as the sublist has a fairly low rate of change. When highly concurrent reads to the sublist's cache were present performance suffered. 

Also #710 showed a case where the shared cache made things worse.

This PR alleviates some of those issues by being smarter when having a literal subject to add or remove from the shared cache.

It also uses Go 1.9 sync.Map which performs better under highly concurrent conditions with many cores.

/cc @nats-io/core
