### PR TITLE
Fixed crash related to route permissions after allow/deny feature

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -395,14 +395,8 @@ func parseCluster(cm map[string]interface{}, opts *Options) error {
 				// The parsing sets Import into Publish and Export into Subscribe, convert
 				// accordingly.
 				opts.Cluster.Permissions = &RoutePermissions{
-					Import: &SubjectPermission{
-						Allow: auth.defaultPermissions.Publish.Allow,
-						Deny:  auth.defaultPermissions.Publish.Deny,
-					},
-					Export: &SubjectPermission{
-						Allow: auth.defaultPermissions.Subscribe.Allow,
-						Deny:  auth.defaultPermissions.Subscribe.Deny,
-					},
+					Import: auth.defaultPermissions.Publish,
+					Export: auth.defaultPermissions.Subscribe,
 				}
 			}
 		case "routes":

--- a/server/route.go
+++ b/server/route.go
@@ -498,14 +498,9 @@ func (c *client) setRoutePermissions(perms *RoutePermissions) {
 	// The Import permission is mapped to Publish
 	// and Export permission is mapped to Subscribe.
 	// For meaning of Import/Export, see canImport and canExport.
-	p := &Permissions{}
-	p.Publish = &SubjectPermission{
-		Allow: perms.Import.Allow,
-		Deny:  perms.Import.Deny,
-	}
-	p.Subscribe = &SubjectPermission{
-		Allow: perms.Export.Allow,
-		Deny:  perms.Export.Deny,
+	p := &Permissions{
+		Publish:   perms.Import,
+		Subscribe: perms.Export,
 	}
 	c.setPermissions(p)
 }


### PR DESCRIPTION
This is an issue in master only, not in any public release.
The issue is that permissions should be assigned as-is for the
route perms because Publish/Subscribe could be nil, so trying
to dereference Publish.Allow/Deny or Subscribe.Allow/Deny could
crash. The code checking for permissions correctly check if
Publish/Subscribe is nil or not.

This was introduced with PR #725

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
