### PR TITLE
Update some tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,30 +888,6 @@ For example, running the `gnatsd -m 8222` command, you should see that the NATS 
 [70450] 2018/08/29 12:48:30.819964 [INF] Server is ready
 ```
 
-## Development
-
-This section contains notes for those looking to do development on gnatsd.
-
-### Windows
-
-Some unit tests make use of temporary symlinks for testing purposes. On Windows, this can fail due to insufficient privileges:
-
-```
---- FAIL: TestConfigReload (0.00s)
-        reload_test.go:175: Error creating symlink: symlink .\configs\reload\test.conf g:\src\github.com\nats-io\gnatsd\server\tmp.conf: A required privilege is not held by the client.
-FAIL
-```
-
-Similarly, this can fail when creating a symlink on a network drive, which is typically not allowed by default:
-
-```
---- FAIL: TestConfigReload (0.00s)
-        reload_test.go:175: Error creating symlink: symlink .\configs\reload\test.conf g:\src\github.com\nats-io\gnatsd\server\tmp.conf: Incorrect function.
-FAIL
-```
-
-If this is the case, ensure that the tests are run with privileges on a local drive (e.g. running on `C:` as admin).
-
 ## Community and Contributing
 
 NATS has a vibrant and friendly community.  If you are interested in connecting with other NATS users or contributing, read about our [community](http://nats.io/community/) on [NATS.io](http://nats.io/).

--- a/server/configs/reload/reload.conf
+++ b/server/configs/reload/reload.conf
@@ -6,9 +6,9 @@ port: 2233
 debug:         true # enable on reload
 trace:         true # enable on reload
 logtime:       true # enable on reload
-syslog:        true # enable on reload
 
-pid_file:         "/tmp/gnatsd.pid" # change on reload
+log_file:         "gnatsd.log" # change on reload
+pid_file:         "gnatsd.pid" # change on reload
 max_control_line: 512 # change on reload
 ping_interval:    5 # change on reload
 ping_max:         1 # change on reload

--- a/server/server.go
+++ b/server/server.go
@@ -34,6 +34,7 @@ import (
 	// Allow dynamic profiling.
 	_ "net/http/pprof"
 
+	"github.com/nats-io/gnatsd/logger"
 	"github.com/nats-io/gnatsd/util"
 )
 
@@ -419,6 +420,17 @@ func (s *Server) Shutdown() {
 
 	if opts.PortsFileDir != _EMPTY_ {
 		s.deletePortsFile(opts.PortsFileDir)
+	}
+
+	// Close logger if applicable. It allows tests on Windows
+	// to be able to do proper cleanup (delete log file).
+	s.logging.RLock()
+	log := s.logging.logger
+	s.logging.RUnlock()
+	if log != nil {
+		if l, ok := log.(*logger.Logger); ok {
+			l.Close()
+		}
 	}
 }
 


### PR DESCRIPTION
- Config reload tests have been modified to not rely on symlink.
- Close logger on shutdown (for Windows tests cleanup)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
