### PR TITLE
Report route filtering on source server

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -59,8 +59,8 @@ func (u *User) clone() *User {
 // SubjectPermission is an individual allow and deny struct for publish
 // and subscribe authorizations.
 type SubjectPermission struct {
-	Allow []string `json:"allow"`
-	Deny  []string `json:"deny"`
+	Allow []string `json:"allow,omitempty"`
+	Deny  []string `json:"deny,omitempty"`
 }
 
 // Permissions are the allowed subjects on a per

--- a/test/configs/srv_a_perms.conf
+++ b/test/configs/srv_a_perms.conf
@@ -1,6 +1,7 @@
 # Cluster Server A with Permissions
 
 listen: 127.0.0.1:5222
+http: 127.0.0.1:5223
 
 cluster {
   listen: 127.0.0.1:5244

--- a/test/configs/srv_b.conf
+++ b/test/configs/srv_b.conf
@@ -1,6 +1,7 @@
 # Cluster Server B
 
 listen: 127.0.0.1:5224
+http: 127.0.0.1:5225
 
 cluster {
   listen: 127.0.0.1:5246

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -869,6 +869,7 @@ func TestRouteBasicPermissions(t *testing.T) {
 	defer srvB.Shutdown()
 
 	checkClusterFormed(t, srvA, srvB)
+	resetPreviousHTTPConnections()
 
 	// Check for proper monitoring reporting for permissions.
 	murl := fmt.Sprintf("http://%s:%d/", optsA.HTTPHost, optsA.HTTPPort)

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"net/http"
 	"os"
 	"runtime"
 	"strconv"
@@ -869,64 +868,6 @@ func TestRouteBasicPermissions(t *testing.T) {
 	defer srvB.Shutdown()
 
 	checkClusterFormed(t, srvA, srvB)
-	resetPreviousHTTPConnections()
-
-	// Check for proper monitoring reporting for permissions.
-	murl := fmt.Sprintf("http://%s:%d/", optsA.HTTPHost, optsA.HTTPPort)
-	resp, err := http.Get(murl + "routez")
-	if err != nil {
-		t.Fatalf("Expected no error: Got %v\n", err)
-	}
-	if resp.StatusCode != 200 {
-		t.Fatalf("Expected a 200 response, got %d\n", resp.StatusCode)
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Got an error reading the body: %v\n", err)
-	}
-	// We expect to see imports and exports
-	if !strings.Contains(string(body), "imports") {
-		t.Fatal("Routez body should contain \"imports\" information.")
-	}
-	if !strings.Contains(string(body), "exports") {
-		t.Fatal("Routez body should contain \"exports\" information.")
-	}
-	rz := &server.Routez{}
-	if err := json.Unmarshal(body, rz); err != nil {
-		t.Fatalf("Got an error unmarshalling the body: %v\n", err)
-	}
-	if rz.Imports == nil || rz.Imports.Allow == nil ||
-		len(rz.Imports.Allow) != 1 || rz.Imports.Allow[0] != "foo" ||
-		rz.Imports.Deny != nil {
-		t.Fatalf("Unexpected Imports %v\n", rz.Imports)
-	}
-	if rz.Exports == nil || rz.Exports.Allow == nil || rz.Exports.Deny == nil ||
-		len(rz.Exports.Allow) != 1 || rz.Exports.Allow[0] != "*" ||
-		len(rz.Exports.Deny) != 2 || rz.Exports.Deny[0] != "foo" || rz.Exports.Deny[1] != "nats" {
-		t.Fatalf("Unexpected Exports %v\n", rz.Exports)
-	}
-
-	murl = fmt.Sprintf("http://%s:%d/", optsB.HTTPHost, optsB.HTTPPort)
-	resp, err = http.Get(murl + "routez")
-	if err != nil {
-		t.Fatalf("Expected no error: Got %v\n", err)
-	}
-	if resp.StatusCode != 200 {
-		t.Fatalf("Expected a 200 response, got %d\n", resp.StatusCode)
-	}
-	defer resp.Body.Close()
-	body, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Got an error reading the body: %v\n", err)
-	}
-	// We expect to see NO imports and exports for server B.
-	if strings.Contains(string(body), "imports") {
-		t.Fatal("Routez body should NOT contain \"imports\" information.")
-	}
-	if strings.Contains(string(body), "exports") {
-		t.Fatal("Routez body should NOT contain \"exports\" information.")
-	}
 
 	// Create a connection to server B
 	ncb, err := nats.Connect(fmt.Sprintf("nats://127.0.0.1:%d", optsB.Port))


### PR DESCRIPTION
The source server will now report any filtering it will be doing on connected routes.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
