### PR TITLE
Basic Nkey support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
 - 1.11
 install:
 - go get github.com/nats-io/go-nats
+- go get github.com/nats-io/nkeys
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
 - go get -u honnef.co/go/tools/cmd/megacheck

--- a/server/auth.go
+++ b/server/auth.go
@@ -131,6 +131,25 @@ func (p *Permissions) clone() *Permissions {
 	return clone
 }
 
+// checkAuthforWarnings will look for insecure settings and log concerns.
+// Lock is assumed held.
+func (s *Server) checkAuthforWarnings() {
+	warn := false
+	if s.opts.Password != "" && !isBcrypt(s.opts.Password) {
+		warn = true
+	}
+	for _, u := range s.users {
+		if !isBcrypt(u.Password) {
+			warn = true
+			break
+		}
+	}
+	if warn {
+		// Should be a warning but we currently do not have that option.
+		s.Errorf("Plaintext passwords detected. Use Nkeys or Bcrypt passwords in config files.")
+	}
+}
+
 // configureAuthorization will do any setup needed for authorization.
 // Lock is assumed held.
 func (s *Server) configureAuthorization() {

--- a/server/auth.go
+++ b/server/auth.go
@@ -145,8 +145,8 @@ func (s *Server) checkAuthforWarnings() {
 		}
 	}
 	if warn {
-		// Should be a warning but we currently do not have that option.
-		s.Errorf("Plaintext passwords detected. Use Nkeys or Bcrypt passwords in config files.")
+		// Warning about using plaintext passwords.
+		s.Warnf("Plaintext passwords detected. Use Nkeys or Bcrypt passwords in config files.")
 	}
 }
 

--- a/server/auth.go
+++ b/server/auth.go
@@ -15,9 +15,11 @@ package server
 
 import (
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
 	"strings"
 
+	"github.com/nats-io/nkeys"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -37,6 +39,12 @@ type ClientAuthentication interface {
 	RegisterUser(*User)
 }
 
+// Nkey is for multiple nkey based users
+type NkeyUser struct {
+	Nkey        string       `json:"user"`
+	Permissions *Permissions `json:"permissions"`
+}
+
 // User is for multiple accounts/users.
 type User struct {
 	Username    string       `json:"user"`
@@ -53,6 +61,18 @@ func (u *User) clone() *User {
 	clone := &User{}
 	*clone = *u
 	clone.Permissions = u.Permissions.clone()
+	return clone
+}
+
+// clone performs a deep copy of the NkeyUser struct, returning a new clone with
+// all values copied.
+func (n *NkeyUser) clone() *NkeyUser {
+	if n == nil {
+		return nil
+	}
+	clone := &NkeyUser{}
+	*clone = *n
+	clone.Permissions = n.Permissions.clone()
 	return clone
 }
 
@@ -125,10 +145,19 @@ func (s *Server) configureAuthorization() {
 	// This just checks and sets up the user map if we have multiple users.
 	if opts.CustomClientAuthentication != nil {
 		s.info.AuthRequired = true
-	} else if opts.Users != nil {
-		s.users = make(map[string]*User)
-		for _, u := range opts.Users {
-			s.users[u.Username] = u
+	} else if opts.Nkeys != nil || opts.Users != nil {
+		// Support both at the same time.
+		if opts.Nkeys != nil {
+			s.nkeys = make(map[string]*NkeyUser)
+			for _, u := range opts.Nkeys {
+				s.nkeys[u.Nkey] = u
+			}
+		}
+		if opts.Users != nil {
+			s.users = make(map[string]*User)
+			for _, u := range opts.Users {
+				s.users[u.Username] = u
+			}
 		}
 		s.info.AuthRequired = true
 	} else if opts.Username != "" || opts.Authorization != "" {
@@ -152,31 +181,72 @@ func (s *Server) checkAuthorization(c *client) bool {
 	}
 }
 
-// hasUsers leyt's us know if we have a users array.
-func (s *Server) hasUsers() bool {
-	s.mu.Lock()
-	hu := s.users != nil
-	s.mu.Unlock()
-	return hu
-}
-
 // isClientAuthorized will check the client against the proper authorization method and data.
-// This could be token or username/password based.
+// This could be nkey, token, or username/password based.
 func (s *Server) isClientAuthorized(c *client) bool {
-	// Snapshot server options.
-	opts := s.getOpts()
+	// Snapshot server options by hand and only grab what we really need.
+	s.optsMu.RLock()
+	customClientAuthentication := s.opts.CustomClientAuthentication
+	authorization := s.opts.Authorization
+	username := s.opts.Username
+	password := s.opts.Password
+	s.optsMu.RUnlock()
 
-	// Check custom auth first, then multiple users, then token, then single user/pass.
-	if opts.CustomClientAuthentication != nil {
-		return opts.CustomClientAuthentication.Check(c)
-	} else if s.hasUsers() {
-		s.mu.Lock()
-		user, ok := s.users[c.opts.Username]
+	// Check custom auth first, then nkeys, then multiple users, then token, then single user/pass.
+	if customClientAuthentication != nil {
+		return customClientAuthentication.Check(c)
+	}
+
+	var nkey *NkeyUser
+	var user *User
+	var ok bool
+
+	s.mu.Lock()
+	authRequired := s.info.AuthRequired
+	if !authRequired {
+		// TODO(dlc) - If they send us credentials should we fail?
 		s.mu.Unlock()
+		return true
+	}
 
+	// Check if we have nkeys or users for client.
+	hasNkeys := s.nkeys != nil
+	hasUsers := s.users != nil
+	if hasNkeys && c.opts.Nkey != "" {
+		nkey, ok = s.nkeys[c.opts.Nkey]
 		if !ok {
+			s.mu.Unlock()
 			return false
 		}
+	} else if hasUsers && c.opts.Username != "" {
+		user, ok = s.users[c.opts.Username]
+		if !ok {
+			s.mu.Unlock()
+			return false
+		}
+	}
+	s.mu.Unlock()
+
+	// Verify the signature against the nonce.
+	if nkey != nil {
+		if c.opts.Sig == "" {
+			return false
+		}
+		sig, err := base64.RawURLEncoding.DecodeString(c.opts.Sig)
+		if err != nil {
+			return false
+		}
+		pub, err := nkeys.FromPublicKey(c.opts.Nkey)
+		if err != nil {
+			return false
+		}
+		if err := pub.Verify(c.nonce, sig); err != nil {
+			return false
+		}
+		return true
+	}
+
+	if user != nil {
 		ok = comparePasswords(user.Password, c.opts.Password)
 		// If we are authorized, register the user which will properly setup any permissions
 		// for pub/sub authorizations.
@@ -184,18 +254,18 @@ func (s *Server) isClientAuthorized(c *client) bool {
 			c.RegisterUser(user)
 		}
 		return ok
-
-	} else if opts.Authorization != "" {
-		return comparePasswords(opts.Authorization, c.opts.Authorization)
-
-	} else if opts.Username != "" {
-		if opts.Username != c.opts.Username {
-			return false
-		}
-		return comparePasswords(opts.Password, c.opts.Password)
 	}
 
-	return true
+	if authorization != "" {
+		return comparePasswords(authorization, c.opts.Authorization)
+	} else if username != "" {
+		if username != c.opts.Username {
+			return false
+		}
+		return comparePasswords(password, c.opts.Password)
+	}
+
+	return false
 }
 
 // checkRouterAuth checks optional router authorization which can be nil or username/password.

--- a/server/client.go
+++ b/server/client.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/rand"
 	"net"
+	"regexp"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -247,11 +248,11 @@ type clientOpts struct {
 	Verbose       bool   `json:"verbose"`
 	Pedantic      bool   `json:"pedantic"`
 	TLSRequired   bool   `json:"tls_required"`
-	Nkey          string `json:"nkey"`
-	Sig           string `json:"sig"`
-	Authorization string `json:"auth_token"`
-	Username      string `json:"user"`
-	Password      string `json:"pass"`
+	Nkey          string `json:"nkey,omitempty"`
+	Sig           string `json:"sig,omitempty"`
+	Authorization string `json:"auth_token,omitempty"`
+	Username      string `json:"user,omitempty"`
+	Password      string `json:"pass,omitempty"`
 	Name          string `json:"name"`
 	Lang          string `json:"lang"`
 	Version       string `json:"version"`
@@ -704,8 +705,35 @@ func (c *client) processErr(errStr string) {
 	c.closeConnection(ParseError)
 }
 
+// Password pattern matcher.
+var passPat = regexp.MustCompile(`"?\s*pass\S*\s*"?\s*[:=]\s*("?[^\s,}$]*)`)
+
+// This will remove any notion of passwords from trace messages
+// for logging.
+func removePassFromTrace(arg []byte) []byte {
+
+	if !bytes.Contains(arg, []byte("pass")) {
+		return arg
+	}
+	m := passPat.FindAllSubmatch(arg, -1)
+	if len(m) == 0 {
+		return arg
+	}
+
+	for _, match := range m {
+		if len(match) != 2 {
+			continue
+		}
+		arg = bytes.Replace(arg, match[1], []byte("[REDACTED]"), 1)
+
+	}
+	return arg
+}
+
 func (c *client) processConnect(arg []byte) error {
-	c.traceInOp("CONNECT", arg)
+	if c.trace {
+		c.traceInOp("CONNECT", removePassFromTrace(arg))
+	}
 
 	c.mu.Lock()
 	// If we can't stop the timer because the callback is in progress...

--- a/server/client.go
+++ b/server/client.go
@@ -137,6 +137,7 @@ type client struct {
 	cid   uint64
 	opts  clientOpts
 	start time.Time
+	nonce []byte
 	nc    net.Conn
 	ncs   string
 	out   outbound
@@ -246,6 +247,8 @@ type clientOpts struct {
 	Verbose       bool   `json:"verbose"`
 	Pedantic      bool   `json:"pedantic"`
 	TLSRequired   bool   `json:"tls_required"`
+	Nkey          string `json:"nkey"`
+	Sig           string `json:"sig"`
 	Authorization string `json:"auth_token"`
 	Username      string `json:"user"`
 	Password      string `json:"pass"`

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -14,6 +14,7 @@
 package server
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -180,4 +181,54 @@ func TestReOpenLogFile(t *testing.T) {
 	if strings.HasSuffix(string(buf), "New message") {
 		t.Fatalf("New message was not appended after file was re-opened, got: %v", string(buf))
 	}
+}
+
+func TestNoPasswordsFromConnectTrace(t *testing.T) {
+	opts := DefaultOptions()
+	opts.NoLog = false
+	opts.Trace = true
+	opts.Username = "derek"
+	opts.Password = "s3cr3t"
+
+	s := &Server{opts: opts}
+	dl := &DummyLogger{}
+	s.SetLogger(dl, false, true)
+
+	_ = s.logging.logger.(*DummyLogger)
+	if s.logging.trace != 1 {
+		t.Fatalf("Expected trace 1, received value %d\n", s.logging.trace)
+	}
+	defer s.SetLogger(nil, false, false)
+
+	c, _, _ := newClientForServer(s)
+
+	connectOp := []byte("CONNECT {\"user\":\"derek\",\"pass\":\"s3cr3t\"}\r\n")
+	err := c.parse(connectOp)
+	if err != nil {
+		t.Fatalf("Received error: %v\n", err)
+	}
+
+	dl.Lock()
+	hasPass := strings.Contains(dl.msg, "s3cr3t")
+	dl.Unlock()
+
+	if hasPass {
+		t.Fatalf("Password detected in log output: %s", dl.msg)
+	}
+}
+
+func TestRemovePassFromTrace(t *testing.T) {
+	pass := []byte("s3cr3t")
+	check := func(r []byte) {
+		t.Helper()
+		if bytes.Contains(r, pass) {
+			t.Fatalf("Found password in %q", r)
+		}
+	}
+	check(removePassFromTrace([]byte("CONNECT {\"user\":\"derek\",\"pass\":\"s3cr3t\"}\r\n")))
+	check(removePassFromTrace([]byte("CONNECT {\"user\":\"derek\",\"pass\":  \"s3cr3t\"}\r\n")))
+	check(removePassFromTrace([]byte("CONNECT {\"user\":\"derek\",\"pass\":    \"s3cr3t\"     }\r\n")))
+	check(removePassFromTrace([]byte("CONNECT {\"password\":\"s3cr3t\",}\r\n")))
+	check(removePassFromTrace([]byte("CONNECT {pass:s3cr3t\r\n")))
+	check(removePassFromTrace([]byte("CONNECT {pass:s3cr3t ,   password =  s3cr3t}")))
 }

--- a/server/nkey.go
+++ b/server/nkey.go
@@ -1,0 +1,39 @@
+// Copyright 2018 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/base64"
+)
+
+// Raw length of the nonce challenge
+const (
+	nonceRawLen = 16
+	nonceLen    = 22 // base64.RawURLEncoding.EncodedLen(nonceRawLen)
+)
+
+// nonceRequired tells us if we should send a nonce.
+// Assumes server lock is held
+func (s *Server) nonceRequired() bool {
+	return len(s.opts.Nkeys) > 0
+}
+
+// Generate a nonce for INFO challenge.
+// Assumes server lock is held
+func (s *Server) generateNonce(n []byte) {
+	var raw [nonceRawLen]byte
+	data := raw[:]
+	s.prand.Read(data)
+	base64.RawURLEncoding.Encode(n, data)
+}

--- a/server/nkey_test.go
+++ b/server/nkey_test.go
@@ -1,0 +1,266 @@
+// Copyright 2018 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bufio"
+	crand "crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	mrand "math/rand"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nkeys"
+)
+
+// Nonce has to be a string since we used different encoding by default than json.Unmarshal.
+type nonceInfo struct {
+	Id    string `json:"server_id"`
+	CID   uint64 `json:"client_id,omitempty"`
+	Nonce string `json:"nonce,omitempty"`
+}
+
+// This is a seed for a user. We can extract public and private keys from this for testing.
+const seed = "SUAOB32VQGYIOM622XYNXN4Q6GQR5I6DFZPPYZMNI5MMNVAQZDAL3OLH554ISOUTJM4EC6NWS5UHMS4CMONVVRW3VXXEQULMR6MDLPOEUVFPU"
+
+func nkeyBasicSetup() (*Server, *client, *bufio.Reader, string) {
+	kp, _ := nkeys.FromSeed(seed)
+	pub, _ := kp.PublicKey()
+	opts := defaultServerOptions
+	opts.Nkeys = []*NkeyUser{&NkeyUser{Nkey: pub}}
+	return rawSetup(opts)
+}
+
+func mixedSetup() (*Server, *client, *bufio.Reader, string) {
+	kp, _ := nkeys.FromSeed(seed)
+	pub, _ := kp.PublicKey()
+	opts := defaultServerOptions
+	opts.Nkeys = []*NkeyUser{&NkeyUser{Nkey: pub}}
+	opts.Users = []*User{&User{Username: "derek", Password: "foo"}}
+	return rawSetup(opts)
+}
+
+func newClientForServer(s *Server) (*client, *bufio.Reader, string) {
+	cli, srv := net.Pipe()
+	cr := bufio.NewReaderSize(cli, maxBufSize)
+	ch := make(chan *client)
+	createClientAsync(ch, s, srv)
+	l, _ := cr.ReadString('\n')
+	// Grab client
+	c := <-ch
+	return c, cr, l
+}
+
+func TestServerInfoNonce(t *testing.T) {
+	_, l := setUpClientWithResponse()
+	if !strings.HasPrefix(l, "INFO ") {
+		t.Fatalf("INFO response incorrect: %s\n", l)
+	}
+	// Make sure payload is proper json
+	var info nonceInfo
+	err := json.Unmarshal([]byte(l[5:]), &info)
+	if err != nil {
+		t.Fatalf("Could not parse INFO json: %v\n", err)
+	}
+	if info.Nonce != "" {
+		t.Fatalf("Expected an empty nonce with no nkeys defined")
+	}
+
+	// Now setup server with auth and nkeys to trigger nonce generation
+	s, _, _, l := nkeyBasicSetup()
+
+	if !strings.HasPrefix(l, "INFO ") {
+		t.Fatalf("INFO response incorrect: %s\n", l)
+	}
+	// Make sure payload is proper json
+	err = json.Unmarshal([]byte(l[5:]), &info)
+	if err != nil {
+		t.Fatalf("Could not parse INFO json: %v\n", err)
+	}
+	if info.Nonce == "" {
+		t.Fatalf("Expected a non-empty nonce with nkeys defined")
+	}
+
+	// Make sure new clients get new nonces
+	oldNonce := info.Nonce
+
+	_, _, l = newClientForServer(s)
+
+	err = json.Unmarshal([]byte(l[5:]), &info)
+	if err != nil {
+		t.Fatalf("Could not parse INFO json: %v\n", err)
+	}
+	if info.Nonce == "" {
+		t.Fatalf("Expected a non-empty nonce")
+	}
+	if strings.Compare(oldNonce, info.Nonce) == 0 {
+		t.Fatalf("Expected subsequent nonces to be different\n")
+	}
+}
+
+func TestNkeyClientConnect(t *testing.T) {
+	s, c, cr, _ := nkeyBasicSetup()
+	// Send CONNECT with no signature or nkey, should fail.
+	connectOp := []byte("CONNECT {\"verbose\":true,\"pedantic\":true}\r\n")
+	go c.parse(connectOp)
+	l, _ := cr.ReadString('\n')
+	if !strings.HasPrefix(l, "-ERR ") {
+		t.Fatalf("Expected an error")
+	}
+
+	kp, _ := nkeys.FromSeed(seed)
+	pubKey, _ := kp.PublicKey()
+
+	// Send nkey but no signature
+	c, cr, _ = newClientForServer(s)
+	cs := fmt.Sprintf("CONNECT {\"nkey\":%q, \"verbose\":true,\"pedantic\":true}\r\n", pubKey)
+	connectOp = []byte(cs)
+	go c.parse(connectOp)
+	l, _ = cr.ReadString('\n')
+	if !strings.HasPrefix(l, "-ERR ") {
+		t.Fatalf("Expected an error")
+	}
+
+	// Now improperly sign etc.
+	c, cr, _ = newClientForServer(s)
+	cs = fmt.Sprintf("CONNECT {\"nkey\":%q,\"sig\":%q,\"verbose\":true,\"pedantic\":true}\r\n", pubKey, "bad_sig")
+	go c.parse([]byte(cs))
+	l, _ = cr.ReadString('\n')
+	if !strings.HasPrefix(l, "-ERR ") {
+		t.Fatalf("Expected an error")
+	}
+
+	// Now properly sign the nonce
+	c, cr, l = newClientForServer(s)
+	// Check for Nonce
+	var info nonceInfo
+	err := json.Unmarshal([]byte(l[5:]), &info)
+	if err != nil {
+		t.Fatalf("Could not parse INFO json: %v\n", err)
+	}
+	if info.Nonce == "" {
+		t.Fatalf("Expected a non-empty nonce with nkeys defined")
+	}
+	sigraw, err := kp.Sign([]byte(info.Nonce))
+	if err != nil {
+		t.Fatalf("Failed signing nonce: %v", err)
+	}
+	sig := base64.RawURLEncoding.EncodeToString(sigraw)
+
+	// PING needed to flush the +OK to us.
+	cs = fmt.Sprintf("CONNECT {\"nkey\":%q,\"sig\":\"%s\",\"verbose\":true,\"pedantic\":true}\r\nPING\r\n", pubKey, sig)
+	go c.parse([]byte(cs))
+	l, _ = cr.ReadString('\n')
+	if !strings.HasPrefix(l, "+OK") {
+		t.Fatalf("Expected an OK, got: %v", l)
+	}
+}
+
+func TestMixedClientConnect(t *testing.T) {
+	s, c, cr, _ := mixedSetup()
+	// Normal user/pass
+	// PING needed to flush the +OK to us.
+	go c.parse([]byte("CONNECT {\"user\":\"derek\",\"pass\":\"foo\",\"verbose\":true,\"pedantic\":true}\r\nPING\r\n"))
+	l, _ := cr.ReadString('\n')
+	if !strings.HasPrefix(l, "+OK") {
+		t.Fatalf("Expected an OK, got: %v", l)
+	}
+
+	kp, _ := nkeys.FromSeed(seed)
+	pubKey, _ := kp.PublicKey()
+
+	c, cr, l = newClientForServer(s)
+	// Check for Nonce
+	var info nonceInfo
+	err := json.Unmarshal([]byte(l[5:]), &info)
+	if err != nil {
+		t.Fatalf("Could not parse INFO json: %v\n", err)
+	}
+	if info.Nonce == "" {
+		t.Fatalf("Expected a non-empty nonce with nkeys defined")
+	}
+	sigraw, err := kp.Sign([]byte(info.Nonce))
+	if err != nil {
+		t.Fatalf("Failed signing nonce: %v", err)
+	}
+	sig := base64.RawURLEncoding.EncodeToString(sigraw)
+
+	// PING needed to flush the +OK to us.
+	cs := fmt.Sprintf("CONNECT {\"nkey\":%q,\"sig\":\"%s\",\"verbose\":true,\"pedantic\":true}\r\nPING\r\n", pubKey, sig)
+	go c.parse([]byte(cs))
+	l, _ = cr.ReadString('\n')
+	if !strings.HasPrefix(l, "+OK") {
+		t.Fatalf("Expected an OK, got: %v", l)
+	}
+}
+
+func BenchmarkCryptoRandGeneration(b *testing.B) {
+	data := make([]byte, 16)
+	for i := 0; i < b.N; i++ {
+		crand.Read(data)
+	}
+}
+
+func BenchmarkMathRandGeneration(b *testing.B) {
+	data := make([]byte, 16)
+	prng := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < b.N; i++ {
+		prng.Read(data)
+	}
+}
+
+func BenchmarkNonceGeneration(b *testing.B) {
+	data := make([]byte, nonceRawLen)
+	b64 := make([]byte, nonceLen)
+	prand := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < b.N; i++ {
+		prand.Read(data)
+		base64.RawURLEncoding.Encode(b64, data)
+	}
+}
+
+func BenchmarkPublicVerify(b *testing.B) {
+	data := make([]byte, nonceRawLen)
+	nonce := make([]byte, nonceLen)
+	mrand.Read(data)
+	base64.RawURLEncoding.Encode(nonce, data)
+
+	user, err := nkeys.CreateUser(nil)
+	if err != nil {
+		b.Fatalf("Error creating User Nkey: %v", err)
+	}
+	sig, err := user.Sign(nonce)
+	if err != nil {
+		b.Fatalf("Error sigining nonce: %v", err)
+	}
+	pk, err := user.PublicKey()
+	if err != nil {
+		b.Fatalf("Could not extract public key from user: %v", err)
+	}
+	pub, err := nkeys.FromPublicKey(pk)
+	if err != nil {
+		b.Fatalf("Could not create public key pair from public key string: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := pub.Verify(nonce, sig); err != nil {
+			b.Fatalf("Error verifying nonce: %v", err)
+		}
+	}
+}

--- a/server/nkey_test.go
+++ b/server/nkey_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	mrand "math/rand"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -206,6 +207,27 @@ func TestMixedClientConnect(t *testing.T) {
 	l, _ = cr.ReadString('\n')
 	if !strings.HasPrefix(l, "+OK") {
 		t.Fatalf("Expected an OK, got: %v", l)
+	}
+}
+
+func TestMixedClientConfig(t *testing.T) {
+	confFileName := createConfFile(t, []byte(`
+    authorization {
+      users = [
+        {nkey: "UDKTV7HZVYJFJN64LLMYQBUR6MTNNYCDC3LAZH4VHURW3GZLL3FULBXV"}
+        {user: alice, password: foo}
+      ]
+    }`))
+	defer os.Remove(confFileName)
+	opts, err := ProcessConfigFile(confFileName)
+	if err != nil {
+		t.Fatalf("Received an error processing config file: %v", err)
+	}
+	if len(opts.Nkeys) != 1 {
+		t.Fatalf("Expected 1 nkey, got %d", len(opts.Nkeys))
+	}
+	if len(opts.Users) != 1 {
+		t.Fatalf("Expected 1 user, got %d", len(opts.Users))
 	}
 }
 

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -764,18 +764,14 @@ func TestNewStyleAuthorizationConfig(t *testing.T) {
 
 // Test new nkey users
 func TestNkeyUsersConfig(t *testing.T) {
-	confFileName := "nkeys.conf"
-	defer os.Remove(confFileName)
-	content := `
+	confFileName := createConfFile(t, []byte(`
     authorization {
       users = [
         {nkey: "UDKTV7HZVYJFJN64LLMYQBUR6MTNNYCDC3LAZH4VHURW3GZLL3FULBXV"}
         {nkey: "UA3C5TBZYK5GJQJRWPMU6NFY5JNAEVQB2V2TUZFZDHFJFUYVKTTUOFKZ"}
       ]
-    }`
-	if err := ioutil.WriteFile(confFileName, []byte(content), 0666); err != nil {
-		t.Fatalf("Error writing config file: %v", err)
-	}
+    }`))
+	defer os.Remove(confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v", err)
@@ -787,9 +783,7 @@ func TestNkeyUsersConfig(t *testing.T) {
 }
 
 func TestNkeyUsersWithPermsConfig(t *testing.T) {
-	confFileName := "nkeys.conf"
-	defer os.Remove(confFileName)
-	content := `
+	confFileName := createConfFile(t, []byte(`
     authorization {
       users = [
         {nkey: "UDKTV7HZVYJFJN64LLMYQBUR6MTNNYCDC3LAZH4VHURW3GZLL3FULBXV",
@@ -799,10 +793,8 @@ func TestNkeyUsersWithPermsConfig(t *testing.T) {
          }
         }
       ]
-    }`
-	if err := ioutil.WriteFile(confFileName, []byte(content), 0666); err != nil {
-		t.Fatalf("Error writing config file: %v", err)
-	}
+    }`))
+	defer os.Remove(confFileName)
 	opts, err := ProcessConfigFile(confFileName)
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v", err)

--- a/server/server.go
+++ b/server/server.go
@@ -289,6 +289,9 @@ func (s *Server) Start() {
 	}
 	s.Noticef("Git commit [%s]", gc)
 
+	// Check for insecure configurations.op
+	s.checkAuthforWarnings()
+
 	// Avoid RACE between Start() and Shutdown()
 	s.mu.Lock()
 	s.running = true
@@ -907,7 +910,9 @@ func (s *Server) saveClosedClient(c *client, nc net.Conn, reason ClosedState) {
 
 	// Place in the ring buffer
 	s.mu.Lock()
-	s.closed.append(cc)
+	if s.closed != nil {
+		s.closed.append(cc)
+	}
 	s.mu.Unlock()
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"os"
@@ -40,24 +41,25 @@ import (
 // Info is the information sent to clients to help them understand information
 // about this server.
 type Info struct {
-	ID           string `json:"server_id"`
-	Version      string `json:"version"`
-	Proto        int    `json:"proto"`
-	GitCommit    string `json:"git_commit,omitempty"`
-	GoVersion    string `json:"go"`
-	Host         string `json:"host"`
-	Port         int    `json:"port"`
-	AuthRequired bool   `json:"auth_required,omitempty"`
-	TLSRequired  bool   `json:"tls_required,omitempty"`
-	TLSVerify    bool   `json:"tls_verify,omitempty"`
-	MaxPayload   int    `json:"max_payload"`
-	IP           string `json:"ip,omitempty"`
-	CID          uint64 `json:"client_id,omitempty"`
+	ID                string   `json:"server_id"`
+	Version           string   `json:"version"`
+	Proto             int      `json:"proto"`
+	GitCommit         string   `json:"git_commit,omitempty"`
+	GoVersion         string   `json:"go"`
+	Host              string   `json:"host"`
+	Port              int      `json:"port"`
+	AuthRequired      bool     `json:"auth_required,omitempty"`
+	TLSRequired       bool     `json:"tls_required,omitempty"`
+	TLSVerify         bool     `json:"tls_verify,omitempty"`
+	MaxPayload        int      `json:"max_payload"`
+	IP                string   `json:"ip,omitempty"`
+	CID               uint64   `json:"client_id,omitempty"`
+	Nonce             string   `json:"nonce,omitempty"`
+	ClientConnectURLs []string `json:"connect_urls,omitempty"` // Contains URLs a client can connect to.
 
 	// Route Specific
-	ClientConnectURLs []string           `json:"connect_urls,omitempty"` // Contains URLs a client can connect to.
-	Import            *SubjectPermission `json:"import,omitempty"`
-	Export            *SubjectPermission `json:"export,omitempty"`
+	Import *SubjectPermission `json:"import,omitempty"`
+	Export *SubjectPermission `json:"export,omitempty"`
 }
 
 // Server is our main struct.
@@ -65,6 +67,7 @@ type Server struct {
 	gcid uint64
 	stats
 	mu            sync.Mutex
+	prand         *rand.Rand
 	info          Info
 	sl            *Sublist
 	configFile    string
@@ -77,6 +80,7 @@ type Server struct {
 	routes        map[uint64]*client
 	remotes       map[string]*client
 	users         map[string]*User
+	nkeys         map[string]*NkeyUser
 	totalClients  uint64
 	closed        *closedRingBuffer
 	done          chan bool
@@ -165,6 +169,7 @@ func New(opts *Options) *Server {
 	s := &Server{
 		configFile: opts.ConfigFile,
 		info:       info,
+		prand:      rand.New(rand.NewSource(time.Now().UnixNano())),
 		sl:         NewSublist(),
 		opts:       opts,
 		done:       make(chan bool, 1),
@@ -749,6 +754,13 @@ func (s *Server) copyInfo() Info {
 		info.ClientConnectURLs = make([]string, len(s.info.ClientConnectURLs))
 		copy(info.ClientConnectURLs, s.info.ClientConnectURLs)
 	}
+	if s.nonceRequired() {
+		// Nonce handling
+		var raw [nonceLen]byte
+		nonce := raw[:]
+		s.generateNonce(nonce)
+		info.Nonce = string(nonce)
+	}
 	return info
 }
 
@@ -765,6 +777,7 @@ func (s *Server) createClient(conn net.Conn) *client {
 	// Grab JSON info string
 	s.mu.Lock()
 	info := s.copyInfo()
+	c.nonce = []byte(info.Nonce)
 	s.totalClients++
 	s.mu.Unlock()
 


### PR DESCRIPTION
This PR provides basic Nkey support. Server sends nonces and future clients will sign the nonce challenge and return that with their public Nkey.

Added in some warnings for plaintext passwords in config files.

Also added in redaction for passwords in log files when tracing of CONNECT messages.

/cc @nats-io/core
