### PR TITLE
Add Warnf to Logger interface

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -26,6 +26,7 @@ type Logger struct {
 	debug      bool
 	trace      bool
 	infoLabel  string
+	warnLabel  string
 	errorLabel string
 	fatalLabel string
 	debugLabel string
@@ -108,23 +109,30 @@ func pidPrefix() string {
 func setPlainLabelFormats(l *Logger) {
 	l.infoLabel = "[INF] "
 	l.debugLabel = "[DBG] "
+	l.warnLabel = "[WRN] "
 	l.errorLabel = "[ERR] "
 	l.fatalLabel = "[FTL] "
 	l.traceLabel = "[TRC] "
 }
 
 func setColoredLabelFormats(l *Logger) {
-	colorFormat := "[\x1b[%dm%s\x1b[0m] "
-	l.infoLabel = fmt.Sprintf(colorFormat, 32, "INF")
-	l.debugLabel = fmt.Sprintf(colorFormat, 36, "DBG")
-	l.errorLabel = fmt.Sprintf(colorFormat, 31, "ERR")
-	l.fatalLabel = fmt.Sprintf(colorFormat, 31, "FTL")
-	l.traceLabel = fmt.Sprintf(colorFormat, 33, "TRC")
+	colorFormat := "[\x1b[%sm%s\x1b[0m] "
+	l.infoLabel = fmt.Sprintf(colorFormat, "32", "INF")
+	l.debugLabel = fmt.Sprintf(colorFormat, "36", "DBG")
+	l.warnLabel = fmt.Sprintf(colorFormat, "0;93", "WRN")
+	l.errorLabel = fmt.Sprintf(colorFormat, "31", "ERR")
+	l.fatalLabel = fmt.Sprintf(colorFormat, "31", "FTL")
+	l.traceLabel = fmt.Sprintf(colorFormat, "33", "TRC")
 }
 
 // Noticef logs a notice statement
 func (l *Logger) Noticef(format string, v ...interface{}) {
 	l.logger.Printf(l.infoLabel+format, v...)
+}
+
+// Warnf logs a notice statement
+func (l *Logger) Warnf(format string, v ...interface{}) {
+	l.logger.Printf(l.warnLabel+format, v...)
 }
 
 // Errorf logs an error statement

--- a/logger/syslog.go
+++ b/logger/syslog.go
@@ -102,6 +102,11 @@ func (l *SysLogger) Noticef(format string, v ...interface{}) {
 	l.writer.Notice(fmt.Sprintf(format, v...))
 }
 
+// Warnf logs a notice statement
+func (l *SysLogger) Warnf(format string, v ...interface{}) {
+	l.writer.Notice(fmt.Sprintf(format, v...))
+}
+
 // Fatalf logs a fatal error
 func (l *SysLogger) Fatalf(format string, v ...interface{}) {
 	l.writer.Crit(fmt.Sprintf(format, v...))

--- a/logger/syslog_windows.go
+++ b/logger/syslog_windows.go
@@ -80,6 +80,11 @@ func (l *SysLogger) Noticef(format string, v ...interface{}) {
 	l.writer.Info(1, formatMsg("NOTICE", format, v...))
 }
 
+// Noticef logs a notice statement
+func (l *SysLogger) Warnf(format string, v ...interface{}) {
+	l.writer.Info(1, formatMsg("WARN", format, v...))
+}
+
 // Fatalf logs a fatal error
 func (l *SysLogger) Fatalf(format string, v ...interface{}) {
 	msg := formatMsg("FATAL", format, v...)

--- a/server/log.go
+++ b/server/log.go
@@ -27,6 +27,9 @@ type Logger interface {
 	// Log a notice statement
 	Noticef(format string, v ...interface{})
 
+	// Log a warning statement
+	Warnf(format string, v ...interface{})
+
 	// Log a fatal error
 	Fatalf(format string, v ...interface{})
 
@@ -141,6 +144,13 @@ func (s *Server) Noticef(format string, v ...interface{}) {
 func (s *Server) Errorf(format string, v ...interface{}) {
 	s.executeLogCall(func(logger Logger, format string, v ...interface{}) {
 		logger.Errorf(format, v...)
+	}, format, v...)
+}
+
+// Warnf logs a warning error
+func (s *Server) Warnf(format string, v ...interface{}) {
+	s.executeLogCall(func(logger Logger, format string, v ...interface{}) {
+		logger.Warnf(format, v...)
 	}, format, v...)
 }
 

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -58,6 +58,9 @@ func TestSetLogger(t *testing.T) {
 	expectedStr = "This is a Trace"
 	server.Tracef(expectedStr)
 	dl.checkContent(t, expectedStr)
+	expectedStr = "This is a Warning"
+	server.Tracef(expectedStr)
+	dl.checkContent(t, expectedStr)
 
 	// Make sure that we can reset to fal
 	server.SetLogger(dl, false, false)
@@ -94,6 +97,11 @@ func (l *DummyLogger) Noticef(format string, v ...interface{}) {
 	l.msg = fmt.Sprintf(format, v...)
 }
 func (l *DummyLogger) Errorf(format string, v ...interface{}) {
+	l.Lock()
+	defer l.Unlock()
+	l.msg = fmt.Sprintf(format, v...)
+}
+func (l *DummyLogger) Warnf(format string, v ...interface{}) {
 	l.Lock()
 	defer l.Unlock()
 	l.msg = fmt.Sprintf(format, v...)

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -677,6 +677,7 @@ type checkDuplicateRouteLogger struct {
 
 func (l *checkDuplicateRouteLogger) Noticef(format string, v ...interface{}) {}
 func (l *checkDuplicateRouteLogger) Errorf(format string, v ...interface{})  {}
+func (l *checkDuplicateRouteLogger) Warnf(format string, v ...interface{})   {}
 func (l *checkDuplicateRouteLogger) Fatalf(format string, v ...interface{})  {}
 func (l *checkDuplicateRouteLogger) Tracef(format string, v ...interface{})  {}
 func (l *checkDuplicateRouteLogger) Debugf(format string, v ...interface{}) {

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -60,6 +60,9 @@ func (d *dummyLogger) Tracef(format string, args ...interface{}) {
 func (d *dummyLogger) Noticef(format string, args ...interface{}) {
 }
 
+func (d *dummyLogger) Warnf(format string, args ...interface{}) {
+}
+
 func TestStackFatal(t *testing.T) {
 	d := &dummyLogger{}
 	stackFatalf(d, "test stack %d", 1)


### PR DESCRIPTION
Adds support to be able to log warnings when using `Warnf`.

<img width="947" alt="screen shot 2018-09-10 at 2 47 48 pm" src="https://user-images.githubusercontent.com/26195/45326613-339c1400-b509-11e8-8912-b52e711c6422.png">

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

 - [x] Link to issue, e.g. `Resolves #NNN`
 - [x] Documentation added (if applicable)
 - [x] Tests added
 - [x] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

 - Add `Warnf` as part of the `Logger` interface

/cc @nats-io/core
