### PR TITLE
Update for nkey changes

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -251,7 +251,7 @@ func (s *Server) isClientAuthorized(c *client) bool {
 		if c.opts.Sig == "" {
 			return false
 		}
-		sig, err := base64.RawURLEncoding.DecodeString(c.opts.Sig)
+		sig, err := base64.StdEncoding.DecodeString(c.opts.Sig)
 		if err != nil {
 			return false
 		}

--- a/server/nkey.go
+++ b/server/nkey.go
@@ -19,8 +19,8 @@ import (
 
 // Raw length of the nonce challenge
 const (
-	nonceRawLen = 16
-	nonceLen    = 22 // base64.RawURLEncoding.EncodedLen(nonceRawLen)
+	nonceRawLen = 11
+	nonceLen    = 16 // base64.StdEncoding.EncodedLen(nonceRawLen)
 )
 
 // nonceRequired tells us if we should send a nonce.
@@ -35,5 +35,5 @@ func (s *Server) generateNonce(n []byte) {
 	var raw [nonceRawLen]byte
 	data := raw[:]
 	s.prand.Read(data)
-	base64.RawURLEncoding.Encode(n, data)
+	base64.StdEncoding.Encode(n, data)
 }

--- a/server/nkey_test.go
+++ b/server/nkey_test.go
@@ -37,7 +37,7 @@ type nonceInfo struct {
 }
 
 // This is a seed for a user. We can extract public and private keys from this for testing.
-const seed = "SUAOB32VQGYIOM622XYNXN4Q6GQR5I6DFZPPYZMNI5MMNVAQZDAL3OLH554ISOUTJM4EC6NWS5UHMS4CMONVVRW3VXXEQULMR6MDLPOEUVFPU"
+const seed = "SUAKYRHVIOREXV7EUZTBHUHL7NUMHPMAS7QMDU3GTIUWEI5LDNOXD43IZY"
 
 func nkeyBasicSetup() (*Server, *client, *bufio.Reader, string) {
 	kp, _ := nkeys.FromSeed(seed)
@@ -161,7 +161,7 @@ func TestNkeyClientConnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed signing nonce: %v", err)
 	}
-	sig := base64.RawURLEncoding.EncodeToString(sigraw)
+	sig := base64.StdEncoding.EncodeToString(sigraw)
 
 	// PING needed to flush the +OK to us.
 	cs = fmt.Sprintf("CONNECT {\"nkey\":%q,\"sig\":\"%s\",\"verbose\":true,\"pedantic\":true}\r\nPING\r\n", pubKey, sig)
@@ -199,7 +199,7 @@ func TestMixedClientConnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed signing nonce: %v", err)
 	}
-	sig := base64.RawURLEncoding.EncodeToString(sigraw)
+	sig := base64.StdEncoding.EncodeToString(sigraw)
 
 	// PING needed to flush the +OK to us.
 	cs := fmt.Sprintf("CONNECT {\"nkey\":%q,\"sig\":\"%s\",\"verbose\":true,\"pedantic\":true}\r\nPING\r\n", pubKey, sig)
@@ -252,7 +252,7 @@ func BenchmarkNonceGeneration(b *testing.B) {
 	prand := mrand.New(mrand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < b.N; i++ {
 		prand.Read(data)
-		base64.RawURLEncoding.Encode(b64, data)
+		base64.StdEncoding.Encode(b64, data)
 	}
 }
 
@@ -260,9 +260,9 @@ func BenchmarkPublicVerify(b *testing.B) {
 	data := make([]byte, nonceRawLen)
 	nonce := make([]byte, nonceLen)
 	mrand.Read(data)
-	base64.RawURLEncoding.Encode(nonce, data)
+	base64.StdEncoding.Encode(nonce, data)
 
-	user, err := nkeys.CreateUser(nil)
+	user, err := nkeys.CreateUser()
 	if err != nil {
 		b.Fatalf("Error creating User Nkey: %v", err)
 	}

--- a/vendor/github.com/nats-io/nkeys/keypair.go
+++ b/vendor/github.com/nats-io/nkeys/keypair.go
@@ -15,6 +15,7 @@ package nkeys
 
 import (
 	"bytes"
+	"crypto/rand"
 	"io"
 
 	"golang.org/x/crypto/ed25519"
@@ -26,12 +27,15 @@ type kp struct {
 }
 
 // createPair will create a KeyPair based on the rand entropy and a type/prefix byte. rand can be nil.
-func createPair(rand io.Reader, prefix PrefixByte) (KeyPair, error) {
-	_, privateKey, err := ed25519.GenerateKey(rand)
+func createPair(prefix PrefixByte) (KeyPair, error) {
+	var rawSeed [32]byte
+
+	_, err := io.ReadFull(rand.Reader, rawSeed[:])
 	if err != nil {
 		return nil, err
 	}
-	seed, err := EncodeSeed(prefix, privateKey)
+
+	seed, err := EncodeSeed(prefix, rawSeed[:])
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/nats-io/nkeys/main.go
+++ b/vendor/github.com/nats-io/nkeys/main.go
@@ -17,7 +17,6 @@ package nkeys
 
 import (
 	"errors"
-	"io"
 )
 
 // Errors
@@ -42,32 +41,32 @@ type KeyPair interface {
 	Verify(input []byte, sig []byte) error
 }
 
-// CreateUser will create an User typed KeyPair.
-func CreateUser(rand io.Reader) (KeyPair, error) {
-	return createPair(rand, PrefixByteUser)
+// CreateUser will create a User typed KeyPair.
+func CreateUser() (KeyPair, error) {
+	return createPair(PrefixByteUser)
 }
 
 // CreateAccount will create an Account typed KeyPair.
-func CreateAccount(rand io.Reader) (KeyPair, error) {
-	return createPair(rand, PrefixByteAccount)
+func CreateAccount() (KeyPair, error) {
+	return createPair(PrefixByteAccount)
 }
 
-// CreateServer will create a server typed KeyPair.
-func CreateServer(rand io.Reader) (KeyPair, error) {
-	return createPair(rand, PrefixByteServer)
+// CreateServer will create a Server typed KeyPair.
+func CreateServer() (KeyPair, error) {
+	return createPair(PrefixByteServer)
 }
 
-// CreateCluster will create a cluster typed KeyPair.
-func CreateCluster(rand io.Reader) (KeyPair, error) {
-	return createPair(rand, PrefixByteCluster)
+// CreateCluster will create a Cluster typed KeyPair.
+func CreateCluster() (KeyPair, error) {
+	return createPair(PrefixByteCluster)
 }
 
-// CreateOperator will create an operator typed KeyPair.
-func CreateOperator(rand io.Reader) (KeyPair, error) {
-	return createPair(rand, PrefixByteOperator)
+// CreateOperator will create an Operator typed KeyPair.
+func CreateOperator() (KeyPair, error) {
+	return createPair(PrefixByteOperator)
 }
 
-// FromPublicKey will create a KeyPair capable fo verifying signatures.
+// FromPublicKey will create a KeyPair capable of verifying signatures.
 func FromPublicKey(public string) (KeyPair, error) {
 	raw, err := decode(public)
 	if err != nil {
@@ -83,6 +82,15 @@ func FromPublicKey(public string) (KeyPair, error) {
 // FromSeed will create a KeyPair capable of signing and verifying signatures.
 func FromSeed(seed string) (KeyPair, error) {
 	_, _, err := DecodeSeed(seed)
+	if err != nil {
+		return nil, err
+	}
+	return &kp{seed}, nil
+}
+
+// Create a KeyPair from the raw 32 byte seed for a given type.
+func FromRawSeed(prefix PrefixByte, rawSeed []byte) (KeyPair, error) {
+	seed, err := EncodeSeed(prefix, rawSeed)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/nats-io/nkeys/strkey.go
+++ b/vendor/github.com/nats-io/nkeys/strkey.go
@@ -83,7 +83,7 @@ func EncodeSeed(public PrefixByte, src []byte) (string, error) {
 		return "", err
 	}
 
-	if len(src) != ed25519.PrivateKeySize {
+	if len(src) != ed25519.SeedSize {
 		return "", ErrInvalidSeedLen
 	}
 

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -5,7 +5,7 @@
 			"importpath": "github.com/nats-io/nkeys",
 			"repository": "https://github.com/nats-io/nkeys",
 			"vcs": "git",
-			"revision": "b1c20ce69b6a01afa42403ea6f7b408d6cbc8e4e",
+			"revision": "9206fa847ab4dfdf7378fb1965717f32978852e2",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
Updated for new nkey changes. Also use standard base64 encoding vs URL. Reduce size of raw nonce to 11 which yields 16byte base64.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
