### PR TITLE
Fix regex matching group for removing password

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -706,7 +706,7 @@ func (c *client) processErr(errStr string) {
 }
 
 // Password pattern matcher.
-var passPat = regexp.MustCompile(`"?\s*pass\S*\s*"?\s*[:=]\s*("?[^\s,}$]*)`)
+var passPat = regexp.MustCompile(`"?\s*pass\S*?"?[:=]\s*"?(([^"])*)`)
 
 // This will remove any notion of passwords from trace messages
 // for logging.
@@ -721,7 +721,7 @@ func removePassFromTrace(arg []byte) []byte {
 	}
 
 	for _, match := range m {
-		if len(match) != 2 {
+		if len(match) != 3 {
 			continue
 		}
 		arg = bytes.Replace(arg, match[1], []byte("[REDACTED]"), 1)

--- a/server/log_test.go
+++ b/server/log_test.go
@@ -228,7 +228,10 @@ func TestRemovePassFromTrace(t *testing.T) {
 	check(removePassFromTrace([]byte("CONNECT {\"user\":\"derek\",\"pass\":\"s3cr3t\"}\r\n")))
 	check(removePassFromTrace([]byte("CONNECT {\"user\":\"derek\",\"pass\":  \"s3cr3t\"}\r\n")))
 	check(removePassFromTrace([]byte("CONNECT {\"user\":\"derek\",\"pass\":    \"s3cr3t\"     }\r\n")))
-	check(removePassFromTrace([]byte("CONNECT {\"password\":\"s3cr3t\",}\r\n")))
-	check(removePassFromTrace([]byte("CONNECT {pass:s3cr3t\r\n")))
+	check(removePassFromTrace([]byte("CONNECT {\"pass\":\"s3cr3t\",}\r\n")))
 	check(removePassFromTrace([]byte("CONNECT {pass:s3cr3t ,   password =  s3cr3t}")))
+	check(removePassFromTrace([]byte("CONNECT {\"echo\":true,\"verbose\":false,\"pedantic\":false,\"user\":\"foo\",\"pass\":\"s3cr3t\",\"tls_required\":false,\"name\":\"APM7JU94z77YzP6WTBEiuw\"}\r\n")))
+	check(removePassFromTrace([]byte("CONNECT {pass:s3cr3t\r\n")))
+	check(removePassFromTrace([]byte("CONNECT {\"password\":\"s3cr3t\",}\r\n")))
+	check(removePassFromTrace([]byte("CONNECT {\"echo\":true,\"verbose\":false,\"pedantic\":false,\"user\":\"foo\",\"password\":\"s3cr3t\",\"tls_required\":false,\"name\":\"APM7JU94z77YzP6WTBEiuw\"}\r\n")))
 }


### PR DESCRIPTION
Found that current [regex](https://github.com/nats-io/gnatsd/blob/846544ecfe405aaeceb349b23d32a1f73804830c/server/client.go#L708-L709) to filter passwords occasionally can replace the wrong field in some cases. Updating the regex to prevent the following case (using cluster authorization in this case):
 
Before:

```
[TRC] 127.0.0.1:60178 - rid:3 - ->> [CONNECT {...,"user":"foo","pass":"s3cr3t","name":[REDACTED],...}]

```

After:
```
[TRC] 127.0.0.1:60137 - rid:3 - ->> [CONNECT {...,"user":"foo","pass":"[REDACTED]","name":"jY8IWHNwTq65A5F7PNDQKU",...}]
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

 - Update regex for removing password from logs

/cc @nats-io/core
