### PR TITLE
[ADDED] Account Support

### DIFF
--- a/conf/lex.go
+++ b/conf/lex.go
@@ -594,6 +594,8 @@ func lexMapKeyStart(lx *lexer) stateFn {
 	switch {
 	case isKeySeparator(r):
 		return lx.errorf("Unexpected key separator '%v'.", r)
+	case r == arrayEnd:
+		return lx.errorf("Unexpected array end '%v' processing map.", r)
 	case unicode.IsSpace(r):
 		lx.next()
 		return lexSkip(lx, lexMapKeyStart)

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -497,7 +497,6 @@ func TestImportAuthorized(t *testing.T) {
 }
 
 func TestSimpleMapping(t *testing.T) {
-	t.Helper()
 	s, fooAcc, barAcc := simpleAccountServer(t)
 	defer s.Shutdown()
 

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -1,0 +1,286 @@
+// Copyright 2018 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func simpleAccountServer(t *testing.T) *Server {
+	opts := defaultServerOptions
+	s := New(&opts)
+
+	// Now create two accounts.
+	_, err := s.RegisterAccount("foo")
+	if err != nil {
+		t.Fatalf("Error creating account 'foo': %v", err)
+	}
+	_, err = s.RegisterAccount("bar")
+	if err != nil {
+		t.Fatalf("Error creating account 'bar': %v", err)
+	}
+	return s
+}
+
+func TestRegisterDuplicateAccounts(t *testing.T) {
+	s := simpleAccountServer(t)
+	if _, err := s.RegisterAccount("foo"); err == nil {
+		t.Fatal("Expected an error registering 'foo' twice")
+	}
+}
+
+func TestAccountIsolation(t *testing.T) {
+	s := simpleAccountServer(t)
+	fooAcc := s.LookupAccount("foo")
+	barAcc := s.LookupAccount("bar")
+	if fooAcc == nil || barAcc == nil {
+		t.Fatalf("Error retrieving accounts for 'foo' and 'bar'")
+	}
+	cfoo, crFoo, _ := newClientForServer(s)
+	if err := cfoo.RegisterWithAccount(fooAcc); err != nil {
+		t.Fatalf("Error register client with 'foo' account: %v", err)
+	}
+	cbar, crBar, _ := newClientForServer(s)
+	if err := cbar.RegisterWithAccount(barAcc); err != nil {
+		t.Fatalf("Error register client with 'bar' account: %v", err)
+	}
+
+	// Make sure they are different accounts/sl.
+	if cfoo.acc == cbar.acc {
+		t.Fatalf("Error, accounts the same for both clients")
+	}
+
+	// Now do quick test that makes sure messages do not cross over.
+	// setup bar as a foo subscriber.
+	go cbar.parse([]byte("SUB foo 1\r\nPING\r\nPING\r\n"))
+	l, err := crBar.ReadString('\n')
+	if err != nil {
+		t.Fatalf("Error for client 'bar' from server: %v", err)
+	}
+	if !strings.HasPrefix(l, "PONG\r\n") {
+		t.Fatalf("PONG response incorrect: %q\n", l)
+	}
+
+	go cfoo.parse([]byte("SUB foo 1\r\nPUB foo 5\r\nhello\r\nPING\r\n"))
+	l, err = crFoo.ReadString('\n')
+	if err != nil {
+		t.Fatalf("Error for client 'foo' from server: %v", err)
+	}
+
+	matches := msgPat.FindAllStringSubmatch(l, -1)[0]
+	if matches[SUB_INDEX] != "foo" {
+		t.Fatalf("Did not get correct subject: '%s'\n", matches[SUB_INDEX])
+	}
+	if matches[SID_INDEX] != "1" {
+		t.Fatalf("Did not get correct sid: '%s'\n", matches[SID_INDEX])
+	}
+	checkPayload(crFoo, []byte("hello\r\n"), t)
+
+	// Now make sure nothing shows up on bar.
+	l, err = crBar.ReadString('\n')
+	if err != nil {
+		t.Fatalf("Error for client 'bar' from server: %v", err)
+	}
+	if !strings.HasPrefix(l, "PONG\r\n") {
+		t.Fatalf("PONG response incorrect: %q\n", l)
+	}
+}
+
+func TestAccountFromOptions(t *testing.T) {
+	opts := defaultServerOptions
+	opts.Accounts = []*Account{
+		&Account{Name: "foo"},
+		&Account{Name: "bar"},
+	}
+	s := New(&opts)
+
+	if la := len(s.accounts); la != 2 {
+		t.Fatalf("Expected to have a server with two accounts, got %v", la)
+	}
+	// Check that sl is filled in.
+	fooAcc := s.LookupAccount("foo")
+	barAcc := s.LookupAccount("bar")
+	if fooAcc == nil || barAcc == nil {
+		t.Fatalf("Error retrieving accounts for 'foo' and 'bar'")
+	}
+	if fooAcc.sl == nil || barAcc.sl == nil {
+		t.Fatal("Expected Sublists to be filled in on Opts.Accounts")
+	}
+}
+
+func TestNewAccountsFromClients(t *testing.T) {
+	opts := defaultServerOptions
+	s := New(&opts)
+
+	c, cr, _ := newClientForServer(s)
+	connectOp := []byte("CONNECT {\"account\":\"foo\"}\r\n")
+	go c.parse(connectOp)
+	l, _ := cr.ReadString('\n')
+	if !strings.HasPrefix(l, "-ERR ") {
+		t.Fatalf("Expected an error")
+	}
+
+	opts.AllowNewAccounts = true
+	s = New(&opts)
+
+	c, _, _ = newClientForServer(s)
+	err := c.parse(connectOp)
+	if err != nil {
+		t.Fatalf("Received an error trying to create an account: %v", err)
+	}
+}
+
+// Clients can ask that the account be forced to be new. If it exists this is an error.
+func TestNewAccountRequireNew(t *testing.T) {
+	// This has foo and bar accounts already.
+	s := simpleAccountServer(t)
+
+	c, cr, _ := newClientForServer(s)
+	connectOp := []byte("CONNECT {\"account\":\"foo\",\"new_account\":true}\r\n")
+	go c.parse(connectOp)
+	l, _ := cr.ReadString('\n')
+	if !strings.HasPrefix(l, "-ERR ") {
+		t.Fatalf("Expected an error")
+	}
+
+	// Now allow new accounts on the fly, make sure second time does not work.
+	opts := defaultServerOptions
+	opts.AllowNewAccounts = true
+	s = New(&opts)
+
+	c, _, _ = newClientForServer(s)
+	err := c.parse(connectOp)
+	if err != nil {
+		t.Fatalf("Received an error trying to create an account: %v", err)
+	}
+
+	c, cr, _ = newClientForServer(s)
+	go c.parse(connectOp)
+	l, _ = cr.ReadString('\n')
+	if !strings.HasPrefix(l, "-ERR ") {
+		t.Fatalf("Expected an error")
+	}
+}
+
+func accountNameExists(name string, accounts []*Account) bool {
+	for _, acc := range accounts {
+		if strings.Compare(acc.Name, name) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAccountSimpleConfig(t *testing.T) {
+	confFileName := createConfFile(t, []byte(`accounts = [foo, bar]`))
+	defer os.Remove(confFileName)
+	opts, err := ProcessConfigFile(confFileName)
+	if err != nil {
+		t.Fatalf("Received an error processing config file: %v", err)
+	}
+	if la := len(opts.Accounts); la != 2 {
+		t.Fatalf("Expected to see 2 accounts in opts, got %d\n", la)
+	}
+	if !accountNameExists("foo", opts.Accounts) {
+		t.Fatal("Expected a 'foo' account")
+	}
+	if !accountNameExists("bar", opts.Accounts) {
+		t.Fatal("Expected a 'bar' account")
+	}
+
+	// Make sure double entries is an error.
+	confFileName = createConfFile(t, []byte(`accounts = [foo, foo]`))
+	defer os.Remove(confFileName)
+	_, err = ProcessConfigFile(confFileName)
+	if err == nil {
+		t.Fatalf("Expected an error with double account entries")
+	}
+}
+
+func TestAccountParseConfig(t *testing.T) {
+	confFileName := createConfFile(t, []byte(`
+    accounts {
+      synadia {
+        users = [
+          {user: alice, password: foo}
+          {user: bob, password: bar}
+        ]
+      }
+      nats.io {
+        users = [
+          {user: derek, password: foo}
+          {user: ivan, password: bar}
+        ]
+      }
+    }
+    `))
+	defer os.Remove(confFileName)
+	opts, err := ProcessConfigFile(confFileName)
+	if err != nil {
+		t.Fatalf("Received an error processing config file: %v", err)
+	}
+
+	if la := len(opts.Accounts); la != 2 {
+		t.Fatalf("Expected to see 2 accounts in opts, got %d\n", la)
+	}
+
+	if lu := len(opts.Users); lu != 4 {
+		t.Fatalf("Expected 4 total Users, got %d\n", lu)
+	}
+
+	var natsAcc *Account
+	for _, acc := range opts.Accounts {
+		if acc.Name == "nats.io" {
+			natsAcc = acc
+			break
+		}
+	}
+	if natsAcc == nil {
+		t.Fatalf("Error retrieving account for 'nats.io'")
+	}
+
+	for _, u := range opts.Users {
+		if u.Username == "derek" {
+			if u.Account != natsAcc {
+				t.Fatalf("Expected to see the 'nats.io' account, but received %+v", u.Account)
+				break
+			}
+		}
+	}
+}
+
+func TestAccountParseConfigDuplicateUsers(t *testing.T) {
+	confFileName := createConfFile(t, []byte(`
+    accounts {
+      synadia {
+        users = [
+          {user: alice, password: foo}
+          {user: bob, password: bar}
+        ]
+      }
+      nats.io {
+        users = [
+          {user: alice, password: bar}
+        ]
+      }
+    }
+    `))
+	defer os.Remove(confFileName)
+	_, err := ProcessConfigFile(confFileName)
+	if err == nil {
+		t.Fatalf("Expected an error with double user entries")
+	}
+}

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -14,6 +14,7 @@
 package server
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -69,7 +70,7 @@ func TestAccountIsolation(t *testing.T) {
 		t.Fatalf("Error for client 'bar' from server: %v", err)
 	}
 	if !strings.HasPrefix(l, "PONG\r\n") {
-		t.Fatalf("PONG response incorrect: %q\n", l)
+		t.Fatalf("PONG response incorrect: %q", l)
 	}
 
 	go cfoo.parse([]byte("SUB foo 1\r\nPUB foo 5\r\nhello\r\nPING\r\n"))
@@ -83,7 +84,7 @@ func TestAccountIsolation(t *testing.T) {
 		t.Fatalf("Did not get correct subject: '%s'\n", matches[SUB_INDEX])
 	}
 	if matches[SID_INDEX] != "1" {
-		t.Fatalf("Did not get correct sid: '%s'\n", matches[SID_INDEX])
+		t.Fatalf("Did not get correct sid: '%s'", matches[SID_INDEX])
 	}
 	checkPayload(crFoo, []byte("hello\r\n"), t)
 
@@ -93,7 +94,7 @@ func TestAccountIsolation(t *testing.T) {
 		t.Fatalf("Error for client 'bar' from server: %v", err)
 	}
 	if !strings.HasPrefix(l, "PONG\r\n") {
-		t.Fatalf("PONG response incorrect: %q\n", l)
+		t.Fatalf("PONG response incorrect: %q", l)
 	}
 }
 
@@ -190,7 +191,7 @@ func TestAccountSimpleConfig(t *testing.T) {
 		t.Fatalf("Received an error processing config file: %v", err)
 	}
 	if la := len(opts.Accounts); la != 2 {
-		t.Fatalf("Expected to see 2 accounts in opts, got %d\n", la)
+		t.Fatalf("Expected to see 2 accounts in opts, got %d", la)
 	}
 	if !accountNameExists("foo", opts.Accounts) {
 		t.Fatal("Expected a 'foo' account")
@@ -232,11 +233,11 @@ func TestAccountParseConfig(t *testing.T) {
 	}
 
 	if la := len(opts.Accounts); la != 2 {
-		t.Fatalf("Expected to see 2 accounts in opts, got %d\n", la)
+		t.Fatalf("Expected to see 2 accounts in opts, got %d", la)
 	}
 
 	if lu := len(opts.Users); lu != 4 {
-		t.Fatalf("Expected 4 total Users, got %d\n", lu)
+		t.Fatalf("Expected 4 total Users, got %d", lu)
 	}
 
 	var natsAcc *Account
@@ -391,10 +392,10 @@ func TestSimpleMapping(t *testing.T) {
 		}
 		matches := mraw[0]
 		if matches[SUB_INDEX] != "import.foo" {
-			t.Fatalf("Did not get correct subject: '%s'\n", matches[SUB_INDEX])
+			t.Fatalf("Did not get correct subject: '%s'", matches[SUB_INDEX])
 		}
 		if matches[SID_INDEX] != sid {
-			t.Fatalf("Did not get correct sid: '%s'\n", matches[SID_INDEX])
+			t.Fatalf("Did not get correct sid: '%s'", matches[SID_INDEX])
 		}
 	}
 
@@ -459,10 +460,10 @@ func TestNoPrefixWildcardMapping(t *testing.T) {
 	}
 	matches := mraw[0]
 	if matches[SUB_INDEX] != "foo" {
-		t.Fatalf("Did not get correct subject: '%s'\n", matches[SUB_INDEX])
+		t.Fatalf("Did not get correct subject: '%s'", matches[SUB_INDEX])
 	}
 	if matches[SID_INDEX] != "1" {
-		t.Fatalf("Did not get correct sid: '%s'\n", matches[SID_INDEX])
+		t.Fatalf("Did not get correct sid: '%s'", matches[SID_INDEX])
 	}
 	checkPayload(crBar, []byte("hello\r\n"), t)
 }
@@ -512,10 +513,10 @@ func TestPrefixWildcardMapping(t *testing.T) {
 	}
 	matches := mraw[0]
 	if matches[SUB_INDEX] != "pub.imports.foo" {
-		t.Fatalf("Did not get correct subject: '%s'\n", matches[SUB_INDEX])
+		t.Fatalf("Did not get correct subject: '%s'", matches[SUB_INDEX])
 	}
 	if matches[SID_INDEX] != "1" {
-		t.Fatalf("Did not get correct sid: '%s'\n", matches[SID_INDEX])
+		t.Fatalf("Did not get correct sid: '%s'", matches[SID_INDEX])
 	}
 	checkPayload(crBar, []byte("hello\r\n"), t)
 }
@@ -565,10 +566,10 @@ func TestPrefixWildcardMappingWithLiteralSub(t *testing.T) {
 	}
 	matches := mraw[0]
 	if matches[SUB_INDEX] != "pub.imports.foo" {
-		t.Fatalf("Did not get correct subject: '%s'\n", matches[SUB_INDEX])
+		t.Fatalf("Did not get correct subject: '%s'", matches[SUB_INDEX])
 	}
 	if matches[SID_INDEX] != "1" {
-		t.Fatalf("Did not get correct sid: '%s'\n", matches[SID_INDEX])
+		t.Fatalf("Did not get correct sid: '%s'", matches[SID_INDEX])
 	}
 	checkPayload(crBar, []byte("hello\r\n"), t)
 }
@@ -630,17 +631,19 @@ func TestCrossAccountRequestReply(t *testing.T) {
 	}
 	matches := mraw[0]
 	if matches[SUB_INDEX] != "test.request" {
-		t.Fatalf("Did not get correct subject: '%s'\n", matches[SUB_INDEX])
+		t.Fatalf("Did not get correct subject: '%s'", matches[SUB_INDEX])
 	}
 	if matches[SID_INDEX] != "1" {
-		t.Fatalf("Did not get correct sid: '%s'\n", matches[SID_INDEX])
+		t.Fatalf("Did not get correct sid: '%s'", matches[SID_INDEX])
 	}
-	if matches[REPLY_INDEX] != "bar" {
-		t.Fatalf("Did not get correct sid: '%s'\n", matches[SID_INDEX])
+	// Make sure this looks like _INBOX
+	if !strings.HasPrefix(matches[REPLY_INDEX], "_INBOX.") {
+		t.Fatalf("Expected an _INBOX.* like reply, got '%s'", matches[REPLY_INDEX])
 	}
 	checkPayload(crFoo, []byte("help\r\n"), t)
 
-	go cfoo.parseAndFlush([]byte("PUB bar 2\r\n22\r\n"))
+	replyOp := fmt.Sprintf("PUB %s 2\r\n22\r\n", matches[REPLY_INDEX])
+	go cfoo.parseAndFlush([]byte(replyOp))
 
 	// Now read the response from crBar
 	l, err = crBar.ReadString('\n')
@@ -653,13 +656,13 @@ func TestCrossAccountRequestReply(t *testing.T) {
 	}
 	matches = mraw[0]
 	if matches[SUB_INDEX] != "bar" {
-		t.Fatalf("Did not get correct subject: '%s'\n", matches[SUB_INDEX])
+		t.Fatalf("Did not get correct subject: '%s'", matches[SUB_INDEX])
 	}
 	if matches[SID_INDEX] != "11" {
-		t.Fatalf("Did not get correct sid: '%s'\n", matches[SID_INDEX])
+		t.Fatalf("Did not get correct sid: '%s'", matches[SID_INDEX])
 	}
 	if matches[REPLY_INDEX] != "" {
-		t.Fatalf("Did not get correct sid: '%s'\n", matches[SID_INDEX])
+		t.Fatalf("Did not get correct sid: '%s'", matches[SID_INDEX])
 	}
 	checkPayload(crBar, []byte("22\r\n"), t)
 
@@ -667,5 +670,15 @@ func TestCrossAccountRequestReply(t *testing.T) {
 	/// for the response but should be removed when the response was processed.
 	if nr := fooAcc.numRoutes(); nr != 0 {
 		t.Fatalf("Expected no remaining routes on fooAcc, got %d", nr)
+	}
+}
+
+func BenchmarkNewRouteReply(b *testing.B) {
+	opts := defaultServerOptions
+	s := New(&opts)
+	c, _, _ := newClientForServer(s)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.newRouteReply()
 	}
 }

--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -287,60 +287,60 @@ func TestAccountParseConfigDuplicateUsers(t *testing.T) {
 func TestImportAuthorized(t *testing.T) {
 	_, foo, bar := simpleAccountServer(t)
 
-	checkBool(foo.checkImportAuthorized(bar, "foo"), false, t)
-	checkBool(foo.checkImportAuthorized(bar, "*"), false, t)
-	checkBool(foo.checkImportAuthorized(bar, ">"), false, t)
-	checkBool(foo.checkImportAuthorized(bar, "foo.*"), false, t)
-	checkBool(foo.checkImportAuthorized(bar, "foo.>"), false, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo"), false, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "*"), false, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, ">"), false, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo.*"), false, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo.>"), false, t)
 
-	foo.addExport("foo", isPublicExport)
-	checkBool(foo.checkImportAuthorized(bar, "foo"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "bar"), false, t)
-	checkBool(foo.checkImportAuthorized(bar, "*"), false, t)
+	foo.addStreamExport("foo", isPublicExport)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "bar"), false, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "*"), false, t)
 
-	foo.addExport("*", []*Account{bar})
-	checkBool(foo.checkImportAuthorized(bar, "foo"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "bar"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "baz"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "foo.bar"), false, t)
-	checkBool(foo.checkImportAuthorized(bar, ">"), false, t)
-	checkBool(foo.checkImportAuthorized(bar, "*"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "foo.*"), false, t)
-	checkBool(foo.checkImportAuthorized(bar, "*.*"), false, t)
-	checkBool(foo.checkImportAuthorized(bar, "*.>"), false, t)
+	foo.addStreamExport("*", []*Account{bar})
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "bar"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "baz"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo.bar"), false, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, ">"), false, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "*"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo.*"), false, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "*.*"), false, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "*.>"), false, t)
 
 	// Reset and test '>' public export
 	_, foo, bar = simpleAccountServer(t)
-	foo.addExport(">", nil)
+	foo.addStreamExport(">", nil)
 	// Everything should work.
-	checkBool(foo.checkImportAuthorized(bar, "foo"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "bar"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "baz"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "foo.bar"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, ">"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "*"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "foo.*"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "*.*"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "*.>"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "bar"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "baz"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo.bar"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, ">"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "*"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo.*"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "*.*"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "*.>"), true, t)
 
 	// Reset and test pwc and fwc
 	s, foo, bar := simpleAccountServer(t)
-	foo.addExport("foo.*.baz.>", []*Account{bar})
-	checkBool(foo.checkImportAuthorized(bar, "foo.bar.baz.1"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "foo.bar.baz.*"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "foo.*.baz.1.1"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "foo.22.baz.22"), true, t)
-	checkBool(foo.checkImportAuthorized(bar, "foo.bar.baz"), false, t)
-	checkBool(foo.checkImportAuthorized(bar, ""), false, t)
-	checkBool(foo.checkImportAuthorized(bar, "foo.bar.*.*"), false, t)
+	foo.addStreamExport("foo.*.baz.>", []*Account{bar})
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo.bar.baz.1"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo.bar.baz.*"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo.*.baz.1.1"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo.22.baz.22"), true, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo.bar.baz"), false, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, ""), false, t)
+	checkBool(foo.checkStreamImportAuthorized(bar, "foo.bar.*.*"), false, t)
 
 	// Make sure we match the account as well
 
 	fb, _ := s.RegisterAccount("foobar")
 	bz, _ := s.RegisterAccount("baz")
 
-	checkBool(foo.checkImportAuthorized(fb, "foo.bar.baz.1"), false, t)
-	checkBool(foo.checkImportAuthorized(bz, "foo.bar.baz.1"), false, t)
+	checkBool(foo.checkStreamImportAuthorized(fb, "foo.bar.baz.1"), false, t)
+	checkBool(foo.checkStreamImportAuthorized(bz, "foo.bar.baz.1"), false, t)
 }
 
 func TestSimpleMapping(t *testing.T) {
@@ -361,16 +361,16 @@ func TestSimpleMapping(t *testing.T) {
 	}
 
 	// Test first that trying to import with no matching export permission returns an error.
-	if err := cbar.acc.addImport(fooAcc, "foo", "import"); err != ErrAccountImportAuthorization {
+	if err := cbar.acc.addStreamImport(fooAcc, "foo", "import"); err != ErrStreamImportAuthorization {
 		t.Fatalf("Expected error of ErrAccountImportAuthorization but got %v", err)
 	}
 
 	// Now map the subject space between foo and bar.
 	// Need to do export first.
-	if err := cfoo.acc.addExport("foo", nil); err != nil { // Public with no accounts defined.
+	if err := cfoo.acc.addStreamExport("foo", nil); err != nil { // Public with no accounts defined.
 		t.Fatalf("Error adding account export to client foo: %v", err)
 	}
-	if err := cbar.acc.addImport(fooAcc, "foo", "import"); err != nil {
+	if err := cbar.acc.addStreamImport(fooAcc, "foo", "import"); err != nil {
 		t.Fatalf("Error adding account import to client bar: %v", err)
 	}
 
@@ -432,10 +432,10 @@ func TestNoPrefixWildcardMapping(t *testing.T) {
 		t.Fatalf("Error registering client with 'bar' account: %v", err)
 	}
 
-	if err := cfoo.acc.addExport(">", []*Account{barAcc}); err != nil { // Public with no accounts defined.
+	if err := cfoo.acc.addStreamExport(">", []*Account{barAcc}); err != nil { // Public with no accounts defined.
 		t.Fatalf("Error adding account export to client foo: %v", err)
 	}
-	if err := cbar.acc.addImport(fooAcc, "*", ""); err != nil {
+	if err := cbar.acc.addStreamImport(fooAcc, "*", ""); err != nil {
 		t.Fatalf("Error adding account import to client bar: %v", err)
 	}
 
@@ -485,10 +485,10 @@ func TestPrefixWildcardMapping(t *testing.T) {
 		t.Fatalf("Error registering client with 'bar' account: %v", err)
 	}
 
-	if err := cfoo.acc.addExport(">", []*Account{barAcc}); err != nil { // Public with no accounts defined.
+	if err := cfoo.acc.addStreamExport(">", []*Account{barAcc}); err != nil { // Public with no accounts defined.
 		t.Fatalf("Error adding account export to client foo: %v", err)
 	}
-	if err := cbar.acc.addImport(fooAcc, "*", "pub.imports."); err != nil {
+	if err := cbar.acc.addStreamImport(fooAcc, "*", "pub.imports."); err != nil {
 		t.Fatalf("Error adding account import to client bar: %v", err)
 	}
 
@@ -538,10 +538,10 @@ func TestPrefixWildcardMappingWithLiteralSub(t *testing.T) {
 		t.Fatalf("Error registering client with 'bar' account: %v", err)
 	}
 
-	if err := cfoo.acc.addExport(">", []*Account{barAcc}); err != nil { // Public with no accounts defined.
+	if err := cfoo.acc.addStreamExport(">", []*Account{barAcc}); err != nil { // Public with no accounts defined.
 		t.Fatalf("Error adding account export to client foo: %v", err)
 	}
-	if err := cbar.acc.addImport(fooAcc, "*", "pub.imports."); err != nil {
+	if err := cbar.acc.addStreamImport(fooAcc, "*", "pub.imports."); err != nil {
 		t.Fatalf("Error adding account import to client bar: %v", err)
 	}
 
@@ -592,23 +592,23 @@ func TestCrossAccountRequestReply(t *testing.T) {
 	}
 
 	// Add in the service import for the requests. Make it public.
-	if err := cfoo.acc.addService(nil, "test.request"); err != nil {
+	if err := cfoo.acc.addServiceExport(nil, "test.request"); err != nil {
 		t.Fatalf("Error adding account service import to client foo: %v", err)
 	}
 
-	// Test addRoute to make sure it requires accounts, and literalsubjects for both from and to subjects.
-	if err := cbar.acc.addRoute(nil, "foo", "test.request"); err != ErrMissingAccount {
+	// Test addServiceImport to make sure it requires accounts, and literalsubjects for both from and to subjects.
+	if err := cbar.acc.addServiceImport(nil, "foo", "test.request"); err != ErrMissingAccount {
 		t.Fatalf("Expected ErrMissingAccount but received %v.", err)
 	}
-	if err := cbar.acc.addRoute(fooAcc, "*", "test.request"); err != ErrInvalidSubject {
+	if err := cbar.acc.addServiceImport(fooAcc, "*", "test.request"); err != ErrInvalidSubject {
 		t.Fatalf("Expected ErrInvalidSubject but received %v.", err)
 	}
-	if err := cbar.acc.addRoute(fooAcc, "foo", "test..request."); err != ErrInvalidSubject {
+	if err := cbar.acc.addServiceImport(fooAcc, "foo", "test..request."); err != ErrInvalidSubject {
 		t.Fatalf("Expected ErrInvalidSubject but received %v.", err)
 	}
 
 	// Now add in the Route for request to be routed to the foo account.
-	if err := cbar.acc.addRoute(fooAcc, "foo", "test.request"); err != nil {
+	if err := cbar.acc.addServiceImport(fooAcc, "foo", "test.request"); err != nil {
 		t.Fatalf("Error adding account route to client bar: %v", err)
 	}
 
@@ -666,9 +666,9 @@ func TestCrossAccountRequestReply(t *testing.T) {
 	}
 	checkPayload(crBar, []byte("22\r\n"), t)
 
-	// Make sure we have no routes on fooAcc. An implicit one was created
-	/// for the response but should be removed when the response was processed.
-	if nr := fooAcc.numRoutes(); nr != 0 {
+	// Make sure we have no service imports on fooAcc. An implicit one was created
+	// for the response but should be removed when the response was processed.
+	if nr := fooAcc.numServiceRoutes(); nr != 0 {
 		t.Fatalf("Expected no remaining routes on fooAcc, got %d", nr)
 	}
 }
@@ -679,6 +679,6 @@ func BenchmarkNewRouteReply(b *testing.B) {
 	c, _, _ := newClientForServer(s)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.newRouteReply()
+		c.newServiceReply()
 	}
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -64,11 +64,13 @@ type serviceImport struct {
 	ae   bool
 }
 
+// importMap tracks the imported streams and services.
 type importMap struct {
 	streams  map[string]*streamImport
 	services map[string]*serviceImport // TODO(dlc) sync.Map may be better.
 }
 
+// exportMap tracks the exported streams and services.
 type exportMap struct {
 	streams  map[string]map[string]*Account
 	services map[string]map[string]*Account
@@ -364,7 +366,7 @@ func (s *Server) checkAuthforWarnings() {
 	}
 	if warn {
 		// Warning about using plaintext passwords.
-		s.Warnf("Plaintext passwords detected. Use Nkeys or Bcrypt passwords in config files.")
+		s.Warnf("Plaintext passwords detected, use nkeys or bcrypt.")
 	}
 }
 
@@ -480,6 +482,7 @@ func (s *Server) isClientAuthorized(c *client) bool {
 		if err := pub.Verify(c.nonce, sig); err != nil {
 			return false
 		}
+		c.RegisterNkeyUser(nkey)
 		return true
 	}
 

--- a/server/client.go
+++ b/server/client.go
@@ -144,6 +144,8 @@ type client struct {
 	ncs   string
 	out   outbound
 	srv   *Server
+	acc   *Account
+	sl    *Sublist
 	subs  map[string]*subscription
 	perms *permissions
 	in    readCache
@@ -258,6 +260,8 @@ type clientOpts struct {
 	Lang          string `json:"lang"`
 	Version       string `json:"version"`
 	Protocol      int    `json:"protocol"`
+	Account       string `json:"account,omitempty"`
+	AccountNew    bool   `json:"new_account,omitempty"`
 
 	// Routes only
 	Import *SubjectPermission `json:"import,omitempty"`
@@ -313,21 +317,32 @@ func (c *client) initClient() {
 	}
 }
 
+// RegisterWithAccount will register the given user with a specific
+// account. This will change the subject namespace.
+func (c *client) RegisterWithAccount(acc *Account) error {
+	if acc == nil || acc.sl == nil {
+		return ErrBadAccount
+	}
+	c.mu.Lock()
+	c.acc = acc
+	c.sl = acc.sl
+	c.mu.Unlock()
+	return nil
+}
+
 // RegisterUser allows auth to call back into a new client
 // with the authenticated user. This is used to map any permissions
 // into the client.
 func (c *client) RegisterUser(user *User) {
-	if user.Permissions == nil {
-		// Reset perms to nil in case client previously had them.
-		c.mu.Lock()
-		c.perms = nil
-		c.mu.Unlock()
-		return
-	}
-
 	// Process Permissions and map into client connection structures.
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if user.Permissions == nil {
+		// Reset perms to nil in case client previously had them.
+		c.perms = nil
+		return
+	}
 
 	c.setPermissions(user.Permissions)
 }
@@ -770,6 +785,8 @@ func (c *client) processConnect(arg []byte) error {
 	proto := c.opts.Protocol
 	verbose := c.opts.Verbose
 	lang := c.opts.Lang
+	account := c.opts.Account
+	accountNew := c.opts.AccountNew
 	c.mu.Unlock()
 
 	if srv != nil {
@@ -787,6 +804,38 @@ func (c *client) processConnect(arg []byte) error {
 		if ok := srv.checkAuthorization(c); !ok {
 			c.authViolation()
 			return ErrAuthorization
+		}
+
+		// Check for Account designation
+		if account != "" {
+			var acc *Account
+			var wasNew bool
+			if !srv.newAccountsAllowed() {
+				acc = srv.LookupAccount(account)
+				if acc == nil {
+					c.Errorf(ErrMissingAccount.Error())
+					c.sendErr("Account Not Found")
+					return ErrMissingAccount
+				} else if accountNew {
+					c.Errorf(ErrAccountExists.Error())
+					c.sendErr(ErrAccountExists.Error())
+					return ErrAccountExists
+				}
+			} else {
+				// We can create this one on the fly.
+				acc, wasNew = srv.LookupOrRegisterAccount(account)
+				if accountNew && !wasNew {
+					c.Errorf(ErrAccountExists.Error())
+					c.sendErr(ErrAccountExists.Error())
+					return ErrAccountExists
+				}
+			}
+			// If we are here we can register ourselves with the new account.
+			if err := c.RegisterWithAccount(acc); err != nil {
+				c.Errorf("Problem registering with account [%s]", account)
+				c.sendErr("Account Failed Registration")
+				return ErrBadAccount
+			}
 		}
 	}
 
@@ -828,7 +877,18 @@ func (c *client) authTimeout() {
 }
 
 func (c *client) authViolation() {
-	if c.srv != nil && c.srv.getOpts().Users != nil {
+	var hasNkeys, hasUsers bool
+	if s := c.srv; s != nil {
+		s.mu.Lock()
+		hasNkeys = s.nkeys != nil
+		hasUsers = s.users != nil
+		s.mu.Unlock()
+	}
+	if hasNkeys {
+		c.Errorf("%s - Nkey %q",
+			ErrAuthorization.Error(),
+			c.opts.Nkey)
+	} else if hasUsers {
 		c.Errorf("%s - User %q",
 			ErrAuthorization.Error(),
 			c.opts.Username)
@@ -1239,8 +1299,8 @@ func (c *client) processSub(argo []byte) (err error) {
 	sid := string(sub.sid)
 	if c.subs[sid] == nil {
 		c.subs[sid] = sub
-		if c.srv != nil {
-			err = c.srv.sl.Insert(sub)
+		if c.sl != nil {
+			err = c.sl.Insert(sub)
 			if err != nil {
 				delete(c.subs, sid)
 			} else {
@@ -1297,8 +1357,8 @@ func (c *client) unsubscribe(sub *subscription) {
 	c.traceOp("<-> %s", "DELSUB", sub.sid)
 
 	delete(c.subs, string(sub.sid))
-	if c.srv != nil {
-		c.srv.sl.Remove(sub)
+	if c.sl != nil {
+		c.sl.Remove(sub)
 	}
 
 	// If we are a queue subscriber on a client connection and we have routes,
@@ -1562,7 +1622,7 @@ func (c *client) processMsg(msg []byte) {
 	var r *SublistResult
 	var ok bool
 
-	genid := atomic.LoadUint64(&srv.sl.genid)
+	genid := atomic.LoadUint64(&c.sl.genid)
 
 	if genid == c.in.genid && c.in.results != nil {
 		r, ok = c.in.results[string(c.pa.subject)]
@@ -1574,7 +1634,7 @@ func (c *client) processMsg(msg []byte) {
 
 	if !ok {
 		subject := string(c.pa.subject)
-		r = srv.sl.Match(subject)
+		r = c.sl.Match(subject)
 		c.in.results[subject] = r
 		// Prune the results cache. Keeps us from unbounded growth.
 		if len(c.in.results) > maxResultCacheSize {
@@ -1782,6 +1842,35 @@ func (c *client) typeString() string {
 	return "Unknown Type"
 }
 
+// removeUnauthorizedSubs removes any subscriptions the client has that are no
+// longer authorized, e.g. due to a config reload.
+func (c *client) removeUnauthorizedSubs() {
+	c.mu.Lock()
+	if c.perms == nil {
+		c.mu.Unlock()
+		return
+	}
+	srv := c.srv
+	subs := make(map[string]*subscription, len(c.subs))
+	for sid, sub := range c.subs {
+		subs[sid] = sub
+	}
+	c.mu.Unlock()
+
+	for sid, sub := range subs {
+		if c.sl != nil && !c.canSubscribe(sub.subject) {
+			_ = c.sl.Remove(sub)
+			c.mu.Lock()
+			delete(c.subs, sid)
+			c.mu.Unlock()
+			c.sendErr(fmt.Sprintf("Permissions Violation for Subscription to %q (sid %s)",
+				sub.subject, sub.sid))
+			srv.Noticef("Removed sub %q for user %q - not authorized",
+				string(sub.subject), c.opts.Username)
+		}
+	}
+}
+
 func (c *client) closeConnection(reason ClosedState) {
 	c.mu.Lock()
 	if c.nc == nil {
@@ -1820,10 +1909,13 @@ func (c *client) closeConnection(reason ClosedState) {
 
 	c.mu.Unlock()
 
+	// Remove clients subscriptions.
+	c.sl.RemoveBatch(subs)
+
 	if srv != nil {
 		// This is a route that disconnected...
 		if len(connectURLs) > 0 {
-			// Unless disabled, possibly update the server's INFO protcol
+			// Unless disabled, possibly update the server's INFO protocol
 			// and send to clients that know how to handle async INFOs.
 			if !srv.getOpts().Cluster.NoAdvertise {
 				srv.removeClientConnectURLsAndSendINFOToClients(connectURLs)
@@ -1833,9 +1925,8 @@ func (c *client) closeConnection(reason ClosedState) {
 		// Unregister
 		srv.removeClient(c)
 
-		// Remove clients subscriptions.
-		srv.sl.RemoveBatch(subs)
-		if c.typ == CLIENT {
+		// Remove remote subscriptions.
+		if c.typ != ROUTER {
 			// Forward UNSUBs protocols to all routes
 			srv.broadcastUnSubscribeBatch(subs)
 		}

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -395,13 +395,19 @@ func TestClientNoBodyPubSubWithReply(t *testing.T) {
 	}
 }
 
-func (c *client) parseFlushAndClose(op []byte) {
+// This needs to clear any flushOutbound flags since writeLoop not running.
+func (c *client) parseAndFlush(op []byte) {
 	c.parse(op)
 	for cp := range c.pcd {
 		cp.mu.Lock()
+		cp.flags.clear(flushOutbound)
 		cp.flushOutbound()
 		cp.mu.Unlock()
 	}
+}
+
+func (c *client) parseFlushAndClose(op []byte) {
+	c.parseAndFlush(op)
 	c.nc.Close()
 }
 

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -57,6 +57,8 @@ func newClientForServer(s *Server) (*client, *bufio.Reader, string) {
 	cr := bufio.NewReaderSize(cli, maxBufSize)
 	ch := make(chan *client)
 	createClientAsync(ch, s, srv)
+	// So failing tests don't just hang.
+	cli.SetReadDeadline(time.Now().Add(2 * time.Second))
 	l, _ := cr.ReadString('\n')
 	// Grab client
 	c := <-ch
@@ -283,6 +285,7 @@ const (
 )
 
 func checkPayload(cr *bufio.Reader, expected []byte, t *testing.T) {
+	t.Helper()
 	// Read in payload
 	d := make([]byte, len(expected))
 	n, err := cr.Read(d)

--- a/server/configs/accounts.conf
+++ b/server/configs/accounts.conf
@@ -1,0 +1,47 @@
+
+accounts: {
+  synadia: {
+    nkey: ADMHMDX2LEUJRZQHGVSVRWZEJ2CPNHYO6TB4ZCZ37LXAX5SYNEW252GF
+
+    users = [
+      # Bob
+      {nkey : UC6NLCN7AS34YOJVCYD4PJ3QB7QGLYG5B5IMBT25VW5K4TNUJODM7BOX}
+      # Alice
+      {nkey : UBAAQWTW6CG2G6ANGNKB5U2B7HRWHSGMZEZX3AQSAJOQDAUGJD46LD2E}
+    ]
+
+    exports = [
+      {stream: "public.>"} # No accounts means public.
+      {stream: "synadia.private.>", accounts: [cncf, nats.io]}
+      {service: "pub.request"} # No accounts means public.
+      {service: "pub.special.request", accounts: [nats.io]}
+    ]
+
+    imports = [
+      {service: {account: "nats.io", subject: "nats.time"}}
+    ]
+  }
+
+  nats.io: {
+    nkey: AB5UKNPVHDWBP5WODG742274I3OGY5FM3CBIFCYI4OFEH7Y23GNZPXFE
+
+    users = [
+      # Ivan
+      {nkey : UBRYMDSRTC6AVJL6USKKS3FIOE466GMEU67PZDGOWYSYHWA7GSKO42VW}
+      # Derek
+      {nkey : UDEREK22W43P2NFQCSKGM6BWD23OVWEDR7JE7LSNCD232MZIC4X2MEKZ}
+    ]
+
+    imports = [
+      {stream: {account: "synadia", subject:"public.synadia"}, prefix: "imports.synadia"}
+      {stream: {account: "synadia", subject:"synadia.private.*"}}
+      {service: {account: "synadia", subject: "pub.special.request"}, to: "synadia.request"}
+    ]
+
+    exports = [
+      {service: "nats.time"}
+    ]
+  }
+
+  cncf: { nkey: ABDAYEV6KZVLW3GSJ3V7IWC542676TFYILXF2C7Z56LCPSMVHJE5BVYO}
+}

--- a/server/errors.go
+++ b/server/errors.go
@@ -58,4 +58,6 @@ var (
 
 	// ErrMissingAccount is returned when an account does not exist.
 	ErrMissingAccount = errors.New("Account Missing")
+
+	ErrAccountImportAuthorization = errors.New("Account Not Authorized: Subject Not Exported")
 )

--- a/server/errors.go
+++ b/server/errors.go
@@ -59,9 +59,9 @@ var (
 	// ErrMissingAccount is returned when an account does not exist.
 	ErrMissingAccount = errors.New("Account Missing")
 
-	// ErrAccountImportAuthorization is returned when an import is not authorized.
-	ErrAccountImportAuthorization = errors.New("Account Not Authorized: Subject Not Exported")
+	// ErrStreamImportAuthorization is returned when a stream import is not authorized.
+	ErrStreamImportAuthorization = errors.New("Stream Import Not Authorized")
 
-	// ErrAccountRouteAuthorization is returned when a route is not authorized.
-	ErrAccountRouteAuthorization = errors.New("Account Not Authorized On Service")
+	// ErrServiceImportAuthorization is returned when a service import is not authorized.
+	ErrServiceImportAuthorization = errors.New("Service Import Not Authorized")
 )

--- a/server/errors.go
+++ b/server/errors.go
@@ -48,4 +48,14 @@ var (
 	// ErrClientConnectedToRoutePort represents an error condition when a client
 	// attempted to connect to the route listen port.
 	ErrClientConnectedToRoutePort = errors.New("Attempted To Connect To Route Port")
+
+	// ErrAccountExists is returned when an account is attempted to be registered
+	// but already exists.
+	ErrAccountExists = errors.New("Account Exists")
+
+	// ErrBadAccount represents a malformed or incorrect account.
+	ErrBadAccount = errors.New("Bad Account")
+
+	// ErrMissingAccount is returned when an account does not exist.
+	ErrMissingAccount = errors.New("Account Missing")
 )

--- a/server/errors.go
+++ b/server/errors.go
@@ -59,5 +59,9 @@ var (
 	// ErrMissingAccount is returned when an account does not exist.
 	ErrMissingAccount = errors.New("Account Missing")
 
+	// ErrAccountImportAuthorization is returned when an import is not authorized.
 	ErrAccountImportAuthorization = errors.New("Account Not Authorized: Subject Not Exported")
+
+	// ErrAccountRouteAuthorization is returned when a route is not authorized.
+	ErrAccountRouteAuthorization = errors.New("Account Not Authorized On Service")
 )

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -709,14 +709,15 @@ func (s *Server) Subsz(opts *SubszOptions) (*Subsz, error) {
 		}
 	}
 
-	sz := &Subsz{s.sl.Stats(), 0, offset, limit, nil}
+	// FIXME(dlc) - Make account aware.
+	sz := &Subsz{s.gsl.Stats(), 0, offset, limit, nil}
 
 	if subdetail {
 		// Now add in subscription's details
 		var raw [4096]*subscription
 		subs := raw[:0]
 
-		s.sl.localSubs(&subs)
+		s.gsl.localSubs(&subs)
 		details := make([]SubDetail, len(subs))
 		i := 0
 		// TODO(dlc) - may be inefficient and could just do normal match when total subs is large and filtering.
@@ -938,7 +939,7 @@ func (s *Server) Varz(varzOpts *VarzOptions) (*Varz, error) {
 	v.SlowConsumers = atomic.LoadInt64(&s.slowConsumers)
 	v.MaxPending = opts.MaxPending
 	v.WriteDeadline = opts.WriteDeadline
-	v.Subscriptions = s.sl.Count()
+	v.Subscriptions = s.gsl.Count()
 	v.ConfigLoadTime = s.configTime
 	// Need a copy here since s.httpReqStats can change while doing
 	// the marshaling down below.

--- a/server/nkey_test.go
+++ b/server/nkey_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	mrand "math/rand"
-	"net"
 	"os"
 	"strings"
 	"testing"
@@ -54,17 +53,6 @@ func mixedSetup() (*Server, *client, *bufio.Reader, string) {
 	opts.Nkeys = []*NkeyUser{&NkeyUser{Nkey: pub}}
 	opts.Users = []*User{&User{Username: "derek", Password: "foo"}}
 	return rawSetup(opts)
-}
-
-func newClientForServer(s *Server) (*client, *bufio.Reader, string) {
-	cli, srv := net.Pipe()
-	cr := bufio.NewReaderSize(cli, maxBufSize)
-	ch := make(chan *client)
-	createClientAsync(ch, s, srv)
-	l, _ := cr.ReadString('\n')
-	// Grab client
-	c := <-ch
-	return c, cr, l
 }
 
 func TestServerInfoNonce(t *testing.T) {

--- a/server/opts.go
+++ b/server/opts.go
@@ -915,7 +915,11 @@ func parseExportStreamOrService(v map[string]interface{}, pedantic bool) (*expor
 			if curStream != nil {
 				return nil, nil, fmt.Errorf("Detected service but already saw a stream: %+v", mv)
 			}
-			curService = &export{sub: mv.(string)}
+			mvs, ok := mv.(string)
+			if !ok {
+				return nil, nil, fmt.Errorf("Expected service to be string name, got %T", mv)
+			}
+			curService = &export{sub: mvs}
 			if accounts != nil {
 				curService.accs = accounts
 			}

--- a/server/parser.go
+++ b/server/parser.go
@@ -234,7 +234,7 @@ func (c *client) parse(buf []byte) error {
 				if len(c.msgBuf) != c.pa.size+LEN_CR_LF {
 					goto parseErr
 				}
-				c.processMsg(c.msgBuf)
+				c.processInboundMsg(c.msgBuf)
 				c.argBuf, c.msgBuf = nil, nil
 				c.drop, c.as, c.state = 0, i+1, OP_START
 			default:

--- a/server/reload.go
+++ b/server/reload.go
@@ -762,7 +762,8 @@ func (s *Server) reloadClusterPermissions() {
 		subsNeedUNSUB    []*subscription
 		deleteRoutedSubs []*subscription
 	)
-	s.sl.localSubs(&localSubs)
+	// FIXME(dlc) - Change for accounts.
+	s.gsl.localSubs(&localSubs)
 
 	// Go through all local subscriptions
 	for _, sub := range localSubs {
@@ -810,7 +811,8 @@ func (s *Server) reloadClusterPermissions() {
 		route.mu.Unlock()
 	}
 	// Remove as a batch all the subs that we have removed from each route.
-	s.sl.RemoveBatch(deleteRoutedSubs)
+	// FIXME(dlc) - Change for accounts.
+	s.gsl.RemoveBatch(deleteRoutedSubs)
 }
 
 // validateClusterOpts ensures the new ClusterOpts does not change host or

--- a/server/reload.go
+++ b/server/reload.go
@@ -681,7 +681,7 @@ func (s *Server) reloadAuthorization() {
 		}
 
 		// Remove any unauthorized subscriptions.
-		s.removeUnauthorizedSubs(client)
+		client.removeUnauthorizedSubs()
 	}
 
 	for _, route := range routes {

--- a/server/route.go
+++ b/server/route.go
@@ -212,12 +212,15 @@ func (c *client) reRouteQMsg(r *SublistResult, msgh, msg, group []byte) {
 	c.Debugf("Redelivery failed, no queue subscribers for message on group '%q'", group)
 }
 
-// processRoutedMsg processes messages inbound from a route.
-func (c *client) processRoutedMsg(r *SublistResult, msg []byte) {
+// processRoutedMsgResults processes messages inbound from a route.
+func (c *client) processRoutedMsgResults(r *SublistResult, msg []byte) {
 	// Snapshot server.
 	srv := c.srv
 
-	msgh := c.prepMsgHeader()
+	// msg header
+	msgh := c.msgb[:msgHeadProtoLen]
+	msgh = append(msgh, c.pa.subject...)
+	msgh = append(msgh, ' ')
 	si := len(msgh)
 
 	// If we have a queue subscription, deliver direct

--- a/server/route.go
+++ b/server/route.go
@@ -578,7 +578,8 @@ func (s *Server) sendLocalSubsToRoute(route *client) {
 	var raw [4096]*subscription
 	subs := raw[:0]
 
-	s.sl.localSubs(&subs)
+	// FIXME(dlc) this needs to be scoped per account when cluster proto changes.
+	s.gsl.localSubs(&subs)
 
 	route.mu.Lock()
 	closed := route.sendRouteSubProtos(subs, func(sub *subscription) bool {
@@ -691,7 +692,7 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 		}
 	}
 
-	c := &client{srv: s, nc: conn, opts: clientOpts{}, typ: ROUTER, route: r}
+	c := &client{srv: s, sl: s.gsl, nc: conn, opts: clientOpts{}, typ: ROUTER, route: r}
 
 	// Grab server variables
 	s.mu.Lock()

--- a/server/route.go
+++ b/server/route.go
@@ -194,7 +194,7 @@ func (c *client) reRouteQMsg(r *SublistResult, msgh, msg, group []byte) {
 			rsub = sub
 			continue
 		}
-		mh := c.msgHeader(msgh[:], sub)
+		mh := c.msgHeader(msgh[:], sub, c.pa.reply)
 		if c.deliverMsg(sub, mh, msg) {
 			c.Debugf("Redelivery succeeded for message on group '%q'", group)
 			return
@@ -203,7 +203,7 @@ func (c *client) reRouteQMsg(r *SublistResult, msgh, msg, group []byte) {
 	// If we are here we failed to find a local, see if we snapshotted a
 	// remote sub, and if so deliver to that.
 	if rsub != nil {
-		mh := c.msgHeader(msgh[:], rsub)
+		mh := c.msgHeader(msgh[:], rsub, c.pa.reply)
 		if c.deliverMsg(rsub, mh, msg) {
 			c.Debugf("Re-routing message on group '%q' to remote server", group)
 			return
@@ -236,7 +236,7 @@ func (c *client) processRoutedMsgResults(r *SublistResult, msg []byte) {
 		}
 		didDeliver := false
 		if sub != nil {
-			mh := c.msgHeader(msgh[:si], sub)
+			mh := c.msgHeader(msgh[:si], sub, c.pa.reply)
 			didDeliver = c.deliverMsg(sub, mh, msg)
 		}
 		if !didDeliver && c.srv != nil {
@@ -261,7 +261,7 @@ func (c *client) processRoutedMsgResults(r *SublistResult, msg []byte) {
 		sub.client.mu.Unlock()
 
 		// Normal delivery
-		mh := c.msgHeader(msgh[:si], sub)
+		mh := c.msgHeader(msgh[:si], sub, c.pa.reply)
 		c.deliverMsg(sub, mh, msg)
 	}
 }

--- a/server/route.go
+++ b/server/route.go
@@ -428,7 +428,7 @@ func (s *Server) updateRemoteRoutePerms(route *client, info *Info) {
 		_localSubs [4096]*subscription
 		localSubs  = _localSubs[:0]
 	)
-	s.sl.localSubs(&localSubs)
+	s.gsl.localSubs(&localSubs)
 
 	route.sendRouteSubProtos(localSubs, func(sub *subscription) bool {
 		subj := sub.subject

--- a/server/server.go
+++ b/server/server.go
@@ -305,7 +305,8 @@ func (s *Server) newAccountsAllowed() bool {
 	return s.opts.AllowNewAccounts
 }
 
-func (s *Server) LookupOrRegisterAccount(name string) (*Account, bool) {
+// LookupOrRegisterAccount will return the given account if known or create a new entry.
+func (s *Server) LookupOrRegisterAccount(name string) (account *Account, isNew bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if acc, ok := s.accounts[name]; ok {
@@ -835,7 +836,6 @@ func (s *Server) copyInfo() Info {
 
 func (s *Server) createClient(conn net.Conn) *client {
 	// Snapshot server options.
-	// TODO(dlc) - This can get expensive.
 	opts := s.getOpts()
 
 	max_pay := int64(opts.MaxPayload)

--- a/server/server.go
+++ b/server/server.go
@@ -835,6 +835,7 @@ func (s *Server) copyInfo() Info {
 
 func (s *Server) createClient(conn net.Conn) *client {
 	// Snapshot server options.
+	// TODO(dlc) - This can get expensive.
 	opts := s.getOpts()
 
 	max_pay := int64(opts.MaxPayload)

--- a/server/split_test.go
+++ b/server/split_test.go
@@ -24,8 +24,8 @@ func TestSplitBufferSubOp(t *testing.T) {
 	defer cli.Close()
 	defer trash.Close()
 
-	s := &Server{sl: NewSublist()}
-	c := &client{srv: s, subs: make(map[string]*subscription), nc: cli}
+	s := &Server{gsl: NewSublist()}
+	c := &client{srv: s, sl: s.gsl, subs: make(map[string]*subscription), nc: cli}
 
 	subop := []byte("SUB foo 1\r\n")
 	subop1 := subop[:6]
@@ -43,7 +43,7 @@ func TestSplitBufferSubOp(t *testing.T) {
 	if c.state != OP_START {
 		t.Fatalf("Expected OP_START state vs %d\n", c.state)
 	}
-	r := s.sl.Match("foo")
+	r := s.gsl.Match("foo")
 	if r == nil || len(r.psubs) != 1 {
 		t.Fatalf("Did not match subscription properly: %+v\n", r)
 	}
@@ -60,7 +60,7 @@ func TestSplitBufferSubOp(t *testing.T) {
 }
 
 func TestSplitBufferUnsubOp(t *testing.T) {
-	s := &Server{sl: NewSublist()}
+	s := &Server{gsl: NewSublist()}
 	c := &client{srv: s, subs: make(map[string]*subscription)}
 
 	subop := []byte("SUB foo 1024\r\n")
@@ -87,7 +87,7 @@ func TestSplitBufferUnsubOp(t *testing.T) {
 	if c.state != OP_START {
 		t.Fatalf("Expected OP_START state vs %d\n", c.state)
 	}
-	r := s.sl.Match("foo")
+	r := s.gsl.Match("foo")
 	if r != nil && len(r.psubs) != 0 {
 		t.Fatalf("Should be no subscriptions in results: %+v\n", r)
 	}
@@ -300,7 +300,7 @@ func TestSplitConnectArg(t *testing.T) {
 
 func TestSplitDanglingArgBuf(t *testing.T) {
 	s := New(&defaultServerOptions)
-	c := &client{srv: s, subs: make(map[string]*subscription)}
+	c := &client{srv: s, sl: s.gsl, subs: make(map[string]*subscription)}
 
 	// We test to make sure we do not dangle any argBufs after processing
 	// since that could lead to performance issues.

--- a/server/sublist_test.go
+++ b/server/sublist_test.go
@@ -23,8 +23,6 @@ import (
 	"testing"
 	"time"
 
-	dbg "runtime/debug"
-
 	"github.com/nats-io/nuid"
 )
 
@@ -421,8 +419,8 @@ func TestSublistBasicQueueResults(t *testing.T) {
 }
 
 func checkBool(b, expected bool, t *testing.T) {
+	t.Helper()
 	if b != expected {
-		dbg.PrintStack()
 		t.Fatalf("Expected %v, but got %v\n", expected, b)
 	}
 }


### PR DESCRIPTION
This PR introduces accounts and account isolation. Users are assigned to one account per connection and that defines their subject space.

We also introduce streams and services. These are ways to share messages across accounts with the proper permissions. Streams are pub/sub and Services are usually req/reply semantics. 

We allow explicit permissions to services to also generate implicit permissions in realtime for one time use responses.

We also have support for configuration parsing.
 
/cc @nats-io/core
