### PR TITLE
Support for global/reserved accounts

### DIFF
--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -1008,13 +1008,11 @@ func TestAccountGlobalDefault(t *testing.T) {
 	opts := defaultServerOptions
 	s := New(&opts)
 
-	acc := s.LookupAccount(globalAccountName)
-	if acc == nil {
+	if acc := s.LookupAccount(globalAccountName); acc == nil {
 		t.Fatalf("Expected a global default account on a new server, got none.")
 	}
 	// Make sure we can not create one with same name..
-	_, err := s.RegisterAccount(globalAccountName)
-	if err == nil {
+	if _, err := s.RegisterAccount(globalAccountName); err == nil {
 		t.Fatalf("Expected error trying to create a new reserved account")
 	}
 
@@ -1022,8 +1020,7 @@ func TestAccountGlobalDefault(t *testing.T) {
 	confFileName := createConfFile(t, []byte(`accounts { $G {} }`))
 	defer os.Remove(confFileName)
 
-	_, err = ProcessConfigFile(confFileName)
-	if err == nil {
+	if _, err := ProcessConfigFile(confFileName); err == nil {
 		t.Fatalf("Expected an error parsing config file with reserved account")
 	}
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -41,6 +41,10 @@ type ClientAuthentication interface {
 	RegisterUser(*User)
 }
 
+// For backwards compatibility, users who are not explicitly defined into an
+// account will be grouped in the default global account.
+const globalAccountName = "$G"
+
 // Accounts
 type Account struct {
 	Name     string

--- a/server/errors.go
+++ b/server/errors.go
@@ -56,6 +56,9 @@ var (
 	// ErrBadAccount represents a malformed or incorrect account.
 	ErrBadAccount = errors.New("Bad Account")
 
+	// ErrReservedAccount represents a reserved account that can not be created.
+	ErrReservedAccount = errors.New("Reserved Account")
+
 	// ErrMissingAccount is returned when an account does not exist.
 	ErrMissingAccount = errors.New("Account Missing")
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -629,7 +629,7 @@ type importService struct {
 
 // Checks if an account name is reserved.
 func isReservedAccount(name string) bool {
-	return strings.Compare(name, globalAccountName) == 0
+	return name == globalAccountName
 }
 
 // parseAccounts will parse the different accounts syntax.

--- a/server/opts.go
+++ b/server/opts.go
@@ -627,6 +627,11 @@ type importService struct {
 	to  string
 }
 
+// Checks if an account name is reserved.
+func isReservedAccount(name string) bool {
+	return strings.Compare(name, globalAccountName) == 0
+}
+
 // parseAccounts will parse the different accounts syntax.
 func parseAccounts(v interface{}, opts *Options) error {
 	var (
@@ -643,6 +648,10 @@ func parseAccounts(v interface{}, opts *Options) error {
 		m := make(map[string]struct{}, len(v.([]interface{})))
 		for _, name := range v.([]interface{}) {
 			ns := name.(string)
+			// Check for reserved names.
+			if isReservedAccount(ns) {
+				return fmt.Errorf("%q is a Reserved Account", ns)
+			}
 			if _, ok := m[ns]; ok {
 				return fmt.Errorf("Duplicate Account Entry: %s", ns)
 			}
@@ -660,6 +669,9 @@ func parseAccounts(v interface{}, opts *Options) error {
 			mv, ok := amv.(map[string]interface{})
 			if !ok {
 				return fmt.Errorf("Expected map entries for accounts")
+			}
+			if isReservedAccount(aname) {
+				return fmt.Errorf("%q is a Reserved Account", aname)
 			}
 			acc := &Account{Name: aname}
 			opts.Accounts = append(opts.Accounts, acc)

--- a/server/server.go
+++ b/server/server.go
@@ -196,6 +196,9 @@ func New(opts *Options) *Server {
 	// For tracking accounts
 	s.accounts = make(map[string]*Account)
 
+	// Create global account.
+	s.registerAccount(&Account{Name: globalAccountName, sl: s.gsl})
+
 	// For tracking clients
 	s.clients = make(map[uint64]*client)
 
@@ -300,6 +303,12 @@ func (s *Server) newAccountsAllowed() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.opts.AllowNewAccounts
+}
+
+// numReservedAccounts will return the number of reserved accounts configured in the server.
+// Currently this is 1 for the global default service.
+func (s *Server) numReservedAccounts() int {
+	return 1
 }
 
 // LookupOrRegisterAccount will return the given account if known or create a new entry.
@@ -1166,7 +1175,6 @@ func (s *Server) NumSubscriptions() uint32 {
 			subs += acc.sl.Count()
 		}
 	}
-	subs += s.gsl.Count()
 	s.mu.Unlock()
 	return subs
 }


### PR DESCRIPTION
Added a reserved account for the default global account for backwards compatibility.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
