### PR TITLE
Show all config errors and warnings on start

### DIFF
--- a/server/configs/multiple_errors.conf
+++ b/server/configs/multiple_errors.conf
@@ -1,0 +1,70 @@
+
+authorization {
+  user = foo
+  pass = bar
+  token = quux
+}
+
+http_port = 8222
+
+monitoring = 8222
+
+write_deadline = 5
+
+accounts {
+  synadia {
+    exports = [
+      { stream: "synadia.>" }
+    ]
+  
+    # Malformed nkeys
+    nkey = "OC5GRL36RQV7MJ2GT6WQSCKDKJKYTK4T2LGLWJ2SEJKRDHFOQQWGGFQL"
+
+    users [
+      {
+        # Malformed nkeys
+        nkey = "OCARKS2E3KVB7YORL2DG34XLT7PUCOL2SVM7YXV6ETHLW6Z46UUJ2VZ3"
+      }
+    ]
+  }
+
+  #
+  # + nats < synadia
+  #
+  nats {
+    # Malformed nkeys
+    nkey = "ODRZ42QBM7SXQDXXTSVWT2WLLFYOQGAFC4TO6WOAXHEKQHIXR4HFYJDS"
+
+    users [
+      {
+        # Malformed nkeys
+        nkey = "OD6AYQSOIN2IN5OGC6VQZCR4H3UFMIOXSW6NNS6N53CLJA4PB56CEJJI"
+      }
+    ]
+
+    imports = [
+      { stream: { account: "synadia", subject: "synadia.>" }, prefix: "imports.nats" }
+    ]
+  }
+
+  # + cncf < synadia
+  cncf {
+    nkey = "AD4YRVUJF2KASKPGRMNXTYKIYSCB3IHHB4Y2ME6B2PDIV5QJ23C2ZRIT"
+
+    users [
+      {
+        nkey = "UB57IEMPG4KOTPFV5A66QKE2HZ3XBXFHVRCCVMJEWKECMVN2HSH3VTSJ"
+      }
+    ]
+
+    imports = [
+      { stream: { account: "synadia", subject: "synadia.>" }, prefix: "imports.cncf" }
+    ]
+  }
+}
+
+cluster {
+  authorization {
+    users = []
+  }
+}

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -1274,7 +1274,9 @@ func TestClusterPermissionsConfig(t *testing.T) {
 	defer os.Remove(conf)
 	opts, err := ProcessConfigFile(conf)
 	if err != nil {
-		t.Fatalf("Error processing config file: %v", err)
+		if cerr, ok := err.(*processConfigErr); ok && len(cerr.Errors()) > 0 {
+			t.Fatalf("Error processing config file: %v", err)
+		}
 	}
 	if opts.Cluster.Permissions == nil {
 		t.Fatal("Expected cluster permissions to be set")


### PR DESCRIPTION
Enables support to gather all errors that may be found in the configuration file along with the source of the error for each one of them.  This also adds supports for warning error types that will still allow the server to start, but warning messages will be displayed at the beginning instead.  

### Examples

Multiple errors, warnings shown first: 

```sh
$ gnatsd -c server/nats.conf
server/nats.conf:10:1: invalid use of field "write_deadline": write_deadline should be converted to a duration
server/nats.conf:8:1: unknown field "monitoring"
server/nats.conf:20:30: Detected service "bar" but already saw a stream
server/nats.conf:24:5: Not a valid public nkey for an account: "OC5GRL36RQV7MJ2GT6WQSCKDKJKYTK4T2LGLWJ2SEJKRDHFOQQWGGFQL"
server/nats.conf:29:9: Not a valid public nkey for a user
server/nats.conf:39:5: Not a valid public nkey for an account: "ODRZ42QBM7SXQDXXTSVWT2WLLFYOQGAFC4TO6WOAXHEKQHIXR4HFYJDS"
server/nats.conf:44:9: Not a valid public nkey for a user

exit status 1
```

Can use test mode to check for warnings without starting server, if there are any it returns non-zero exit status.

```sh
$ gnatsd -c server/nats.conf -t
server/nats.conf:4:1: invalid use of field "write_deadline": write_deadline should be converted to a duration

exit status 1
```

No errors or warnings using test mode then is still zero exit:

```
configuration file server/nats.conf test is successful
```

Without test mode, collection of warnings are shown at the beginning:

```sh
$ gnatsd -c server/nats.conf
server/nats.conf:4:1: invalid use of field "write_deadline": write_deadline should be converted to a duration
[10857] 2018/10/08 02:53:16.442791 [INF] Starting nats-server version 1.3.1
[10857] 2018/10/08 02:53:16.442867 [INF] Git commit [not set]
[10857] 2018/10/08 02:53:16.443053 [INF] Starting http monitor on 0.0.0.0:8222
[10857] 2018/10/08 02:53:16.443106 [INF] Listening for client connections on 0.0.0.0:4222
[10857] 2018/10/08 02:53:16.443110 [INF] Server is ready

```

 - [X] Link to issue, e.g. `Resolves #NNN`
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [x] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

/cc @nats-io/core 
