### PR TITLE
Allow conf vars within account block

### DIFF
--- a/server/config_check_test.go
+++ b/server/config_check_test.go
@@ -646,11 +646,65 @@ func TestConfigCheck(t *testing.T) {
 
 		accounts {
                   foo = "bar"
-		}
-				`,
+		}`,
 			err:       errors.New(`Expected map entries for accounts`),
 			errorLine: 5,
 			errorPos:  19,
+		},
+		{
+			name: "when accounts has a referenced config variable within same block",
+			config: `
+			  accounts {
+			    PERMISSIONS = {
+				publish = {
+				  allow = ["foo","bar"]
+				  deny = ["quux"]
+				}
+			    }
+
+			    synadia {
+				nkey = "AC5GRL36RQV7MJ2GT6WQSCKDKJKYTK4T2LGLWJ2SEJKRDHFOQQWGGFQL"
+
+				users [
+				  {
+				    nkey = "UCARKS2E3KVB7YORL2DG34XLT7PUCOL2SVM7YXV6ETHLW6Z46UUJ2VZ3"
+				    permissions = $PERMISSIONS
+				  }
+				]
+				exports = [
+				  { stream: "synadia.>" }
+				]
+			    }
+			  }`,
+			err: nil,
+		},
+		{
+			name: "when accounts has an unreferenced config variables within same block",
+			config: `
+			  accounts {
+			    PERMISSIONS = {
+				publish = {
+				  allow = ["foo","bar"]
+				  deny = ["quux"]
+				}
+			    }
+
+			    synadia {
+				nkey = "AC5GRL36RQV7MJ2GT6WQSCKDKJKYTK4T2LGLWJ2SEJKRDHFOQQWGGFQL"
+
+				users [
+				  {
+				    nkey = "UCARKS2E3KVB7YORL2DG34XLT7PUCOL2SVM7YXV6ETHLW6Z46UUJ2VZ3"
+				  }
+				]
+				exports = [
+				  { stream: "synadia.>" }
+				]
+			   }
+			 }`,
+			err:       errors.New(`unknown field "publish"`),
+			errorLine: 4,
+			errorPos:  5,
 		},
 		{
 			name: "when accounts block defines a global account",

--- a/server/opts.go
+++ b/server/opts.go
@@ -662,6 +662,12 @@ func parseAccounts(v interface{}, opts *Options, errors *[]error, warnings *[]er
 		uorn := make(map[string]struct{})
 		for aname, mv := range vv {
 			tk, amv := unwrapValue(mv)
+
+			// Skip referenced config vars within the account block.
+			if tk.IsUsedVariable() {
+				continue
+			}
+
 			// These should be maps.
 			mv, ok := amv.(map[string]interface{})
 			if !ok {


### PR DESCRIPTION
 - [x] Link to issue, e.g. `Resolves #NNN`
 - [x] Documentation added (if applicable)
 - [x] Tests added
 - [x] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

/cc @nats-io/core

Signed-off-by: Waldemar Quevedo <wally@synadia.com>