### PR TITLE
Fixed data race with client trace flag

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1209,8 +1209,8 @@ func (c *client) processPong() {
 	c.mu.Unlock()
 }
 
-func (c *client) processPub(arg []byte) error {
-	if c.trace {
+func (c *client) processPub(trace bool, arg []byte) error {
+	if trace {
 		c.traceInOp("PUB", arg)
 	}
 

--- a/server/parser.go
+++ b/server/parser.go
@@ -201,7 +201,7 @@ func (c *client) parse(buf []byte) error {
 				} else {
 					arg = buf[c.as : i-c.drop]
 				}
-				if err := c.processPub(arg); err != nil {
+				if err := c.processPub(c.trace, arg); err != nil {
 					return err
 				}
 				c.drop, c.as, c.state = OP_START, i+1, MSG_PAYLOAD
@@ -642,7 +642,7 @@ func (c *client) parse(buf []byte) error {
 				} else {
 					arg = buf[c.as : i-c.drop]
 				}
-				if err := c.processRoutedMsgArgs(arg); err != nil {
+				if err := c.processRoutedMsgArgs(c.trace, arg); err != nil {
 					return err
 				}
 				c.drop, c.as, c.state = 0, i+1, MSG_PAYLOAD
@@ -866,13 +866,10 @@ func (c *client) clonePubArg() {
 	c.argBuf = c.scratch[:0]
 	c.argBuf = append(c.argBuf, c.pa.arg...)
 
-	trace := c.trace
-	c.trace = false
 	// This is a routed msg
 	if c.pa.account != nil {
-		c.processRoutedMsgArgs(c.argBuf)
+		c.processRoutedMsgArgs(false, c.argBuf)
 	} else {
-		c.processPub(c.argBuf)
+		c.processPub(false, c.argBuf)
 	}
-	c.trace = trace
 }

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -288,7 +288,7 @@ func TestParsePubArg(t *testing.T) {
 			subject: "foo", reply: "", size: 2222, szb: "2222"},
 	} {
 		t.Run(test.arg, func(t *testing.T) {
-			if err := c.processPub([]byte(test.arg)); err != nil {
+			if err := c.processPub(false, []byte(test.arg)); err != nil {
 				t.Fatalf("Unexpected parse error: %v\n", err)
 			}
 			if !bytes.Equal(c.pa.subject, []byte(test.subject)) {
@@ -311,7 +311,7 @@ func TestParsePubBadSize(t *testing.T) {
 	c := dummyClient()
 	// Setup localized max payload
 	c.mpay = 32768
-	if err := c.processPub([]byte("foo 2222222222222222")); err == nil {
+	if err := c.processPub(false, []byte("foo 2222222222222222")); err == nil {
 		t.Fatalf("Expected parse error for size too large")
 	}
 }

--- a/server/route.go
+++ b/server/route.go
@@ -143,8 +143,8 @@ func (c *client) processAccountUnsub(arg []byte) {
 }
 
 // Process an inbound RMSG specification from the remote route.
-func (c *client) processRoutedMsgArgs(arg []byte) error {
-	if c.trace {
+func (c *client) processRoutedMsgArgs(trace bool, arg []byte) error {
+	if trace {
 		c.traceInOp("RMSG", arg)
 	}
 


### PR DESCRIPTION
This was introduced with https://github.com/nats-io/gnatsd/commit/ec3115ad210cbf8ad0fa1dc722db8975181bec67

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
