### PR TITLE
Single Server Limits

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -362,7 +362,7 @@ func (c *client) initClient() {
 }
 
 // Helper function to report errors.
-func (c *client) reporteErrRegisterAccount(acc *Account, err error) {
+func (c *client) reportErrRegisterAccount(acc *Account, err error) {
 	if err == ErrTooManyAccountConnections {
 		c.maxAccountConnExceeded()
 		return
@@ -446,7 +446,7 @@ func (c *client) RegisterUser(user *User) {
 	// Register with proper account and sublist.
 	if user.Account != nil {
 		if err := c.registerWithAccount(user.Account); err != nil {
-			c.reporteErrRegisterAccount(user.Account, err)
+			c.reportErrRegisterAccount(user.Account, err)
 			return
 		}
 	}
@@ -472,7 +472,7 @@ func (c *client) RegisterNkeyUser(user *NkeyUser) {
 	// Register with proper account and sublist.
 	if user.Account != nil {
 		if err := c.registerWithAccount(user.Account); err != nil {
-			c.reporteErrRegisterAccount(user.Account, err)
+			c.reportErrRegisterAccount(user.Account, err)
 			return
 		}
 	}
@@ -1010,7 +1010,7 @@ func (c *client) processConnect(arg []byte) error {
 			}
 			// If we are here we can register ourselves with the new account.
 			if err := c.registerWithAccount(acc); err != nil {
-				c.reporteErrRegisterAccount(acc, err)
+				c.reportErrRegisterAccount(acc, err)
 				return ErrBadAccount
 			}
 		} else if c.acc == nil {

--- a/server/client.go
+++ b/server/client.go
@@ -124,9 +124,11 @@ const (
 	ProtocolViolation
 	BadClientProtocolVersion
 	WrongPort
+	MaxAccountConnectionsExceeded
 	MaxConnectionsExceeded
 	MaxPayloadExceeded
 	MaxControlLineExceeded
+	MaxSubscriptionsExceeded
 	DuplicateRoute
 	RouteRemoved
 	ServerShutdown
@@ -136,7 +138,7 @@ const (
 type client struct {
 	// Here first because of use of atomics, and memory alignment.
 	stats
-	mpay   int64
+	mpay   int32
 	msubs  int
 	mu     sync.Mutex
 	typ    int
@@ -359,6 +361,16 @@ func (c *client) initClient() {
 	}
 }
 
+// Helper function to report errors.
+func (c *client) reporteErrRegisterAccount(acc *Account, err error) {
+	if err == ErrTooManyAccountConnections {
+		c.maxAccountConnExceeded()
+		return
+	}
+	c.Errorf("Problem registering with account [%s]", acc.Name)
+	c.sendErr("Failed Account Registration")
+}
+
 // RegisterWithAccount will register the given user with a specific
 // account. This will change the subject namespace.
 func (c *client) registerWithAccount(acc *Account) error {
@@ -371,14 +383,60 @@ func (c *client) registerWithAccount(acc *Account) error {
 			c.srv.decActiveAccounts()
 		}
 	}
+	// Check if we have a max connections violation
+	if acc.MaxClientsReached() {
+		return ErrTooManyAccountConnections
+	}
+
 	// Add in new one.
 	if prev := acc.addClient(c); prev == 0 && c.srv != nil {
 		c.srv.incActiveAccounts()
 	}
+
 	c.mu.Lock()
 	c.acc = acc
+	c.applyAccountLimits()
 	c.mu.Unlock()
+
 	return nil
+}
+
+// Apply account limits
+// Lock is held on entry.
+// FIXME(dlc) - Should server be able to override here?
+func (c *client) applyAccountLimits() {
+	if c.acc == nil {
+		return
+	}
+	// Set here, check for more details below. Only set if non-zero.
+	if c.acc.msubs > 0 {
+		c.msubs = c.acc.msubs
+	}
+	if c.acc.mpay > 0 {
+		c.mpay = c.acc.mpay
+	}
+
+	opts := c.srv.getOpts()
+
+	// We check here if the server has an option set that is lower than the account limit.
+	if c.mpay != 0 && opts.MaxPayload != 0 && int32(opts.MaxPayload) < c.acc.mpay {
+		c.Errorf("Max Payload set to %d from server config which overrides %d from account claims", opts.MaxPayload, c.acc.mpay)
+		c.mpay = int32(opts.MaxPayload)
+	}
+
+	// We check here if the server has an option set that is lower than the account limit.
+	if c.msubs != 0 && opts.MaxSubs != 0 && opts.MaxSubs < c.acc.msubs {
+		c.Errorf("Max Subscriptions set to %d from server config which overrides %d from account claims", opts.MaxSubs, c.acc.msubs)
+		c.msubs = opts.MaxSubs
+	}
+
+	if c.msubs > 0 && len(c.subs) > c.msubs {
+		go func() {
+			c.maxSubsExceeded()
+			time.Sleep(20 * time.Millisecond)
+			c.closeConnection(MaxSubscriptionsExceeded)
+		}()
+	}
 }
 
 // RegisterUser allows auth to call back into a new client
@@ -388,8 +446,7 @@ func (c *client) RegisterUser(user *User) {
 	// Register with proper account and sublist.
 	if user.Account != nil {
 		if err := c.registerWithAccount(user.Account); err != nil {
-			c.Errorf("Problem registering with account [%s]", user.Account.Name)
-			c.sendErr("Failed Account Registration")
+			c.reporteErrRegisterAccount(user.Account, err)
 			return
 		}
 	}
@@ -415,8 +472,7 @@ func (c *client) RegisterNkeyUser(user *NkeyUser) {
 	// Register with proper account and sublist.
 	if user.Account != nil {
 		if err := c.registerWithAccount(user.Account); err != nil {
-			c.Errorf("Problem registering with account [%s]", user.Account.Name)
-			c.sendErr("Failed Account Registration")
+			c.reporteErrRegisterAccount(user.Account, err)
 			return
 		}
 	}
@@ -954,8 +1010,7 @@ func (c *client) processConnect(arg []byte) error {
 			}
 			// If we are here we can register ourselves with the new account.
 			if err := c.registerWithAccount(acc); err != nil {
-				c.Errorf("Problem registering with account [%s]", account)
-				c.sendErr("Failed Account Registration")
+				c.reporteErrRegisterAccount(acc, err)
 				return ErrBadAccount
 			}
 		} else if c.acc == nil {
@@ -1047,6 +1102,11 @@ func (c *client) authViolation() {
 	c.closeConnection(AuthenticationViolation)
 }
 
+func (c *client) maxAccountConnExceeded() {
+	c.sendErrAndErr(ErrTooManyAccountConnections.Error())
+	c.closeConnection(MaxAccountConnectionsExceeded)
+}
+
 func (c *client) maxConnExceeded() {
 	c.sendErrAndErr(ErrTooManyConnections.Error())
 	c.closeConnection(MaxConnectionsExceeded)
@@ -1056,7 +1116,7 @@ func (c *client) maxSubsExceeded() {
 	c.sendErrAndErr(ErrTooManySubs.Error())
 }
 
-func (c *client) maxPayloadViolation(sz int, max int64) {
+func (c *client) maxPayloadViolation(sz int, max int32) {
 	c.Errorf("%s: %d vs %d", ErrMaxPayload.Error(), sz, max)
 	c.sendErr("Maximum Payload Violation")
 	c.closeConnection(MaxPayloadExceeded)
@@ -1304,8 +1364,8 @@ func (c *client) processPub(trace bool, arg []byte) error {
 	if c.pa.size < 0 {
 		return fmt.Errorf("processPub Bad or Missing Size: '%s'", arg)
 	}
-	maxPayload := atomic.LoadInt64(&c.mpay)
-	if maxPayload > 0 && int64(c.pa.size) > maxPayload {
+	maxPayload := atomic.LoadInt32(&c.mpay)
+	if maxPayload > 0 && int32(c.pa.size) > maxPayload {
 		c.maxPayloadViolation(c.pa.size, maxPayload)
 		return ErrMaxPayload
 	}

--- a/server/errors.go
+++ b/server/errors.go
@@ -47,6 +47,10 @@ var (
 	// server has been reached.
 	ErrTooManyConnections = errors.New("Maximum Connections Exceeded")
 
+	// ErrTooManyAccountConnections signals that an acount has reached its maximum number of active
+	// connections.
+	ErrTooManyAccountConnections = errors.New("Maximum Account Active Connections Exceeded")
+
 	// ErrTooManySubs signals a client that the maximum number of subscriptions per connection
 	// has been reached.
 	ErrTooManySubs = errors.New("Maximum Subscriptions Exceeded")

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1029,10 +1029,14 @@ func (reason ClosedState) String() string {
 		return "Incorrect Port"
 	case MaxConnectionsExceeded:
 		return "Maximum Connections Exceeded"
+	case MaxAccountConnectionsExceeded:
+		return "Maximum Account Connections Exceeded"
 	case MaxPayloadExceeded:
 		return "Maximum Message Payload Exceeded"
 	case MaxControlLineExceeded:
 		return "Maximum Control Line Exceeded"
+	case MaxSubscriptionsExceeded:
+		return "Maximum Subscriptions Exceeded"
 	case DuplicateRoute:
 		return "Duplicate Route"
 	case RouteRemoved:

--- a/server/reload.go
+++ b/server/reload.go
@@ -412,7 +412,7 @@ func (m *maxPayloadOption) Apply(server *Server) {
 	server.mu.Lock()
 	server.info.MaxPayload = m.newValue
 	for _, client := range server.clients {
-		atomic.StoreInt64(&client.mpay, int64(m.newValue))
+		atomic.StoreInt32(&client.mpay, int32(m.newValue))
 	}
 	server.mu.Unlock()
 	server.Noticef("Reloaded: max_payload = %d", m.newValue)

--- a/server/server.go
+++ b/server/server.go
@@ -489,15 +489,6 @@ func (s *Server) LookupAccount(name string) *Account {
 	return s.fetchAccount(name)
 }
 
-/*
-// UpdateAccount will fetch new claims and if found update the account.
-func (s *Server) UpdateAccount(acc *Account) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.updateAccount(acc)
-}
-*/
-
 // This will fetch new claims and if found update the account with new claims.
 // Lock should be held upon entry.
 func (s *Server) updateAccount(acc *Account) bool {
@@ -1073,7 +1064,7 @@ func (s *Server) createClient(conn net.Conn) *client {
 	// Snapshot server options.
 	opts := s.getOpts()
 
-	maxPay := int64(opts.MaxPayload)
+	maxPay := int32(opts.MaxPayload)
 	maxSubs := opts.MaxSubs
 	now := time.Now()
 


### PR DESCRIPTION
Implemented single server account claim limits for subscriptions and active connections and message payload size.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
