### PR TITLE
Fixed issue with gateways

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -2069,7 +2069,7 @@ func (c *client) processInboundClientMsg(msg []byte) {
 		// mode and the remote gateways have queue subs, then we need to
 		// collect the queue groups this message was sent to so that we
 		// exclude them when sending to gateways.
-		if len(r.qsubs) > 0 && c.srv.gateway.enabled && c.srv.gatewaysHaveQSubs() {
+		if len(r.qsubs) > 0 && c.srv.gateway.enabled && atomic.LoadInt64(&c.srv.gateway.totalQSubs) > 0 {
 			qnames = &queues
 		}
 		c.processMsgResults(c.acc, r, msg, c.pa.subject, c.pa.reply, qnames)

--- a/server/opts.go
+++ b/server/opts.go
@@ -65,7 +65,8 @@ type GatewayOpts struct {
 	RejectUnknown      bool                 `json:"reject_unknown,omitempty"`
 
 	// Not exported, for tests.
-	resolver netResolver
+	resolver         netResolver
+	sendQSubsBufSize int
 }
 
 // RemoteGatewayOpts are options for connecting to a remote gateway


### PR DESCRIPTION
- If/when splitting buffer to pass to queueOutbound(), it has to
  be include full protocol.
- Fix counting of total queue subs
- Fix tests
- Send RS- if no plain sub interest even if there is queue sub
  interest.
- Removed a one-liner function

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

/cc @nats-io/core
