### PR TITLE
Allow servers to send system events.

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -155,7 +155,9 @@ func (a *Account) TotalSubs() int {
 func (a *Account) addClient(c *client) int {
 	a.mu.Lock()
 	n := len(a.clients)
-	a.clients[c] = c
+	if a.clients != nil {
+		a.clients[c] = c
+	}
 	a.mu.Unlock()
 	if c != nil && c.srv != nil && a != c.srv.gacc {
 		c.srv.accConnsUpdate(a)

--- a/server/accounts.go
+++ b/server/accounts.go
@@ -40,18 +40,21 @@ type rme struct {
 // Account are subject namespace definitions. By default no messages are shared between accounts.
 // You can share via exports and imports of streams and services.
 type Account struct {
-	Name     string
-	Nkey     string
-	Issuer   string
-	claimJWT string
-	updated  time.Time
-	mu       sync.RWMutex
-	sl       *Sublist
-	etmr     *time.Timer
-	clients  map[*client]*client
-	rm       map[string]*rme
-	imports  importMap
-	exports  exportMap
+	Name      string
+	Nkey      string
+	Issuer    string
+	claimJWT  string
+	updated   time.Time
+	mu        sync.RWMutex
+	sl        *Sublist
+	etmr      *time.Timer
+	ctmr      *time.Timer
+	strack    map[string]int
+	nrclients int
+	clients   map[*client]*client
+	rm        map[string]*rme
+	imports   importMap
+	exports   exportMap
 	limits
 	nae     int
 	pruning bool
@@ -106,19 +109,28 @@ type exportMap struct {
 	services map[string]*exportAuth
 }
 
-// NumClients returns active number of clients for this account.
+// NumClients returns active number of clients for this account for
+// all known servers.
 func (a *Account) NumClients() int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return len(a.clients) + a.nrclients
+}
+
+// NumLocalClients returns active number of clients for this account
+// on this server.
+func (a *Account) NumLocalClients() int {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return len(a.clients)
 }
 
 // MaxClientsReached returns if we have reached our limit for number of connections.
-func (a *Account) MaxClientsReached() bool {
+func (a *Account) MaxTotalClientsReached() bool {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	if a.mconns != 0 {
-		return len(a.clients) >= a.mconns
+		return len(a.clients)+a.nrclients >= a.mconns
 	}
 	return false
 }
@@ -138,23 +150,37 @@ func (a *Account) TotalSubs() int {
 	return int(a.sl.Count())
 }
 
-// addClient keeps our accounting of active clients updated.
+// addClient keeps our accounting of local active clients updated.
 // Returns previous total.
 func (a *Account) addClient(c *client) int {
 	a.mu.Lock()
 	n := len(a.clients)
 	a.clients[c] = c
 	a.mu.Unlock()
+	if c != nil && c.srv != nil && a != c.srv.gacc {
+		c.srv.accConnsUpdate(a)
+	}
 	return n
 }
 
-// removeClient keeps our accounting of active clients updated.
+// removeClient keeps our accounting of local active clients updated.
 func (a *Account) removeClient(c *client) int {
 	a.mu.Lock()
 	n := len(a.clients)
 	delete(a.clients, c)
 	a.mu.Unlock()
+	if c != nil && c.srv != nil && a != c.srv.gacc {
+		c.srv.accConnsUpdate(a)
+	}
 	return n
+}
+
+func (a *Account) randomClient() *client {
+	var c *client
+	for _, c = range a.clients {
+		break
+	}
+	return c
 }
 
 // AddServiceExport will configure the account with the defined export.

--- a/server/events.go
+++ b/server/events.go
@@ -304,6 +304,7 @@ func (s *Server) remoteServerShutdown(sub *subscription, subject, reply string, 
 	toks := strings.Split(subject, tsep)
 	if len(toks) < shutdownEventTokens {
 		s.Debugf("Received remote server shutdown on bad subject %q", subject)
+		return
 	}
 	sid := toks[serverSubjectIndex]
 	su := s.sys.servers[sid]

--- a/server/events.go
+++ b/server/events.go
@@ -17,13 +17,35 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
 const (
-	connectEventSubj    = "$SYS.%s.CLIENT.CONNECT"
-	disconnectEventSubj = "$SYS.%s.CLIENT.DISCONNECT"
+	connectEventSubj    = "$SYS.ACCOUNT.%s.CONNECT"
+	disconnectEventSubj = "$SYS.ACCOUNT.%s.DISCONNECT"
+	accConnsEventSubj   = "$SYS.SERVER.ACCOUNT.%s.CONNS"
+	accConnsReqSubj     = "$SYS.REQ.ACCOUNT.%s.CONNS"
+	connsRespSubj       = "$SYS._INBOX_.%s"
+	shutdownEventSubj   = "$SYS.SERVER.%s.SHUTDOWN"
+	shutdownEventTokens = 4
+	serverSubjectIndex  = 2
 )
+
+// Used to send and receive messages from inside the server.
+type internal struct {
+	account *Account
+	client  *client
+	seq     uint64
+	sid     uint64
+	servers map[string]*serverUpdate
+	sweeper *time.Timer
+	subs    map[string]msgHandler
+	sendq   chan *pubMsg
+	wg      sync.WaitGroup
+}
 
 // ConnectEventMsg is sent when a new connection is made that is part of an account.
 type ConnectEventMsg struct {
@@ -39,6 +61,22 @@ type DisconnectEventMsg struct {
 	Sent     DataStats  `json:"sent"`
 	Received DataStats  `json:"received"`
 	Reason   string     `json:"reason"`
+}
+
+// accNumConns is an event that will be sent from a server that is tracking
+// a given account when the number of connections changes. It will also HB
+// updates in the absence of any changes.
+type accNumConns struct {
+	Server  ServerInfo `json:"server"`
+	Account string     `json:"acc"`
+	Conns   int        `json:"conns"`
+}
+
+// accNumConnsReq is sent when we are starting to track an account for the first
+// time. We will request others send info to us about their local state.
+type accNumConnsReq struct {
+	Server  ServerInfo `json:"server"`
+	Account string     `json:"acc"`
 }
 
 type ServerInfo struct {
@@ -68,30 +106,52 @@ type DataStats struct {
 
 // Used for internally queueing up messages that the server wants to send.
 type pubMsg struct {
-	r   *SublistResult
-	sub string
-	si  *ServerInfo
-	msg interface{}
+	r    *SublistResult
+	sub  string
+	rply string
+	si   *ServerInfo
+	msg  interface{}
+	last bool
 }
 
-func (s *Server) internalSendLoop() {
-	defer s.grWG.Done()
+// Used to track server updates.
+type serverUpdate struct {
+	seq   uint64
+	ltime time.Time
+}
+
+// internalSendLoop will be responsible for serializing all messages that
+// a server wants to send.
+func (s *Server) internalSendLoop(wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	s.mu.Lock()
-	if s.sys == nil {
+	if s.sys == nil || s.sys.sendq == nil {
 		s.mu.Unlock()
 		return
 	}
 	c := s.sys.client
 	acc := s.sys.account
 	sendq := s.sys.sendq
+	id := s.info.ID
+	host := s.info.Host
+	seqp := &s.sys.seq
 	s.mu.Unlock()
 
-	for s.isRunning() {
+	for s.eventsRunning() {
+		// Setup information for next message
+		seq := atomic.AddUint64(seqp, 1)
 		select {
 		case pm := <-sendq:
-			s.stampServerInfo(pm.si)
-			b, _ := json.MarshalIndent(pm.msg, "", "  ")
-
+			if pm.si != nil {
+				pm.si.Host = host
+				pm.si.ID = id
+				pm.si.Seq = seq
+			}
+			var b []byte
+			if pm.msg != nil {
+				b, _ = json.MarshalIndent(pm.msg, _EMPTY_, "  ")
+			}
 			// Prep internal structures needed to send message.
 			c.pa.subject = []byte(pm.sub)
 			c.pa.size = len(b)
@@ -102,32 +162,356 @@ func (s *Server) internalSendLoop() {
 			if acc.imports.services != nil {
 				c.checkForImportServices(acc, b)
 			}
-			c.processMsgResults(acc, pm.r, b, []byte(pm.sub), nil, nil)
+			c.processMsgResults(acc, pm.r, b, c.pa.subject, []byte(pm.rply), nil)
 			c.flushClients()
+			// See if we are doing graceful shutdown.
+			if pm.last {
+				return
+			}
 		case <-s.quitCh:
 			return
 		}
 	}
 }
 
-// This will queue up a message to be sent.
-func (s *Server) sendInternalMsg(r *SublistResult, sub string, si *ServerInfo, msg interface{}) {
-	if s.sys == nil {
+// Will send a shutdown message.
+func (s *Server) sendShutdownEvent() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sys == nil || s.sys.sendq == nil {
 		return
 	}
-	s.sys.sendq <- &pubMsg{r, sub, si, msg}
+	subj := fmt.Sprintf(shutdownEventSubj, s.info.ID)
+	r := s.sys.account.sl.Match(subj)
+	sendq := s.sys.sendq
+	// Stop any more messages from queueing up.
+	s.sys.sendq = nil
+	// Unhook all msgHandlers. Normal client cleanup will deal with subs, etc.
+	s.sys.subs = nil
+	// Send to the internal queue and mark as last.
+	sendq <- &pubMsg{r, subj, _EMPTY_, nil, nil, true}
 }
 
-// accountConnectEvent will send an account client connect event if there is interest.
-func (s *Server) accountConnectEvent(c *client) {
-	if s.sys == nil || s.sys.client == nil || s.sys.account == nil {
+// This will queue up a message to be sent.
+func (s *Server) sendInternalMsg(r *SublistResult, sub, rply string, si *ServerInfo, msg interface{}) {
+	if s.sys == nil || s.sys.sendq == nil {
+		return
+	}
+	s.sys.sendq <- &pubMsg{r, sub, rply, si, msg, false}
+}
+
+// Locked version of checking if events system running. Also checks server.
+func (s *Server) eventsRunning() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.running && s.eventsEnabled()
+}
+
+func (s *Server) eventsEnabled() bool {
+	return s.sys != nil && s.sys.client != nil && s.sys.account != nil
+}
+
+// orphanServerDuration is how long we have to not hear from a remote server
+// top consider it orphaned. We will remove any accounting associated with it.
+var orphanServerDuration = 5 * connHBInterval
+var checkRemoteServerInterval = 3 * connHBInterval
+
+// Check for orphan servers who may have gone away without notification.
+func (s *Server) checkRemoteServers() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.eventsEnabled() {
+		return
+	}
+	now := time.Now()
+	for sid, su := range s.sys.servers {
+		if now.Sub(su.ltime) > orphanServerDuration {
+			s.Debugf("Detected orphan remote server: %q", sid)
+			// Simulate it going away.
+			s.processRemoteServerShutdown(sid)
+			delete(s.sys.servers, sid)
+		}
+	}
+	s.sys.sweeper.Reset(checkRemoteServerInterval)
+}
+
+// Start a ticker that will fire periodically and check for orphaned servers.
+func (s *Server) startRemoteServerSweepTimer() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.eventsEnabled() {
+		return
+	}
+	s.sys.sweeper = time.AfterFunc(checkRemoteServerInterval, s.checkRemoteServers)
+}
+
+// This will setup our system wide tracking subs.
+// For now we will setup one wildcard subscription to
+// monitor all accounts for changes in number of connections.
+// We can make this on a per account tracking basis if needed.
+// Tradeoff is subscription and interest graph events vs connect and
+// disconnect events, etc.
+func (s *Server) initEventTracking() {
+	if !s.eventsEnabled() {
+		return
+	}
+	subject := fmt.Sprintf(accConnsEventSubj, "*")
+	if _, err := s.sysSubscribe(subject, s.remoteConnsUpdate); err != nil {
+		s.Errorf("Error setting up internal tracking: %v", err)
+	}
+	// This will be for responses for account info that we send out.
+	subject = fmt.Sprintf(connsRespSubj, s.info.ID)
+	if _, err := s.sysSubscribe(subject, s.remoteConnsUpdate); err != nil {
+		s.Errorf("Error setting up internal tracking: %v", err)
+	}
+	// Listen for broad requests to respond with account info.
+	subject = fmt.Sprintf(accConnsReqSubj, "*")
+	if _, err := s.sysSubscribe(subject, s.connsRequest); err != nil {
+		s.Errorf("Error setting up internal tracking: %v", err)
+	}
+	// Listen for all server shutdowns.
+	subject = fmt.Sprintf(shutdownEventSubj, "*")
+	if _, err := s.sysSubscribe(subject, s.remoteServerShutdown); err != nil {
+		s.Errorf("Error setting up internal tracking: %v", err)
+	}
+}
+
+// processRemoteServerShutdown will update any affected accounts.
+// Will upidate the remote count for clients.
+// Lock assume held.
+func (s *Server) processRemoteServerShutdown(sid string) {
+	for _, a := range s.accounts {
+		a.mu.Lock()
+		prev := a.strack[sid]
+		delete(a.strack, sid)
+		a.nrclients -= prev
+		a.mu.Unlock()
+	}
+}
+
+// serverShutdownEvent is called when we get an event from another server shutting down.
+func (s *Server) remoteServerShutdown(sub *subscription, subject, reply string, msg []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.eventsEnabled() {
+		return
+	}
+	toks := strings.Split(subject, tsep)
+	if len(toks) != shutdownEventTokens {
+		s.Debugf("Received remote server shutdown on bad subject %q", subject)
+	}
+	sid := toks[serverSubjectIndex]
+	su := s.sys.servers[sid]
+	if su != nil {
+		s.processRemoteServerShutdown(sid)
+	}
+}
+
+// updateRemoteServer is called when we have an update from a remote server.
+// This allows us to track remote servers, respond to shutdown messages properly,
+// make sure that messages are ordered, and allow us to prune dead servers.
+// Lock should be held upon entry.
+func (s *Server) updateRemoteServer(ms *ServerInfo) {
+	su := s.sys.servers[ms.ID]
+	if su == nil {
+		s.sys.servers[ms.ID] = &serverUpdate{ms.Seq, time.Now()}
+	} else {
+		if ms.Seq <= su.seq {
+			s.Errorf("Received out of order remote server update from: %q", ms.ID)
+			return
+		}
+		if ms.Seq != su.seq+1 {
+			s.Errorf("Missed [%d] remote server updates from: %q", ms.Seq-su.seq+1, ms.ID)
+		}
+		su.seq = ms.Seq
+		su.ltime = time.Now()
+	}
+}
+
+// shutdownEventing will clean up all eventing state.
+// Lock is held upon entry.
+func (s *Server) shutdownEventing() {
+	if !s.eventsRunning() {
+		return
+	}
+
+	if s.sys.sweeper != nil {
+		s.sys.sweeper.Stop()
+		s.sys.sweeper = nil
+	}
+
+	// We will queue up a shutdown event and wait for the
+	// internal send loop to exit.
+	s.sendShutdownEvent()
+	s.sys.wg.Wait()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Whip through all accounts.
+	for _, a := range s.accounts {
+		a.mu.Lock()
+		a.nrclients = 0
+		// Now clear state
+		if a.etmr != nil {
+			a.etmr.Stop()
+			a.etmr = nil
+		}
+		if a.ctmr != nil {
+			a.ctmr.Stop()
+			a.ctmr = nil
+		}
+		a.clients = nil
+		a.strack = nil
+		a.mu.Unlock()
+	}
+	// Turn everything off here.
+	s.sys = nil
+}
+
+func (s *Server) connsRequest(sub *subscription, subject, reply string, msg []byte) {
+	if !s.eventsRunning() {
+		return
+	}
+
+	m := accNumConnsReq{}
+	if err := json.Unmarshal(msg, &m); err != nil {
+		s.sys.client.Errorf("Error unmarshalling account connections request message: %v", err)
+		return
+	}
+	acc := s.LookupAccount(m.Account)
+	if acc == nil {
+		return
+	}
+	if nlc := acc.NumLocalClients(); nlc > 0 {
+		s.sendAccConnsUpdate(acc, reply)
+	}
+}
+
+// remoteConnsUpdate gets called when we receive a remote update from another server.
+func (s *Server) remoteConnsUpdate(sub *subscription, subject, reply string, msg []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.eventsEnabled() {
+		return
+	}
+
+	m := accNumConns{}
+	if err := json.Unmarshal(msg, &m); err != nil {
+		s.sys.client.Errorf("Error unmarshalling account connection event message: %v", err)
+		return
+	}
+	// Double check that this is not us, should never happen, so error if it does.
+	if m.Server.ID == s.info.ID {
+		s.sys.client.Errorf("Processing our own account connection event message: ignored")
+		return
+	}
+	// See if we have the account registered, if not drop it.
+	acc := s.lookupAccount(m.Account)
+	if acc == nil {
+		s.sys.client.Debugf("Received account connection event for unknown account: %s", m.Account)
+		return
+	}
+	// If we are here we have interest in tracking this account. Update our accounting.
+	acc.mu.Lock()
+	if acc.strack == nil {
+		acc.strack = make(map[string]int)
+	}
+	// This does not depend on receiving all updates since each one is idempotent.
+	prev := acc.strack[m.Server.ID]
+	acc.strack[m.Server.ID] = m.Conns
+	acc.nrclients += (m.Conns - prev)
+	acc.mu.Unlock()
+
+	s.updateRemoteServer(&m.Server)
+}
+
+// Setup tracking for this account. This allows us to track globally
+// account activity.
+func (s *Server) enableAccountTracking(a *Account) {
+	if a == nil || !s.eventsEnabled() || a == s.sys.account {
 		return
 	}
 	acc := s.sys.account
+	sc := s.sys.client
+
+	subj := fmt.Sprintf(accConnsReqSubj, a.Name)
+	r := acc.sl.Match(subj)
+	if noOutSideInterest(sc, r) {
+		return
+	}
+	reply := fmt.Sprintf(connsRespSubj, s.info.ID)
+	m := accNumConnsReq{Account: a.Name}
+	s.sendInternalMsg(r, subj, reply, &m.Server, &m)
+}
+
+// FIXME(dlc) - make configurable.
+const connHBInterval = 30 * time.Second
+
+// sendAccConnsUpdate is called to send out our information on the
+// account's local connections.
+func (s *Server) sendAccConnsUpdate(a *Account, subj string) {
+	if !s.eventsEnabled() || a == nil || a == s.sys.account || a == s.gacc {
+		return
+	}
+	acc := s.sys.account
+	sc := s.sys.client
+
+	r := acc.sl.Match(subj)
+	if noOutSideInterest(sc, r) {
+		return
+	}
+
+	a.mu.Lock()
+	// If no limits set, don't update, no need to.
+	if a.mconns == 0 {
+		a.mu.Unlock()
+		return
+	}
+	// Build event with account name and number of local clients.
+	m := accNumConns{
+		Account: a.Name,
+		Conns:   len(a.clients),
+	}
+	// Check to see if we have an HB running and update.
+	if a.ctmr == nil {
+		a.etmr = time.AfterFunc(connHBInterval, func() { s.accConnsUpdate(a) })
+	} else {
+		a.etmr.Reset(connHBInterval)
+	}
+	a.mu.Unlock()
+
+	s.sendInternalMsg(r, subj, "", &m.Server, &m)
+}
+
+// accConnsUpdate is called whenever there is a change to the account's
+// number of active connections, or during a heartbeat.
+func (s *Server) accConnsUpdate(a *Account) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.eventsEnabled() || a == nil || a == s.sys.account {
+		return
+	}
+	subj := fmt.Sprintf(accConnsEventSubj, a.Name)
+	s.sendAccConnsUpdate(a, subj)
+}
+
+// accountConnectEvent will send an account client connect event if there is interest.
+// This is a billing event.
+func (s *Server) accountConnectEvent(c *client) {
+	s.mu.Lock()
+	if !s.eventsEnabled() {
+		s.mu.Unlock()
+		return
+	}
+	acc := s.sys.account
+	sc := s.sys.client
+	s.mu.Unlock()
 
 	subj := fmt.Sprintf(connectEventSubj, c.acc.Name)
 	r := acc.sl.Match(subj)
-	if s.noOutSideInterest(r) {
+	if noOutSideInterest(sc, r) {
 		return
 	}
 
@@ -145,20 +529,24 @@ func (s *Server) accountConnectEvent(c *client) {
 		},
 	}
 	c.mu.Unlock()
-
-	s.sendInternalMsg(r, subj, &m.Server, &m)
+	s.sendInternalMsg(r, subj, "", &m.Server, &m)
 }
 
 // accountDisconnectEvent will send an account client disconnect event if there is interest.
+// This is a billing event.
 func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string) {
-	if s.sys == nil || s.sys.client == nil || s.sys.account == nil {
+	s.mu.Lock()
+	if !s.eventsEnabled() {
+		s.mu.Unlock()
 		return
 	}
 	acc := s.sys.account
+	sc := s.sys.client
+	s.mu.Unlock()
 
 	subj := fmt.Sprintf(disconnectEventSubj, c.acc.Name)
 	r := acc.sl.Match(subj)
-	if s.noOutSideInterest(r) {
+	if noOutSideInterest(sc, r) {
 		return
 	}
 
@@ -186,8 +574,7 @@ func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string)
 		Reason: reason,
 	}
 	c.mu.Unlock()
-
-	s.sendInternalMsg(r, subj, &m.Server, &m)
+	s.sendInternalMsg(r, subj, "", &m.Server, &m)
 }
 
 // Internal message callback. If the msg is needed past the callback it is
@@ -195,7 +582,7 @@ func (s *Server) accountDisconnectEvent(c *client, now time.Time, reason string)
 type msgHandler func(sub *subscription, subject, reply string, msg []byte)
 
 func (s *Server) deliverInternalMsg(sub *subscription, subject, reply, msg []byte) {
-	if s.sys == nil {
+	if !s.eventsEnabled() || s.sys.subs == nil {
 		return
 	}
 	s.mu.Lock()
@@ -208,7 +595,7 @@ func (s *Server) deliverInternalMsg(sub *subscription, subject, reply, msg []byt
 
 // Create an internal subscription. No support for queue groups atm.
 func (s *Server) sysSubscribe(subject string, cb msgHandler) (*subscription, error) {
-	if s.sys == nil {
+	if !s.eventsEnabled() {
 		return nil, ErrNoSysAccount
 	}
 	if cb == nil {
@@ -232,7 +619,7 @@ func (s *Server) sysSubscribe(subject string, cb msgHandler) (*subscription, err
 }
 
 func (s *Server) sysUnsubscribe(sub *subscription) {
-	if sub == nil || s.sys == nil {
+	if sub == nil || !s.eventsEnabled() {
 		return
 	}
 	s.mu.Lock()
@@ -243,8 +630,7 @@ func (s *Server) sysUnsubscribe(sub *subscription) {
 	c.unsubscribe(acc, sub, true)
 }
 
-func (s *Server) noOutSideInterest(r *SublistResult) bool {
-	sc := s.sys.client
+func noOutSideInterest(sc *client, r *SublistResult) bool {
 	if sc == nil || r == nil {
 		return true
 	}
@@ -262,18 +648,6 @@ func (s *Server) noOutSideInterest(r *SublistResult) bool {
 		}
 	}
 	return true
-}
-
-func (s *Server) stampServerInfo(si *ServerInfo) {
-	if si == nil {
-		return
-	}
-	s.mu.Lock()
-	si.ID = s.info.ID
-	si.Seq = s.sys.seq
-	si.Host = s.info.Host
-	s.sys.seq++
-	s.mu.Unlock()
 }
 
 func (c *client) flushClients() {

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -339,6 +339,8 @@ func TestSystemAccountInternalSubscriptions(t *testing.T) {
 
 func TestSystemAccountConnectionLimits(t *testing.T) {
 	sa, optsA, sb, optsB := runTrustedCluster(t)
+	defer sa.Shutdown()
+	defer sb.Shutdown()
 
 	// We want to test that we are limited to a certain number of active connections
 	// across multiple servers.

--- a/server/events_test.go
+++ b/server/events_test.go
@@ -36,27 +36,6 @@ func createAccount(s *Server) (*Account, nkeys.KeyPair) {
 	return s.LookupAccount(pub), akp
 }
 
-func TestSystemAccount(t *testing.T) {
-	s := opTrustBasicSetup()
-	defer s.Shutdown()
-	buildMemAccResolver(s)
-
-	acc, _ := createAccount(s)
-	s.setSystemAccount(acc)
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.sys == nil || s.sys.account == nil {
-		t.Fatalf("Expected sys.account to be non-nil")
-	}
-	if s.sys.client == nil {
-		t.Fatalf("Expected sys.client to be non-nil")
-	}
-	if s.sys.client.echo {
-		t.Fatalf("Internal clients should always have echo false")
-	}
-}
-
 func createUserCreds(t *testing.T, s *Server, akp nkeys.KeyPair) nats.Option {
 	t.Helper()
 	kp, _ := nkeys.CreateUser()
@@ -82,9 +61,66 @@ func runTrustedServer(t *testing.T) (*Server, *Options) {
 	kp, _ := nkeys.FromSeed(oSeed)
 	pub, _ := kp.PublicKey()
 	opts.TrustedNkeys = []string{pub}
+	opts.accResolver = &MemAccResolver{}
 	s := RunServer(opts)
-	buildMemAccResolver(s)
 	return s, opts
+}
+
+func runTrustedCluster(t *testing.T) (*Server, *Options, *Server, *Options) {
+	t.Helper()
+
+	kp, _ := nkeys.FromSeed(oSeed)
+	pub, _ := kp.PublicKey()
+
+	mr := &MemAccResolver{}
+
+	// Now create a system account.
+	// NOTE: This can NOT be shared directly between servers.
+	// Set via server options.
+	okp, _ := nkeys.FromSeed(oSeed)
+	akp, _ := nkeys.CreateAccount()
+	apub, _ := akp.PublicKey()
+	nac := jwt.NewAccountClaims(apub)
+	jwt, _ := nac.Encode(okp)
+
+	mr.Store(apub, jwt)
+
+	optsA := DefaultOptions()
+	optsA.Cluster.Host = "127.0.0.1"
+	optsA.TrustedNkeys = []string{pub}
+	optsA.accResolver = mr
+	optsA.SystemAccount = apub
+
+	sa := RunServer(optsA)
+
+	optsB := nextServerOpts(optsA)
+	optsB.Routes = RoutesFromStr(fmt.Sprintf("nats://%s:%d", optsA.Cluster.Host, optsA.Cluster.Port))
+	sb := RunServer(optsB)
+
+	checkClusterFormed(t, sa, sb)
+
+	return sa, optsA, sb, optsB
+}
+
+func TestSystemAccount(t *testing.T) {
+	s, _ := runTrustedServer(t)
+	defer s.Shutdown()
+
+	acc, _ := createAccount(s)
+	s.setSystemAccount(acc)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.sys == nil || s.sys.account == nil {
+		t.Fatalf("Expected sys.account to be non-nil")
+	}
+	if s.sys.client == nil {
+		t.Fatalf("Expected sys.client to be non-nil")
+	}
+	if s.sys.client.echo {
+		t.Fatalf("Internal clients should always have echo false")
+	}
 }
 
 func TestSystemAccountNewConnection(t *testing.T) {
@@ -102,7 +138,7 @@ func TestSystemAccountNewConnection(t *testing.T) {
 	}
 	defer ncs.Close()
 
-	sub, _ := ncs.SubscribeSync(">")
+	sub, _ := ncs.SubscribeSync("$SYS.ACCOUNT.>")
 	defer sub.Unsubscribe()
 	ncs.Flush()
 
@@ -121,14 +157,14 @@ func TestSystemAccountNewConnection(t *testing.T) {
 		t.Fatalf("Error receiving msg: %v", err)
 	}
 
-	if !strings.HasPrefix(msg.Subject, fmt.Sprintf("$SYS.%s.CLIENT.CONNECT", acc2.Name)) {
-		t.Fatalf("Expected subject to start with %q, got %q", "$SYS.<ACCOUNT>.CLIENT.CONNECT", msg.Subject)
+	if !strings.HasPrefix(msg.Subject, fmt.Sprintf("$SYS.ACCOUNT.%s.CONNECT", acc2.Name)) {
+		t.Fatalf("Expected subject to start with %q, got %q", "$SYS.ACCOUNT.<account>.CONNECT", msg.Subject)
 	}
 	tokens := strings.Split(msg.Subject, ".")
 	if len(tokens) < 4 {
 		t.Fatalf("Expected 4 tokens, got %d", len(tokens))
 	}
-	account := tokens[1]
+	account := tokens[2]
 	if account != acc2.Name {
 		t.Fatalf("Expected %q for account, got %q", acc2.Name, account)
 	}
@@ -168,14 +204,14 @@ func TestSystemAccountNewConnection(t *testing.T) {
 		t.Fatalf("Error receiving msg: %v", err)
 	}
 
-	if !strings.HasPrefix(msg.Subject, fmt.Sprintf("$SYS.%s.CLIENT.DISCONNECT", acc2.Name)) {
-		t.Fatalf("Expected subject to start with %q, got %q", "$SYS.<ACCOUNT>.CLIENT.DISCONNECT", msg.Subject)
+	if !strings.HasPrefix(msg.Subject, fmt.Sprintf("$SYS.ACCOUNT.%s.DISCONNECT", acc2.Name)) {
+		t.Fatalf("Expected subject to start with %q, got %q", "$SYS.ACCOUNT.<account>.DISCONNECT", msg.Subject)
 	}
 	tokens = strings.Split(msg.Subject, ".")
 	if len(tokens) < 4 {
 		t.Fatalf("Expected 4 tokens, got %d", len(tokens))
 	}
-	account = tokens[1]
+	account = tokens[2]
 	if account != acc2.Name {
 		t.Fatalf("Expected %q for account, got %q", acc2.Name, account)
 	}
@@ -216,7 +252,7 @@ func TestSystemAccountNewConnection(t *testing.T) {
 	}
 }
 
-func TestSystemInternalSubscriptions(t *testing.T) {
+func TestSystemAccountInternalSubscriptions(t *testing.T) {
 	s, opts := runTrustedServer(t)
 	defer s.Shutdown()
 
@@ -289,7 +325,7 @@ func TestSystemInternalSubscriptions(t *testing.T) {
 	// Now make sure we do not hear ourselves. We optimize this for internally
 	// generated messages.
 	r := SublistResult{psubs: []*subscription{sub}}
-	s.sendInternalMsg(&r, "foo", nil, msg.Data)
+	s.sendInternalMsg(&r, "foo", "", nil, msg.Data)
 
 	select {
 	case <-received:
@@ -297,4 +333,202 @@ func TestSystemInternalSubscriptions(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		break
 	}
+}
+
+func TestSystemAccountConnectionLimits(t *testing.T) {
+	sa, optsA, sb, optsB := runTrustedCluster(t)
+
+	// We want to test that we are limited to a certain number of active connections
+	// across multiple servers.
+
+	// Let's create a user account.
+	okp, _ := nkeys.FromSeed(oSeed)
+	akp, _ := nkeys.CreateAccount()
+	pub, _ := akp.PublicKey()
+	nac := jwt.NewAccountClaims(pub)
+	nac.Limits.Conn = 4 // Limit to 4 connections.
+	jwt, _ := nac.Encode(okp)
+
+	addAccountToMemResolver(sa, pub, jwt)
+
+	urlA := fmt.Sprintf("nats://%s:%d", optsA.Host, optsA.Port)
+	urlB := fmt.Sprintf("nats://%s:%d", optsB.Host, optsB.Port)
+
+	// Create a user on each server. Break on first failure.
+	for {
+		nca1, err := nats.Connect(urlA, createUserCreds(t, sa, akp))
+		if err != nil {
+			break
+		}
+		defer nca1.Close()
+		ncb1, err := nats.Connect(urlB, createUserCreds(t, sb, akp))
+		if err != nil {
+			break
+		}
+		defer ncb1.Close()
+	}
+
+	total := sa.NumClients() + sb.NumClients()
+	if total > int(nac.Limits.Conn) {
+		t.Fatalf("Expected only %d connections, was allowed to connect %d", nac.Limits.Conn, total)
+	}
+}
+
+// Test that the remote accounting works when a server is started some time later.
+func TestSystemAccountConnectionLimitsServersStaggered(t *testing.T) {
+	sa, optsA, sb, optsB := runTrustedCluster(t)
+	defer sa.Shutdown()
+	sb.Shutdown()
+
+	// Let's create a user account.
+	okp, _ := nkeys.FromSeed(oSeed)
+	akp, _ := nkeys.CreateAccount()
+	pub, _ := akp.PublicKey()
+	nac := jwt.NewAccountClaims(pub)
+	nac.Limits.Conn = 4 // Limit to 4 connections.
+	jwt, _ := nac.Encode(okp)
+
+	addAccountToMemResolver(sa, pub, jwt)
+
+	urlA := fmt.Sprintf("nats://%s:%d", optsA.Host, optsA.Port)
+	// Create max connections on sa.
+	for i := 0; i < int(nac.Limits.Conn); i++ {
+		nc, err := nats.Connect(urlA, createUserCreds(t, sa, akp))
+		if err != nil {
+			t.Fatalf("Unexpected error on #%d try: %v", i+1, err)
+		}
+		defer nc.Close()
+	}
+
+	// Restart server B.
+	optsB.accResolver = sa.accResolver
+	optsB.SystemAccount = sa.systemAccount().Name
+	sb = RunServer(optsB)
+	defer sb.Shutdown()
+	checkClusterFormed(t, sa, sb)
+
+	// Trigger a load of the user account on the new server
+	// NOTE: If we do not load the user can be the first to request this
+	// account, hence the connection will succeed.
+	sb.LookupAccount(pub)
+
+	// Expect this to fail.
+	urlB := fmt.Sprintf("nats://%s:%d", optsB.Host, optsB.Port)
+	if _, err := nats.Connect(urlB, createUserCreds(t, sb, akp)); err == nil {
+		t.Fatalf("Expected connection to fail due to max limit")
+	}
+}
+
+// Test that the remote accounting works when a server is shutdown.
+func TestSystemAccountConnectionLimitsServerShutdownGraceful(t *testing.T) {
+	sa, optsA, sb, optsB := runTrustedCluster(t)
+	defer sa.Shutdown()
+	defer sb.Shutdown()
+
+	// Let's create a user account.
+	okp, _ := nkeys.FromSeed(oSeed)
+	akp, _ := nkeys.CreateAccount()
+	pub, _ := akp.PublicKey()
+	nac := jwt.NewAccountClaims(pub)
+	nac.Limits.Conn = 10 // Limit to 10 connections.
+	jwt, _ := nac.Encode(okp)
+
+	addAccountToMemResolver(sa, pub, jwt)
+	addAccountToMemResolver(sb, pub, jwt)
+
+	urlA := fmt.Sprintf("nats://%s:%d", optsA.Host, optsA.Port)
+	urlB := fmt.Sprintf("nats://%s:%d", optsB.Host, optsB.Port)
+
+	for i := 0; i < 5; i++ {
+		_, err := nats.Connect(urlA, nats.NoReconnect(), createUserCreds(t, sa, akp))
+		if err != nil {
+			t.Fatalf("Expected to connect, got %v", err)
+		}
+		_, err = nats.Connect(urlB, nats.NoReconnect(), createUserCreds(t, sb, akp))
+		if err != nil {
+			t.Fatalf("Expected to connect, got %v", err)
+		}
+	}
+
+	// We are at capacity so both of these should fail.
+	if _, err := nats.Connect(urlA, createUserCreds(t, sa, akp)); err == nil {
+		t.Fatalf("Expected connection to fail due to max limit")
+	}
+	if _, err := nats.Connect(urlB, createUserCreds(t, sb, akp)); err == nil {
+		t.Fatalf("Expected connection to fail due to max limit")
+	}
+
+	// Now shutdown Server B.
+	sb.Shutdown()
+
+	// Now we should be able to create more on A now.
+	for i := 0; i < 5; i++ {
+		_, err := nats.Connect(urlA, createUserCreds(t, sa, akp))
+		if err != nil {
+			t.Fatalf("Expected to connect on %d, got %v", i, err)
+		}
+	}
+}
+
+// Test that the remote accounting works when a server goes away.
+func TestSystemAccountConnectionLimitsServerShutdownForced(t *testing.T) {
+	sa, optsA, sb, optsB := runTrustedCluster(t)
+
+	// Let's create a user account.
+	okp, _ := nkeys.FromSeed(oSeed)
+	akp, _ := nkeys.CreateAccount()
+	pub, _ := akp.PublicKey()
+	nac := jwt.NewAccountClaims(pub)
+	nac.Limits.Conn = 20 // Limit to 20 connections.
+	jwt, _ := nac.Encode(okp)
+
+	addAccountToMemResolver(sa, pub, jwt)
+	addAccountToMemResolver(sb, pub, jwt)
+
+	urlA := fmt.Sprintf("nats://%s:%d", optsA.Host, optsA.Port)
+	urlB := fmt.Sprintf("nats://%s:%d", optsB.Host, optsB.Port)
+
+	for i := 0; i < 10; i++ {
+		_, err := nats.Connect(urlA, nats.NoReconnect(), createUserCreds(t, sa, akp))
+		if err != nil {
+			t.Fatalf("Expected to connect, got %v", err)
+		}
+		_, err = nats.Connect(urlB, nats.NoReconnect(), createUserCreds(t, sb, akp))
+		if err != nil {
+			t.Fatalf("Expected to connect, got %v", err)
+		}
+	}
+
+	// We are at capacity so both of these should fail.
+	if _, err := nats.Connect(urlA, createUserCreds(t, sa, akp)); err == nil {
+		t.Fatalf("Expected connection to fail due to max limit")
+	}
+	if _, err := nats.Connect(urlB, createUserCreds(t, sb, akp)); err == nil {
+		t.Fatalf("Expected connection to fail due to max limit")
+	}
+
+	// Now shutdown Server B. Do so such that now communications goo out.
+	sb.mu.Lock()
+	sb.sys = nil
+	sb.mu.Unlock()
+	sb.Shutdown()
+
+	if _, err := nats.Connect(urlA, createUserCreds(t, sa, akp)); err == nil {
+		t.Fatalf("Expected connection to fail due to max limit")
+	}
+
+	// Let's speed up the checking process.
+	checkRemoteServerInterval = 10 * time.Millisecond
+	orphanServerDuration = 30 * time.Millisecond
+	sa.mu.Lock()
+	sa.sys.sweeper.Reset(checkRemoteServerInterval)
+	sa.mu.Unlock()
+
+	// We should eventually be able to connect.
+	checkFor(t, 5*time.Second, 50*time.Millisecond, func() error {
+		if _, err := nats.Connect(urlA, createUserCreds(t, sa, akp)); err != nil {
+			return err
+		}
+		return nil
+	})
 }

--- a/server/opts.go
+++ b/server/opts.go
@@ -94,6 +94,7 @@ type Options struct {
 	Nkeys            []*NkeyUser   `json:"-"`
 	Users            []*User       `json:"-"`
 	Accounts         []*Account    `json:"-"`
+	SystemAccount    string        `json:"-"`
 	AllowNewAccounts bool          `json:"-"`
 	Username         string        `json:"-"`
 	Password         string        `json:"-"`
@@ -138,6 +139,9 @@ type Options struct {
 
 	// private fields, used for testing
 	gatewaysSolicitDelay time.Duration
+
+	// Used to spin up a memory account resolver for testing.
+	accResolver AccountResolver
 }
 
 type netResolver interface {
@@ -2058,7 +2062,7 @@ func getInterfaceIPs() ([]net.IP, error) {
 	return localIPs, nil
 }
 
-func processOptions(opts *Options) {
+func setBaselineOptions(opts *Options) {
 	// Setup non-standard Go defaults
 	if opts.Host == "" {
 		opts.Host = DEFAULT_HOST

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -47,7 +47,7 @@ func TestDefaultOptions(t *testing.T) {
 	}
 
 	opts := &Options{}
-	processOptions(opts)
+	setBaselineOptions(opts)
 
 	if !reflect.DeepEqual(golden, opts) {
 		t.Fatalf("Default Options are incorrect.\nexpected: %+v\ngot: %+v",
@@ -57,7 +57,7 @@ func TestDefaultOptions(t *testing.T) {
 
 func TestOptions_RandomPort(t *testing.T) {
 	opts := &Options{Port: RANDOM_PORT}
-	processOptions(opts)
+	setBaselineOptions(opts)
 
 	if opts.Port != 0 {
 		t.Fatalf("Process of options should have resolved random port to "+
@@ -450,7 +450,7 @@ func TestListenConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v\n", err)
 	}
-	processOptions(opts)
+	setBaselineOptions(opts)
 
 	// Normal clients
 	host := "10.0.1.22"
@@ -500,7 +500,7 @@ func TestListenPortOnlyConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v\n", err)
 	}
-	processOptions(opts)
+	setBaselineOptions(opts)
 
 	port := 8922
 
@@ -520,7 +520,7 @@ func TestListenPortWithColonConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v\n", err)
 	}
-	processOptions(opts)
+	setBaselineOptions(opts)
 
 	port := 8922
 
@@ -539,7 +539,7 @@ func TestListenMonitoringDefault(t *testing.T) {
 	opts := &Options{
 		Host: "10.0.1.22",
 	}
-	processOptions(opts)
+	setBaselineOptions(opts)
 
 	host := "10.0.1.22"
 	if opts.Host != host {
@@ -558,7 +558,7 @@ func TestMultipleUsersConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v\n", err)
 	}
-	processOptions(opts)
+	setBaselineOptions(opts)
 }
 
 // Test highly depends on contents of the config file listed below. Any changes to that file
@@ -568,7 +568,7 @@ func TestAuthorizationConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v\n", err)
 	}
-	processOptions(opts)
+	setBaselineOptions(opts)
 	lu := len(opts.Users)
 	if lu != 3 {
 		t.Fatalf("Expected 3 users, got %d\n", lu)
@@ -655,7 +655,7 @@ func TestNewStyleAuthorizationConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Received an error reading config file: %v\n", err)
 	}
-	processOptions(opts)
+	setBaselineOptions(opts)
 
 	lu := len(opts.Users)
 	if lu != 2 {

--- a/server/reload.go
+++ b/server/reload.go
@@ -503,7 +503,7 @@ func (s *Server) Reload() error {
 
 	// Apply flags over config file settings.
 	newOpts = MergeOptions(newOpts, FlagSnapshot)
-	processOptions(newOpts)
+	setBaselineOptions(newOpts)
 
 	// processOptions sets Port to 0 if set to -1 (RANDOM port)
 	// If that's the case, set it to the saved value when the accept loop was

--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -149,7 +149,7 @@ func TestConfigReloadUnsupported(t *testing.T) {
 		},
 		NoSigs: true,
 	}
-	processOptions(golden)
+	setBaselineOptions(golden)
 
 	if !reflect.DeepEqual(golden, server.getOpts()) {
 		t.Fatalf("Options are incorrect.\nexpected: %+v\ngot: %+v",
@@ -228,7 +228,7 @@ func TestConfigReloadInvalidConfig(t *testing.T) {
 		},
 		NoSigs: true,
 	}
-	processOptions(golden)
+	setBaselineOptions(golden)
 
 	if !reflect.DeepEqual(golden, server.getOpts()) {
 		t.Fatalf("Options are incorrect.\nexpected: %+v\ngot: %+v",
@@ -299,7 +299,7 @@ func TestConfigReload(t *testing.T) {
 		},
 		NoSigs: true,
 	}
-	processOptions(golden)
+	setBaselineOptions(golden)
 
 	if !reflect.DeepEqual(golden, opts) {
 		t.Fatalf("Options are incorrect.\nexpected: %+v\ngot: %+v",

--- a/server/server.go
+++ b/server/server.go
@@ -533,6 +533,8 @@ func (s *Server) setSystemAccount(acc *Account) error {
 		servers: make(map[string]*serverUpdate),
 		subs:    make(map[string]msgHandler),
 		sendq:   make(chan *pubMsg, 128),
+		orphMax: 5 * AccountConnHBInterval,
+		chkOrph: 3 * AccountConnHBInterval,
 	}
 	s.sys.client.initClient()
 	s.sys.client.echo = false


### PR DESCRIPTION
Specifically this is to support distributed tracking of number of account connections across clusters.
Gateways may not work yet based on attempts to only generate payloads when we know there is outside interest.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
