### PR TITLE
Fixing setting of default gateway TLS Timeout

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -220,10 +220,6 @@ func newGateway(opts *Options) (*srvGateway, error) {
 		gateway.resolver = netResolver(net.DefaultResolver)
 	}
 
-	if opts.Gateway.TLSConfig != nil && opts.Gateway.TLSTimeout == 0 {
-		opts.Gateway.TLSTimeout = float64(TLS_TIMEOUT) / float64(time.Second)
-	}
-
 	// Copy default permissions (works if DefaultPermissions is nil)
 	gateway.defPerms = opts.Gateway.DefaultPermissions.clone()
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -2190,6 +2190,12 @@ func setBaselineOptions(opts *Options) {
 		if opts.Gateway.Host == "" {
 			opts.Gateway.Host = DEFAULT_HOST
 		}
+		if opts.Gateway.TLSTimeout == 0 {
+			opts.Gateway.TLSTimeout = float64(TLS_TIMEOUT) / float64(time.Second)
+		}
+		if opts.Gateway.AuthTimeout == 0 {
+			opts.Gateway.AuthTimeout = float64(AUTH_TIMEOUT) / float64(time.Second)
+		}
 	}
 }
 

--- a/server/reload.go
+++ b/server/reload.go
@@ -499,6 +499,7 @@ func (s *Server) Reload() error {
 	}
 	clientOrgPort := s.clientActualPort
 	clusterOrgPort := s.clusterActualPort
+	gatewayOrgPort := s.gatewayActualPort
 	s.mu.Unlock()
 
 	// Apply flags over config file settings.
@@ -514,6 +515,9 @@ func (s *Server) Reload() error {
 	// We don't do that for cluster, so check against -1.
 	if newOpts.Cluster.Port == -1 {
 		newOpts.Cluster.Port = clusterOrgPort
+	}
+	if newOpts.Gateway.Port == -1 {
+		newOpts.Gateway.Port = gatewayOrgPort
 	}
 
 	if err := s.reloadOptions(newOpts); err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -63,10 +63,9 @@ func RunServer(opts *Options) *Server {
 	if opts == nil {
 		opts = DefaultOptions()
 	}
-	s := New(opts)
-
-	if s == nil {
-		panic("No NATS Server object returned.")
+	s, err := NewServer(opts)
+	if err != nil || s == nil {
+		panic(fmt.Sprintf("No NATS Server object returned: %v", err))
 	}
 
 	if !opts.NoLog {


### PR DESCRIPTION
Moved setting to the default value in setBaselineOptions()
so that config reload does not fail.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

/cc @nats-io/core
