### PR TITLE
[ADDED] RemoteAddress() to the CustomClientAuthentication interface

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -16,6 +16,7 @@ package server
 import (
 	"crypto/tls"
 	"encoding/base64"
+	"net"
 	"strings"
 
 	"github.com/nats-io/jwt"
@@ -37,6 +38,8 @@ type ClientAuthentication interface {
 	GetTLSConnectionState() *tls.ConnectionState
 	// Optionally map a user after auth.
 	RegisterUser(*User)
+	// RemoteAddress expose the connection information of the client
+	RemoteAddress() net.Addr
 }
 
 // NkeyUser is for multiple nkey based users

--- a/server/client.go
+++ b/server/client.go
@@ -390,6 +390,19 @@ func (c *client) initClient() {
 	}
 }
 
+// RemoteAddress expose the Address of the client connection,
+// nil when not connected or unknown
+func (c *client) RemoteAddress() net.Addr {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.nc == nil {
+		return nil
+	}
+
+	return c.nc.RemoteAddr()
+}
+
 // Helper function to report errors.
 func (c *client) reportErrRegisterAccount(acc *Account, err error) {
 	if err == ErrTooManyAccountConnections {

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -260,6 +260,26 @@ func TestClientConnectProto(t *testing.T) {
 	wg.Wait()
 }
 
+func TestRemoteAddress(t *testing.T) {
+	c := &client{}
+
+	// though in reality this will panic if it does not, adding coverage anyway
+	if c.RemoteAddress() != nil {
+		t.Errorf("RemoteAddress() did not handle nil connection correctly")
+	}
+
+	_, c, _ = setupClient()
+	addr := c.RemoteAddress()
+
+	if addr.Network() != "pipe" {
+		t.Errorf("RemoteAddress() returned invalid network: %s", addr.Network())
+	}
+
+	if addr.String() != "pipe" {
+		t.Errorf("RemoteAddress() returned invalid string: %s", addr.String())
+	}
+}
+
 func TestClientPing(t *testing.T) {
 	_, c, cr := setupClient()
 
@@ -841,6 +861,17 @@ func TestTLSCloseClientConnection(t *testing.T) {
 	if state == nil {
 		t.Error("GetTLSConnectionState() returned nil")
 	}
+
+	// Test RemoteAddress
+	addr := cli.RemoteAddress()
+	if addr == nil {
+		t.Error("RemoteAddress() returned nil")
+	}
+
+	if addr.(*net.TCPAddr).IP.String() != "127.0.0.1" {
+		t.Error("RemoteAddress() returned incorrect ip " + addr.String())
+	}
+
 	// Fill the buffer. Need to send 1 byte at a time so that we timeout here
 	// the nc.Close() would block due to a write that can not complete.
 	done := false


### PR DESCRIPTION
This adds a RemoteAddress() method to the ClientAuthentication
interface which would facilitate CustomClientAuthentication
mechanisms considering the remote IP address of the client in
their decisions to allow clients or not

Resolves #832 

Signed-off-by: R.I.Pienaar <rip@devco.net>