### PR TITLE
[ADDED] Support a path as argument to --signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,14 @@ gnatsd -sl reopen
 gnatsd -sl stop
 ```
 
-If there are multiple `gnatsd` processes running, specify a PID:
+If there are multiple `gnatsd` processes running, or if `pgrep` isn't available, you must either specify a PID or the absolute path to a PID file:
 
 ```sh
 gnatsd -sl stop=<pid>
+```
+
+```sh
+gnatsd -sl stop=/path/to/pidfile
 ```
 
 See the [Windows Service](#windows-service) section for information on signaling the NATS server on Windows.
@@ -154,6 +158,7 @@ Server Options:
     -ms,--https_port <port>          Use port for https monitoring
     -c, --config <file>              Configuration file
     -sl,--signal <signal>[=<pid>]    Send signal to gnatsd process (stop, quit, reopen, reload)
+                                     <pid> can be either a PID (e.g. 1) or the path to a PID file (e.g. /var/run/gnatsd.pid)
         --client_advertise <string>  Client URL to advertise to other servers
     -t                               Test configuration and exit
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ Server Options:
     -ms,--https_port <port>          Use port for https monitoring
     -c, --config <file>              Configuration file
     -sl,--signal <signal>[=<pid>]    Send signal to gnatsd process (stop, quit, reopen, reload)
+                                     <pid> can be either a PID (e.g. 1) or the path to a PID file (e.g. /var/run/gnatsd.pid)
         --client_advertise <string>  Client URL to advertise to other servers
     -t                               Test configuration and exit
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -2500,7 +2500,7 @@ func processSignal(signal string) error {
 		commandAndPid = strings.Split(signal, "=")
 	)
 	if l := len(commandAndPid); l == 2 {
-		pid = commandAndPid[1]
+		pid = maybeReadPidFile(commandAndPid[1])
 	} else if l > 2 {
 		return fmt.Errorf("invalid signal parameters: %v", commandAndPid[2:])
 	}
@@ -2509,4 +2509,15 @@ func processSignal(signal string) error {
 	}
 	os.Exit(0)
 	return nil
+}
+
+// maybeReadPidFile returns a PID or Windows service name obtained via the following method:
+// 1. Try to open a file with path "pidStr" (absolute or relative).
+// 2. If such a file exists and can be read, return its contents.
+// 3. Otherwise, return the original "pidStr" string.
+func maybeReadPidFile(pidStr string) string {
+	if b, err := ioutil.ReadFile(pidStr); err == nil {
+		return string(b)
+	}
+	return pidStr
 }


### PR DESCRIPTION
 - [ ] ~Link to issue, e.g. `Resolves #NNN`~
 - [X] Documentation added (if applicable)
 - [ ] ~Tests added~ agreed w/ @kozlovic test is not mandatory for this one.
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #

### Changes proposed in this pull request:

 - Make the `-sl` / `--signal` flag accept the path to a PID file as an argument. This is useful in scenarios where `pgrep` isn't available (such as in the official Docker images) but there is a PID file.

/cc @nats-io/core
