### PR TITLE
Allow service import to work with Gateways

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -845,9 +845,12 @@ func TestLameDuckMode(t *testing.T) {
 	srvA.grWG.Wait()
 	srvB.grWG.Wait()
 	checkClientsCount(t, srvC, 1)
-	if n := atomic.LoadInt32(&rt); n != 1 {
-		t.Fatalf("Expected client to reconnect only once, got %v", n)
-	}
+	checkFor(t, 2*time.Second, 15*time.Millisecond, func() error {
+		if n := atomic.LoadInt32(&rt); n != 1 {
+			return fmt.Errorf("Expected client to reconnect only once, got %v", n)
+		}
+		return nil
+	})
 }
 
 func TestServerValidateGatewaysOptions(t *testing.T) {

--- a/test/gateway_test.go
+++ b/test/gateway_test.go
@@ -25,6 +25,7 @@ import (
 
 func testDefaultOptionsForGateway(name string) *server.Options {
 	o := DefaultTestOptions
+	o.Port = -1
 	o.Gateway.Name = name
 	o.Gateway.Host = "127.0.0.1"
 	o.Gateway.Port = -1


### PR DESCRIPTION
This is not complete solution and is a bit hacky but is a start
to be able to have service import work at least in some basic
cases.

Also fixed a bug where replySub would not be removed from
connection's list of subs after delivery.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

/cc @nats-io/core
