### PR TITLE
Add alpine based Dockerfile

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,26 @@
+FROM golang:1.11-alpine3.8 AS builder
+
+WORKDIR $GOPATH/src/github.com/nats-io/gnatsd
+
+MAINTAINER Waldemar Quevedo <wally@synadia.com>
+
+RUN apk add --update git
+
+COPY . .
+
+RUN CGO_ENABLED=0 go build -v -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/nats-io/gnatsd/server.gitCommit=`git rev-parse --short HEAD`" -o /nats-server
+
+FROM alpine:3.8
+
+RUN apk add --update ca-certificates && mkdir -p /nats/bin && mkdir /nats/conf
+
+COPY docker/nats-server.conf /nats/conf/nats-server.conf
+COPY --from=builder /nats-server /nats/bin/nats-server
+
+RUN ln -ns /nats/bin/nats-server /bin/nats-server && ln -ns /nats/bin/nats-server /bin/gnatsd && ln -ns /nats/bin/nats-server /gnatsd
+
+# Expose client, management, cluster and gateway ports
+EXPOSE 4222 8222 6222 5222
+
+ENTRYPOINT ["/bin/nats-server"]
+CMD ["-c", "/nats/conf/nats-server.conf"]

--- a/docker/nats-server.conf
+++ b/docker/nats-server.conf
@@ -1,0 +1,26 @@
+
+# Client port of 4222 on all interfaces
+port: 4222
+
+# HTTP monitoring port
+monitor_port: 8222
+
+# This is for clustering multiple servers together.
+cluster {
+
+  # Route connections to be received on any interface on port 6222
+  port: 6222
+
+  # Routes are protected, so need to use them with --routes flag
+  # e.g. --routes=nats-route://ruser:T0pS3cr3t@otherdockerhost:6222
+  authorization {
+    user: ruser
+    password: T0pS3cr3t
+    timeout: 2
+  }
+
+  # Routes are actively solicited and connected to from this server.
+  # This Docker image has none by default, but you can pass a
+  # flag to the gnatsd docker image to create one to an existing server.
+  routes = []
+}


### PR DESCRIPTION
Adds extra Dockerfile image that can be used to build the server from master.

```
docker build -f docker/Dockerfile.alpine -t <image:tag> .
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

 - [X] Link to issue, e.g. `Resolves #NNN`
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

 - Add Dockerfile.alpine to build latest nats server image

/cc @nats-io/core
