### PR TITLE
ServiceImports and queue groups

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -2185,6 +2185,11 @@ func (c *client) checkForImportServices(acc *Account, msg []byte) {
 		}
 		// FIXME(dlc) - Do L1 cache trick from above.
 		rr := rm.acc.sl.Match(rm.to)
+		// If we are a route or gateway and this message is flipped to a queue subscriber we
+		// need to handle that since the processMsgResults will want a queue filter.
+		if c.kind == ROUTER || c.kind == GATEWAY && c.pa.queues == nil && len(rr.qsubs) > 0 {
+			c.makeQFilter(rr.qsubs)
+		}
 		c.processMsgResults(rm.acc, rr, msg, []byte(rm.to), nrr, nil)
 		// If this is not a gateway connection but gateway is enabled,
 		// try to send this converted message to all gateways.

--- a/server/route.go
+++ b/server/route.go
@@ -311,6 +311,18 @@ func (c *client) processInboundRoutedMsg(msg []byte) {
 	c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply, nil)
 }
 
+// Helper function for routes and gateways to create qfilters need for
+// converted subs from imports, etc.
+func (c *client) makeQFilter(qsubs [][]*subscription) {
+	qs := make([][]byte, 0, len(qsubs))
+	for _, qsub := range qsubs {
+		if len(qsub) > 0 {
+			qs = append(qs, qsub[0].queue)
+		}
+	}
+	c.pa.queues = qs
+}
+
 // Lock should be held entering here.
 func (c *client) sendConnect(tlsRequired bool) {
 	var user, pass string


### PR DESCRIPTION
When service imports cross routes they are mapped back and forth from accounts as needed. If the requestor's reply subject also has a queue group, the response message, which traveled as a normal pub, would be dropped when the service import processing produced queue subscribers.

This fixes that edge case.

Signed-off-by: Derek Collison <derek@nats.io>



/cc @nats-io/core
