### PR TITLE
Support server ping for statusz

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.0.0-beta.2"
+	VERSION = "2.0.0-beta.4"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
Add support to send a broadcast ping to have all servers respond with a statusz. Will do random backoff to prevent thundering herd for requestor.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
