### PR TITLE
Resolve IP if gateway listen is 0.0.0.0 or ::

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.0.0-beta.4"
+	VERSION = "2.0.0-beta.5"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
Otherwise, this may be sent to servers in the cluster and to other
gateways which may result in attempt to connect to self which
in case of TLS would produce error.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
/cc @nats-io/core
