### PR TITLE
Should not send disconnect events on account $G.

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -1143,8 +1143,9 @@ func (c *client) accountAuthExpired() {
 }
 
 func (c *client) authViolation() {
+	var s *Server
 	var hasTrustedNkeys, hasNkeys, hasUsers bool
-	if s := c.srv; s != nil {
+	if s = c.srv; s != nil {
 		s.mu.Lock()
 		hasTrustedNkeys = len(s.trustedKeys) > 0
 		hasNkeys = s.nkeys != nil
@@ -1166,6 +1167,9 @@ func (c *client) authViolation() {
 	}
 	c.sendErr("Authorization Violation")
 	c.closeConnection(AuthenticationViolation)
+	if s != nil {
+		s.sendAuthErrorEvent(c)
+	}
 }
 
 func (c *client) maxAccountConnExceeded() {

--- a/server/server.go
+++ b/server/server.go
@@ -64,6 +64,7 @@ type Info struct {
 	IP                string   `json:"ip,omitempty"`
 	CID               uint64   `json:"client_id,omitempty"`
 	Nonce             string   `json:"nonce,omitempty"`
+	Cluster           string   `json:"cluster,omitempty"`
 	ClientConnectURLs []string `json:"connect_urls,omitempty"` // Contains URLs a client can connect to.
 
 	// Route Specific
@@ -236,12 +237,6 @@ func NewServer(opts *Options) (*Server, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// This is normally done in the AcceptLoop, once the
-	// listener has been created (possibly with random port),
-	// but since some tests may expect the INFO to be properly
-	// set after New(), let's do it now.
-	s.setInfoHostPortAndGenerateJSON()
-
 	// Used internally for quick look-ups.
 	s.clientConnectURLsMap = make(map[string]struct{})
 
@@ -255,6 +250,16 @@ func NewServer(opts *Options) (*Server, error) {
 		return nil, err
 	}
 	s.gateway = gws
+
+	if s.gateway.enabled {
+		s.info.Cluster = s.getGatewayName()
+	}
+
+	// This is normally done in the AcceptLoop, once the
+	// listener has been created (possibly with random port),
+	// but since some tests may expect the INFO to be properly
+	// set after New(), let's do it now.
+	s.setInfoHostPortAndGenerateJSON()
 
 	// For tracking clients
 	s.clients = make(map[uint64]*client)


### PR DESCRIPTION
Converted to authorization error events on different subject.
Add cluster name if gateways are configured and pass in INFO to clients.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
