### PR TITLE
Only consider as slow consumers clients that did CONNECT

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -856,6 +856,13 @@ func (c *client) flushOutbound() bool {
 					// here, and don't report a slow consumer error.
 					sce = false
 				}
+			} else if !c.flags.isSet(connectReceived) {
+				// Under some conditions, a client may hit a slow consumer write deadline
+				// before the authorization or TLS handshake timeout. If that is the case,
+				// then we handle as slow consumer though we do not increase the counter
+				// as can be misleading.
+				c.clearConnection(SlowConsumerWriteDeadline)
+				sce = false
 			}
 			if sce {
 				atomic.AddInt64(&srv.slowConsumers, 1)

--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.0.0-beta.11"
+	VERSION = "2.0.0-beta.12"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -383,3 +383,31 @@ func TestTLSTimeoutNotReportSlowConsumer(t *testing.T) {
 		// ok
 	}
 }
+
+func TestNotReportSlowConsumerUnlessConnected(t *testing.T) {
+	oa, err := server.ProcessConfigFile("./configs/srv_a_tls.conf")
+	if err != nil {
+		t.Fatalf("Unable to load config file: %v", err)
+	}
+
+	// Override WriteDeadline to very small value so that handshake
+	// fails with a slow consumer error.
+	oa.WriteDeadline = 1 * time.Nanosecond
+	sa := RunServer(oa)
+	defer sa.Shutdown()
+
+	ch := make(chan string, 1)
+	cscl := &captureSlowConsumerLogger{ch: ch}
+	sa.SetLogger(cscl, false, false)
+
+	nc := createClientConn(t, oa.Host, oa.Port)
+	defer nc.Close()
+
+	// Make sure we don't get any Slow Consumer error.
+	select {
+	case e := <-ch:
+		t.Fatalf("Unexpected slow consumer error: %s", e)
+	case <-time.After(500 * time.Millisecond):
+		// ok
+	}
+}


### PR DESCRIPTION
Under some scenarios a client may hit the slow consumer write deadline during the connecting stage, meaning that it is possible to consider unhealthy clients that could not finish the TLS handshake as slow consumers.

For example, if the `write_deadline` is way shorter than the TLS timeout deadline it is possible for a client to become a slow consumer even though it has not finished connecting properly:

```sh
[92961] 2018/12/18 22:04:03.308501 [DBG] 127.0.0.1:51506 - cid:1 - Client connection created
[92961] 2018/12/18 22:04:03.308837 [INF] 127.0.0.1:51506 - cid:1 - Slow Consumer Detected: WriteDeadline of 1µs Exceeded
[92961] 2018/12/18 22:04:03.308854 [DBG] 127.0.0.1:51506 - cid:1 - Starting TLS client connection handshake
[92961] 2018/12/18 22:04:03.308931 [ERR] 127.0.0.1:51506 - cid:1 - TLS handshake error: read tcp 127.0.0.1:4222->127.0.0.1:51506: use of closed network connection
[92961] 2018/12/18 22:04:03.308952 [DBG] 127.0.0.1:51506 - cid:1 - Client connection closed
```

And there could also be races, for example even if a TLS handshake already failed the write deadline can still be hit too, becoming accounted as a slow consumer:

```
[84968] 2018/12/18 16:49:56.346511 [DBG] 127.0.0.1:49639 - cid:1 - Starting TLS client connection handshake
[84968] 2018/12/18 16:49:59.350464 [ERR] 127.0.0.1:49639 - cid:1 - TLS handshake error: read tcp 127.0.0.1:4222->127.0.0.1:49639: i/o timeout
[84968] 2018/12/18 16:49:59.350484 [ERR] 127.0.0.1:49639 - cid:1 - TLS handshake timeout
[84968] 2018/12/18 16:49:59.350536 [DBG] 127.0.0.1:49639 - cid:1 - Client connection closed
[84968] 2018/12/18 16:49:59.350789 [INF] 127.0.0.1:49639 - cid:1 - Slow Consumer Detected: WriteDeadline of 1ms Exceeded
```

With this change, we only consider as slow consumers clients that did connect to the cluster without issues.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

 - [x] Link to issue, e.g. `Resolves #NNN`
 - [x] Documentation added (if applicable)
 - [x] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

 - Do not increase slow consumer counter due to write deadline errors unless a client has finished connecting

/cc @nats-io/core
