### PR TITLE
Fixed TLS tests to work with new go-nats behavior

### DIFF
--- a/server/reload_test.go
+++ b/server/reload_test.go
@@ -14,6 +14,7 @@
 package server
 
 import (
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -395,7 +396,7 @@ func TestConfigReloadRotateTLS(t *testing.T) {
 	// Ensure we can connect as a sanity check.
 	addr := fmt.Sprintf("nats://%s:%d", opts.Host, server.Addr().(*net.TCPAddr).Port)
 
-	nc, err := nats.Connect(addr, nats.Secure())
+	nc, err := nats.Connect(addr, nats.Secure(&tls.Config{InsecureSkipVerify: true}))
 	if err != nil {
 		t.Fatalf("Error creating client: %v", err)
 	}
@@ -413,7 +414,7 @@ func TestConfigReloadRotateTLS(t *testing.T) {
 	}
 
 	// Ensure connecting fails.
-	if _, err := nats.Connect(addr, nats.Secure()); err == nil {
+	if _, err := nats.Connect(addr, nats.Secure(&tls.Config{InsecureSkipVerify: true})); err == nil {
 		t.Fatal("Expected connect to fail")
 	}
 
@@ -461,15 +462,9 @@ func TestConfigReloadEnableTLS(t *testing.T) {
 		t.Fatalf("Error reloading config: %v", err)
 	}
 
-	// Ensure connecting is OK even without Secure (the client is now switching automatically).
-	nc, err = nats.Connect(addr)
-	if err != nil {
-		t.Fatalf("Error creating client: %v", err)
-	}
-	nc.Close()
-
-	// Ensure connecting succeeds when using secure.
-	nc, err = nats.Connect(addr, nats.Secure())
+	// Ensure connecting is OK (we need to skip server cert verification since
+	// the library is not doing that by default now).
+	nc, err = nats.Connect(addr, nats.Secure(&tls.Config{InsecureSkipVerify: true}))
 	if err != nil {
 		t.Fatalf("Error creating client: %v", err)
 	}
@@ -487,7 +482,7 @@ func TestConfigReloadDisableTLS(t *testing.T) {
 
 	// Ensure we can connect as a sanity check.
 	addr := fmt.Sprintf("nats://%s:%d", opts.Host, server.Addr().(*net.TCPAddr).Port)
-	nc, err := nats.Connect(addr, nats.Secure())
+	nc, err := nats.Connect(addr, nats.Secure(&tls.Config{InsecureSkipVerify: true}))
 	if err != nil {
 		t.Fatalf("Error creating client: %v", err)
 	}
@@ -500,7 +495,7 @@ func TestConfigReloadDisableTLS(t *testing.T) {
 	}
 
 	// Ensure connecting fails.
-	if _, err := nats.Connect(addr, nats.Secure()); err == nil {
+	if _, err := nats.Connect(addr, nats.Secure(&tls.Config{InsecureSkipVerify: true})); err == nil {
 		t.Fatal("Expected connect to fail")
 	}
 


### PR DESCRIPTION
Since we no longer default to InsecureSkipVerify:true when
not specifying tls://, some tests needed updating.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

/cc @nats-io/core
