### PR TITLE
[FIXED] Memory usage for failed TLS connections

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -584,7 +584,6 @@ func (s *Server) createGateway(cfg *gatewayCfg, url *url.URL, conn net.Conn) {
 	c.mu.Lock()
 	c.initClient()
 	c.gw = &gateway{}
-	c.in.pacache = make(map[string]*perAccountCache, maxPerAccountCacheSize)
 	if solicit {
 		// This is an outbound gateway connection
 		c.gw.outbound = true
@@ -595,11 +594,10 @@ func (s *Server) createGateway(cfg *gatewayCfg, url *url.URL, conn net.Conn) {
 		// the remote's INFO protocol, save the URL we need to connect to.
 		c.gw.connectURL = url
 		c.gw.infoJSON = infoJSON
-		c.gw.outsim = &sync.Map{}
+
 		c.Noticef("Creating outbound gateway connection to %q", cfg.Name)
 	} else {
 		// Inbound gateway connection
-		c.gw.insim = make(map[string]*insie)
 		c.Noticef("Processing inbound gateway connection")
 	}
 
@@ -657,6 +655,14 @@ func (s *Server) createGateway(cfg *gatewayCfg, url *url.URL, conn net.Conn) {
 	}
 
 	// Do final client initialization
+	c.in.pacache = make(map[string]*perAccountCache, maxPerAccountCacheSize)
+	if solicit {
+		// This is an outbound gateway connection
+		c.gw.outsim = &sync.Map{}
+	} else {
+		// Inbound gateway connection
+		c.gw.insim = make(map[string]*insie)
+	}
 
 	// Register in temp map for now until gateway properly registered
 	// in out or in gateways.

--- a/server/route.go
+++ b/server/route.go
@@ -1062,17 +1062,10 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 	// Initialize
 	c.initClient()
 
-	// Initialize the per-account cache.
-	c.in.pacache = make(map[string]*perAccountCache, maxPerAccountCacheSize)
-
 	if didSolicit {
 		// Do this before the TLS code, otherwise, in case of failure
 		// and if route is explicit, it would try to reconnect to 'nil'...
 		r.url = rURL
-
-		// Set permissions associated with the route user (if applicable).
-		// No lock needed since we are already under client lock.
-		c.setRoutePermissions(opts.Cluster.Permissions)
 	}
 
 	// Check for TLS
@@ -1120,6 +1113,14 @@ func (s *Server) createRoute(conn net.Conn, rURL *url.URL) *client {
 	}
 
 	// Do final client initialization
+
+	// Initialize the per-account cache.
+	c.in.pacache = make(map[string]*perAccountCache, maxPerAccountCacheSize)
+	if didSolicit {
+		// Set permissions associated with the route user (if applicable).
+		// No lock needed since we are already under client lock.
+		c.setRoutePermissions(opts.Cluster.Permissions)
+	}
 
 	// Set the Ping timer
 	c.setPingTimer()

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -422,5 +423,87 @@ func TestNotReportSlowConsumerUnlessConnected(t *testing.T) {
 		t.Fatalf("Unexpected slow consumer error: %s", e)
 	case <-time.After(500 * time.Millisecond):
 		// ok
+	}
+}
+
+func TestTLSHandshakeFailureMemUsage(t *testing.T) {
+	for i, test := range []struct {
+		name   string
+		config string
+	}{
+		{
+			"connect to TLS client port",
+			`
+				port: -1
+				%s
+			`,
+		},
+		{
+			"connect to TLS route port",
+			`
+				port: -1
+				cluster {
+					port: -1
+					%s
+				}
+			`,
+		},
+		{
+			"connect to TLS gateway port",
+			`
+				port: -1
+				gateway {
+					name: "A"
+					port: -1
+					%s
+				}
+			`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			content := fmt.Sprintf(test.config, `
+				tls {
+					cert_file: "configs/certs/server-cert.pem"
+					key_file: "configs/certs/server-key.pem"
+					ca_file: "configs/certs/ca.pem"
+					timeout: 5
+				}
+			`)
+			conf := createConfFile(t, []byte(content))
+			defer os.Remove(conf)
+			s, opts := RunServerWithConfig(conf)
+			defer s.Shutdown()
+
+			var port int
+			switch i {
+			case 0:
+				port = opts.Port
+			case 1:
+				port = s.ClusterAddr().Port
+			case 2:
+				port = s.GatewayAddr().Port
+			}
+
+			varz, _ := s.Varz(nil)
+			base := varz.Mem
+			buf := make([]byte, 1024*1024)
+			for i := 0; i < 100; i++ {
+				conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+				if err != nil {
+					t.Fatalf("Error on dial: %v", err)
+				}
+				conn.Write(buf)
+				conn.Close()
+			}
+
+			varz, _ = s.Varz(nil)
+			newval := (varz.Mem - base) / (1024 * 1024)
+			// May need to adjust that, but right now, with 100 clients
+			// we are at about 20MB for client port, 11MB for route
+			// and 6MB for gateways, so pick 50MB as the threshold
+			if newval >= 50 {
+				t.Fatalf("Consumed too much memory: %v MB", newval)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Moving some of the connection initialization post TLS handshake
to avoid temporary memory growth when getting repeated failed
connections to any of the client, route and gateway ports.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
