### PR TITLE
Changes to prevent fan-in scenarios from slow consumer state

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -780,7 +780,11 @@ func (a *Account) clearExpirationTimer() bool {
 	return stopped
 }
 
+// Check expiration and set the proper state as needed.
 func (a *Account) checkExpiration(claims *jwt.ClaimsData) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
 	a.clearExpirationTimer()
 	if claims.Expires == 0 {
 		a.expired = false

--- a/server/client.go
+++ b/server/client.go
@@ -205,7 +205,6 @@ type outbound struct {
 	wdl time.Duration // Snapshot fo write deadline.
 	mp  int64         // snapshot of max pending.
 	fsp int           // Flush signals that are pending from readLoop's pcd.
-	lws int64         // Last write size
 	lft time.Duration // Last flush time.
 }
 
@@ -839,9 +838,8 @@ func (c *client) flushOutbound() bool {
 		c.mu.Lock()
 	}
 
-	// Update flush time and size statistics
+	// Update flush time statistics
 	c.out.lft = lft
-	c.out.lws = n
 
 	// Subtract from pending bytes and messages.
 	c.out.pb -= n

--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.0.0-beta.13"
+	VERSION = "2.0.0-RC1"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/const.go
+++ b/server/const.go
@@ -68,7 +68,7 @@ const (
 	MAX_PAYLOAD_SIZE = (1024 * 1024)
 
 	// MAX_PENDING_SIZE is the maximum outbound pending bytes per client.
-	MAX_PENDING_SIZE = (256 * 1024 * 1024)
+	MAX_PENDING_SIZE = (64 * 1024 * 1024)
 
 	// DEFAULT_MAX_CONNECTIONS is the default maximum connections allowed.
 	DEFAULT_MAX_CONNECTIONS = (64 * 1024)


### PR DESCRIPTION
This tries to balance the new decoupled producer consumer architecture for fanout with the ability to utilized coupled feedback in fan in scenarios where slow consumers where becoming the norm.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
