### PR TITLE
add ntp dep to systemd service file

### DIFF
--- a/util/gnatsd.service
+++ b/util/gnatsd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=NATS messaging server
-After=network.target
+After=network.target ntp.service
 
 [Service]
 PrivateTmp=true


### PR DESCRIPTION
### Changes proposed in this pull request:

 - Add ntp service dependant to natsd's systemd file after directive. This is for the reason that natsd relies on time correction.

/cc @nats-io/core
