### PR TITLE
Allow using quotes around include

### DIFF
--- a/conf/lex.go
+++ b/conf/lex.go
@@ -343,7 +343,10 @@ func lexKeyStart(lx *lexer) stateFn {
 func lexDubQuotedKey(lx *lexer) stateFn {
 	r := lx.peek()
 	if r == dqStringEnd {
-		lx.emit(itemKey)
+		include := lx.keyCheckKeyword(nil, nil)
+		if include != nil {
+			return include
+		}
 		lx.next()
 		return lexSkip(lx, lexKeyEnd)
 	} else if r == eof {
@@ -361,7 +364,10 @@ func lexDubQuotedKey(lx *lexer) stateFn {
 func lexQuotedKey(lx *lexer) stateFn {
 	r := lx.peek()
 	if r == sqStringEnd {
-		lx.emit(itemKey)
+		include := lx.keyCheckKeyword(nil, nil)
+		if include != nil {
+			return include
+		}
 		lx.next()
 		return lexSkip(lx, lexKeyEnd)
 	} else if r == eof {
@@ -394,7 +400,7 @@ func (lx *lexer) keyCheckKeyword(fallThrough, push stateFn) stateFn {
 // lexIncludeStart will consume the whitespace til the start of the value.
 func lexIncludeStart(lx *lexer) stateFn {
 	r := lx.next()
-	if isWhitespace(r) {
+	if isWhitespace(r) || r == dqStringEnd || r == sqStringEnd || isKeySeparator(r) {
 		return lexSkip(lx, lexIncludeStart)
 	}
 	lx.backup()
@@ -441,7 +447,7 @@ func lexIncludeString(lx *lexer) stateFn {
 		lx.backup()
 		lx.emit(itemInclude)
 		return lx.pop()
-	case r == sqStringEnd:
+	case r == sqStringEnd || r == dqStringEnd:
 		lx.backup()
 		lx.emit(itemInclude)
 		lx.next()
@@ -668,7 +674,10 @@ func lexMapKeyStart(lx *lexer) stateFn {
 func lexMapQuotedKey(lx *lexer) stateFn {
 	r := lx.peek()
 	if r == sqStringEnd {
-		lx.emit(itemKey)
+		include := lx.keyCheckKeyword(nil, lexMapValueEnd)
+		if include != nil {
+			return include
+		}
 		lx.next()
 		return lexSkip(lx, lexMapKeyEnd)
 	}
@@ -680,7 +689,10 @@ func lexMapQuotedKey(lx *lexer) stateFn {
 func lexMapDubQuotedKey(lx *lexer) stateFn {
 	r := lx.peek()
 	if r == dqStringEnd {
-		lx.emit(itemKey)
+		include := lx.keyCheckKeyword(nil, lexMapValueEnd)
+		if include != nil {
+			return include
+		}
 		lx.next()
 		return lexSkip(lx, lexMapKeyEnd)
 	}


### PR DESCRIPTION
Improves the compatibility with JSON by allowing to use `"include"` directive within quotes.

 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Fixes #801 

/cc @nats-io/core

Signed-off-by: Waldemar Quevedo <wally@synadia.com>