### PR TITLE
Show parse errors from looked up env vars

### DIFF
--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -101,6 +101,37 @@ func TestEnvVariable(t *testing.T) {
 	test(t, fmt.Sprintf("foo = $%s", evar), ex)
 }
 
+func TestEnvVariableString(t *testing.T) {
+	ex := map[string]interface{}{
+		"foo": "xyz",
+	}
+	evar := "__UNIQ22__"
+	os.Setenv(evar, "xyz")
+	defer os.Unsetenv(evar)
+	test(t, fmt.Sprintf("foo = $%s", evar), ex)
+}
+
+func TestEnvVariableStringStartingWithNumber(t *testing.T) {
+	evar := "__UNIQ22__"
+	os.Setenv(evar, "3xyz")
+	defer os.Unsetenv(evar)
+
+	_, err := Parse("foo = $%s")
+	if err == nil {
+		t.Fatalf("Expected err not being able to process string: %v\n", err)
+	}
+}
+
+func TestEnvVariableStringStartingWithNumberUsingQuotes(t *testing.T) {
+	ex := map[string]interface{}{
+		"foo": "3xyz",
+	}
+	evar := "__UNIQ22__"
+	os.Setenv(evar, "'3xyz'")
+	defer os.Unsetenv(evar)
+	test(t, fmt.Sprintf("foo = $%s", evar), ex)
+}
+
 func TestBcryptVariable(t *testing.T) {
 	ex := map[string]interface{}{
 		"password": "$2a$11$ooo",


### PR DESCRIPTION
Currently if there are issues parsing an env var, the config parser fails silently.

 - [X] Related to #885 
 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

/cc @nats-io/core

Signed-off-by: Waldemar Quevedo <wally@synadia.com>