### PR TITLE
Support for unquoted config strings that start with number

### DIFF
--- a/conf/lex_test.go
+++ b/conf/lex_test.go
@@ -87,6 +87,84 @@ func TestComplexStringValues(t *testing.T) {
 	expect(t, lx, expectedItems)
 }
 
+func TestStringStartingWithNumber(t *testing.T) {
+	expectedItems := []item{
+		{itemKey, "foo", 1, 0},
+		{itemString, "3xyz", 1, 6},
+		{itemEOF, "", 2, 0},
+	}
+
+	lx := lex(`foo = 3xyz`)
+	expect(t, lx, expectedItems)
+
+	lx = lex(`foo = 3xyz,`)
+	expect(t, lx, expectedItems)
+
+	lx = lex(`foo = 3xyz;`)
+	expect(t, lx, expectedItems)
+
+	expectedItems = []item{
+		{itemKey, "foo", 2, 9},
+		{itemString, "3xyz", 2, 15},
+		{itemEOF, "", 2, 0},
+	}
+	content := `
+        foo = 3xyz
+        `
+	lx = lex(content)
+	expect(t, lx, expectedItems)
+
+	expectedItems = []item{
+		{itemKey, "map", 2, 9},
+		{itemMapStart, "", 2, 14},
+		{itemKey, "foo", 3, 11},
+		{itemString, "3xyz", 3, 17},
+		{itemMapEnd, "", 3, 22},
+		{itemEOF, "", 2, 0},
+	}
+	content = `
+        map {
+          foo = 3xyz}
+        `
+	lx = lex(content)
+	expect(t, lx, expectedItems)
+
+	expectedItems = []item{
+		{itemKey, "map", 2, 9},
+		{itemMapStart, "", 2, 14},
+		{itemKey, "foo", 3, 11},
+		{itemString, "3xyz", 3, 17},
+		{itemMapEnd, "", 4, 10},
+		{itemEOF, "", 2, 0},
+	}
+	content = `
+        map {
+          foo = 3xyz;
+        }
+        `
+	lx = lex(content)
+	expect(t, lx, expectedItems)
+
+	expectedItems = []item{
+		{itemKey, "map", 2, 9},
+		{itemMapStart, "", 2, 14},
+		{itemKey, "foo", 3, 11},
+		{itemString, "3xyz", 3, 17},
+		{itemKey, "bar", 4, 11},
+		{itemString, "4wqs", 4, 17},
+		{itemMapEnd, "", 5, 10},
+		{itemEOF, "", 2, 0},
+	}
+	content = `
+        map {
+          foo = 3xyz,
+          bar = 4wqs
+        }
+        `
+	lx = lex(content)
+	expect(t, lx, expectedItems)
+}
+
 func TestBinaryString(t *testing.T) {
 	expectedItems := []item{
 		{itemKey, "foo", 1, 0},
@@ -380,7 +458,7 @@ func TestRawString(t *testing.T) {
 	}
 	lx := lex("foo = bar")
 	expect(t, lx, expectedItems)
-	lx = lex(`foo = bar' `) //'single-quote for emacs TODO: Remove me
+	lx = lex(`foo = bar' `)
 	expect(t, lx, expectedItems)
 }
 

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -101,6 +101,37 @@ func TestEnvVariable(t *testing.T) {
 	test(t, fmt.Sprintf("foo = $%s", evar), ex)
 }
 
+func TestEnvVariableString(t *testing.T) {
+	ex := map[string]interface{}{
+		"foo": "xyz",
+	}
+	evar := "__UNIQ22__"
+	os.Setenv(evar, "xyz")
+	defer os.Unsetenv(evar)
+	test(t, fmt.Sprintf("foo = $%s", evar), ex)
+}
+
+func TestEnvVariableStringStartingWithNumber(t *testing.T) {
+	evar := "__UNIQ22__"
+	os.Setenv(evar, "3xyz")
+	defer os.Unsetenv(evar)
+
+	_, err := Parse("foo = $%s")
+	if err == nil {
+		t.Fatalf("Expected err not being able to process string: %v\n", err)
+	}
+}
+
+func TestEnvVariableStringStartingWithNumberUsingQuotes(t *testing.T) {
+	ex := map[string]interface{}{
+		"foo": "3xyz",
+	}
+	evar := "__UNIQ22__"
+	os.Setenv(evar, "'3xyz'")
+	defer os.Unsetenv(evar)
+	test(t, fmt.Sprintf("foo = $%s", evar), ex)
+}
+
 func TestBcryptVariable(t *testing.T) {
 	ex := map[string]interface{}{
 		"password": "$2a$11$ooo",


### PR DESCRIPTION
Fixes parser to support string values that are not within quotes.

```hcl
authorization {
  user = 3hello
  pass = 4world
}
```

Before it used to fail with an error as follows:

```
nats-server: Parse error on line 2: 'Expected a map value terminator "," or a map terminator "}", but got 'h' instead.'
```

 - [X] Documentation added (if applicable)
 - [X] Tests added
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Fixes #885 

/cc @nats-io/core
