### PR TITLE
Some Optimizations

### DIFF
--- a/server/client_test.go
+++ b/server/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2018 The NATS Authors
+// Copyright 2012-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -966,8 +966,8 @@ func TestDynamicBuffers(t *testing.T) {
 	}
 
 	// Create some helper functions and data structures.
-	done := make(chan bool)          // Used to stop recording.
-	type maxv struct{ rsz, wsz int } // Used to hold max values.
+	done := make(chan bool)            // Used to stop recording.
+	type maxv struct{ rsz, wsz int32 } // Used to hold max values.
 	results := make(chan maxv)
 
 	// stopRecording stops the recording ticker and releases go routine.
@@ -976,14 +976,14 @@ func TestDynamicBuffers(t *testing.T) {
 		return <-results
 	}
 	// max just grabs max values.
-	max := func(a, b int) int {
+	max := func(a, b int32) int32 {
 		if a > b {
 			return a
 		}
 		return b
 	}
 	// Returns current value of the buffer sizes.
-	getBufferSizes := func() (int, int) {
+	getBufferSizes := func() (int32, int32) {
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		return c.in.rsz, c.out.sz
@@ -1013,7 +1013,7 @@ func TestDynamicBuffers(t *testing.T) {
 		}
 	}
 	// Check that the current value is what we expected.
-	checkBuffers := func(ers, ews int) {
+	checkBuffers := func(ers, ews int32) {
 		t.Helper()
 		rsz, wsz := getBufferSizes()
 		if rsz != ers {
@@ -1025,7 +1025,7 @@ func TestDynamicBuffers(t *testing.T) {
 	}
 
 	// Check that the max was as expected.
-	checkResults := func(m maxv, rsz, wsz int) {
+	checkResults := func(m maxv, rsz, wsz int32) {
 		t.Helper()
 		if rsz != m.rsz {
 			t.Fatalf("Expected read buffer of %d, but got %d\n", rsz, m.rsz)

--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.0.0-RC2"
+	VERSION = "2.0.0-RC3"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/events.go
+++ b/server/events.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The NATS Authors
+// Copyright 2018-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -632,12 +632,12 @@ func (s *Server) remoteConnsUpdate(sub *subscription, subject, reply string, msg
 	// If we are here we have interest in tracking this account. Update our accounting.
 	acc.mu.Lock()
 	if acc.strack == nil {
-		acc.strack = make(map[string]int)
+		acc.strack = make(map[string]int32)
 	}
 	// This does not depend on receiving all updates since each one is idempotent.
 	prev := acc.strack[m.Server.ID]
-	acc.strack[m.Server.ID] = m.Conns
-	acc.nrclients += (m.Conns - prev)
+	acc.strack[m.Server.ID] = int32(m.Conns)
+	acc.nrclients += int32(m.Conns) - prev
 	acc.mu.Unlock()
 
 	s.updateRemoteServer(&m.Server)

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The NATS Authors
+// Copyright 2018-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -2070,7 +2070,7 @@ func (c *client) processInboundGatewayMsg(msg []byte) {
 	// Update statistics
 	c.in.msgs++
 	// The msg includes the CR_LF, so pull back out for accounting.
-	c.in.bytes += len(msg) - LEN_CR_LF
+	c.in.bytes += int32(len(msg) - LEN_CR_LF)
 
 	if c.trace {
 		c.traceMsg(msg)

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2018 The NATS Authors
+// Copyright 2013-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -384,7 +384,7 @@ func (ci *ConnInfo) fill(client *client, nc net.Conn, now time.Time) {
 	}
 
 	if client.port != 0 {
-		ci.Port = client.port
+		ci.Port = int(client.port)
 		ci.IP = client.host
 	}
 }
@@ -920,7 +920,7 @@ func (s *Server) Varz(varzOpts *VarzOptions) (*Varz, error) {
 	// Snapshot server options.
 	opts := s.getOpts()
 
-	v := &Varz{Info: &s.info, Options: opts, MaxPayload: opts.MaxPayload, Start: s.start}
+	v := &Varz{Info: &s.info, Options: opts, MaxPayload: int(opts.MaxPayload), Start: s.start}
 	v.Now = time.Now()
 	v.Uptime = myUptime(time.Since(s.start))
 	v.Port = v.Info.Port

--- a/server/opts.go
+++ b/server/opts.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2018 The NATS Authors
+// Copyright 2012-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -105,8 +105,8 @@ type Options struct {
 	HTTPPort         int           `json:"http_port"`
 	HTTPSPort        int           `json:"https_port"`
 	AuthTimeout      float64       `json:"auth_timeout"`
-	MaxControlLine   int           `json:"max_control_line"`
-	MaxPayload       int           `json:"max_payload"`
+	MaxControlLine   int32         `json:"max_control_line"`
+	MaxPayload       int32         `json:"max_payload"`
 	MaxPending       int64         `json:"max_pending"`
 	Cluster          ClusterOpts   `json:"cluster,omitempty"`
 	Gateway          GatewayOpts   `json:"gateway,omitempty"`
@@ -442,9 +442,19 @@ func (o *Options) ProcessConfigFile(configFile string) error {
 		case "prof_port":
 			o.ProfPort = int(v.(int64))
 		case "max_control_line":
-			o.MaxControlLine = int(v.(int64))
+			if v.(int64) > 1<<31-1 {
+				err := &configErr{tk, fmt.Sprintf("%s value is too big", k)}
+				errors = append(errors, err)
+				continue
+			}
+			o.MaxControlLine = int32(v.(int64))
 		case "max_payload":
-			o.MaxPayload = int(v.(int64))
+			if v.(int64) > 1<<31-1 {
+				err := &configErr{tk, fmt.Sprintf("%s value is too big", k)}
+				errors = append(errors, err)
+				continue
+			}
+			o.MaxPayload = int32(v.(int64))
 		case "max_pending":
 			o.MaxPending = v.(int64)
 		case "max_connections", "max_conn":

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2018 The NATS Authors
+// Copyright 2012-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -1706,5 +1706,33 @@ func TestParsingGatewaysErrors(t *testing.T) {
 				t.Fatalf("Expected error containing %q, got %q, for content:\n%s\n", test.expectedErr, err, test.content)
 			}
 		})
+	}
+}
+
+func TestLargeMaxControlLine(t *testing.T) {
+	confFileName := "big_mcl.conf"
+	defer os.Remove(confFileName)
+	content := `
+    max_control_line = 3000000000
+    `
+	if err := ioutil.WriteFile(confFileName, []byte(content), 0666); err != nil {
+		t.Fatalf("Error writing config file: %v", err)
+	}
+	if _, err := ProcessConfigFile(confFileName); err == nil {
+		t.Fatalf("Expected an error from too large of a max_control_line entry")
+	}
+}
+
+func TestLargeMaxPayload(t *testing.T) {
+	confFileName := "big_mp.conf"
+	defer os.Remove(confFileName)
+	content := `
+    max_payload = 3000000000
+    `
+	if err := ioutil.WriteFile(confFileName, []byte(content), 0666); err != nil {
+		t.Fatalf("Error writing config file: %v", err)
+	}
+	if _, err := ProcessConfigFile(confFileName); err == nil {
+		t.Fatalf("Expected an error from too large of a max_payload entry")
 	}
 }

--- a/server/parser.go
+++ b/server/parser.go
@@ -808,7 +808,7 @@ func (c *client) parse(buf []byte) error {
 		// Check for violations of control line length here. Note that this is not
 		// exact at all but the performance hit is too great to be precise, and
 		// catching here should prevent memory exhaustion attacks.
-		if len(c.argBuf) > mcl {
+		if len(c.argBuf) > int(mcl) {
 			c.sendErr("Maximum Control Line Exceeded")
 			c.closeConnection(MaxControlLineExceeded)
 			return ErrMaxControlLine

--- a/server/parser_test.go
+++ b/server/parser_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func dummyClient() *client {
-	return &client{srv: New(&defaultServerOptions), msubs: -1, mpay: -1}
+	return &client{srv: New(&defaultServerOptions), msubs: -1, mpay: -1, mcl: MAX_CONTROL_LINE_SIZE}
 }
 
 func dummyRouteClient() *client {
@@ -578,7 +578,7 @@ func TestParseOK(t *testing.T) {
 
 func TestMaxControlLine(t *testing.T) {
 	c := dummyClient()
-	c.srv.opts.MaxControlLine = 8
+	c.mcl = 8
 
 	pub := []byte("PUB foo.bar 11\r")
 	err := c.parse(pub)

--- a/server/reload.go
+++ b/server/reload.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 The NATS Authors
+// Copyright 2017-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -399,7 +399,7 @@ func (p *portsFileDirOption) Apply(server *Server) {
 // `max_control_line` setting.
 type maxControlLineOption struct {
 	noopOption
-	newValue int
+	newValue int32
 }
 
 // Apply is a no-op because the max control line will be reloaded after options
@@ -412,7 +412,7 @@ func (m *maxControlLineOption) Apply(server *Server) {
 // setting.
 type maxPayloadOption struct {
 	noopOption
-	newValue int
+	newValue int32
 }
 
 // Apply the setting by updating the server info and each client.
@@ -661,9 +661,9 @@ func (s *Server) diffOptions(newOpts *Options) ([]option, error) {
 		case "portsfiledir":
 			diffOpts = append(diffOpts, &portsFileDirOption{newValue: newValue.(string), oldValue: oldValue.(string)})
 		case "maxcontrolline":
-			diffOpts = append(diffOpts, &maxControlLineOption{newValue: newValue.(int)})
+			diffOpts = append(diffOpts, &maxControlLineOption{newValue: newValue.(int32)})
 		case "maxpayload":
-			diffOpts = append(diffOpts, &maxPayloadOption{newValue: newValue.(int)})
+			diffOpts = append(diffOpts, &maxPayloadOption{newValue: newValue.(int32)})
 		case "pinginterval":
 			diffOpts = append(diffOpts, &pingIntervalOption{newValue: newValue.(time.Duration)})
 		case "maxpingsout":

--- a/server/route.go
+++ b/server/route.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2018 The NATS Authors
+// Copyright 2013-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -238,7 +238,7 @@ func (c *client) processInboundRoutedMsg(msg []byte) {
 	// Update statistics
 	c.in.msgs++
 	// The msg includes the CR_LF, so pull back out for accounting.
-	c.in.bytes += len(msg) - LEN_CR_LF
+	c.in.bytes += int32(len(msg) - LEN_CR_LF)
 
 	if c.trace {
 		c.traceMsg(msg)
@@ -1268,14 +1268,14 @@ func (s *Server) updateRouteSubscriptionMap(acc *Account, sub *subscription, del
 	var (
 		_rkey [1024]byte
 		key   []byte
-		qi    int
+		qi    int32
 	)
 	if sub.queue != nil {
 		// Just make the key subject spc group, e.g. 'foo bar'
 		key = _rkey[:0]
 		key = append(key, sub.subject...)
 		key = append(key, byte(' '))
-		qi = len(key)
+		qi = int32(len(key))
 		key = append(key, sub.queue...)
 	} else {
 		key = sub.subject

--- a/server/server.go
+++ b/server/server.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2018 The NATS Authors
+// Copyright 2012-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -60,7 +60,7 @@ type Info struct {
 	AuthRequired      bool     `json:"auth_required,omitempty"`
 	TLSRequired       bool     `json:"tls_required,omitempty"`
 	TLSVerify         bool     `json:"tls_verify,omitempty"`
-	MaxPayload        int      `json:"max_payload"`
+	MaxPayload        int32    `json:"max_payload"`
 	IP                string   `json:"ip,omitempty"`
 	CID               uint64   `json:"client_id,omitempty"`
 	Nonce             string   `json:"nonce,omitempty"`
@@ -1375,7 +1375,7 @@ func (s *Server) createClient(conn net.Conn) *client {
 	opts := s.getOpts()
 
 	maxPay := int32(opts.MaxPayload)
-	maxSubs := opts.MaxSubs
+	maxSubs := int32(opts.MaxSubs)
 	// For system, maxSubs of 0 means unlimited, so re-adjust here.
 	if maxSubs == 0 {
 		maxSubs = -1

--- a/server/split_test.go
+++ b/server/split_test.go
@@ -30,7 +30,7 @@ func TestSplitBufferSubOp(t *testing.T) {
 	}
 	s := &Server{gacc: NewAccount(globalAccountName), accounts: make(map[string]*Account), gateway: gws}
 	s.registerAccount(s.gacc)
-	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, subs: make(map[string]*subscription), nc: cli}
+	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription), nc: cli}
 
 	subop := []byte("SUB foo 1\r\n")
 	subop1 := subop[:6]
@@ -67,7 +67,7 @@ func TestSplitBufferSubOp(t *testing.T) {
 func TestSplitBufferUnsubOp(t *testing.T) {
 	s := &Server{gacc: NewAccount(globalAccountName), accounts: make(map[string]*Account), gateway: &srvGateway{}}
 	s.registerAccount(s.gacc)
-	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, subs: make(map[string]*subscription)}
+	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
 
 	subop := []byte("SUB foo 1024\r\n")
 	if err := c.parse(subop); err != nil {
@@ -100,7 +100,7 @@ func TestSplitBufferUnsubOp(t *testing.T) {
 }
 
 func TestSplitBufferPubOp(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, subs: make(map[string]*subscription)}
+	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
 	pub := []byte("PUB foo.bar INBOX.22 11\r\nhello world\r")
 	pub1 := pub[:2]
 	pub2 := pub[2:9]
@@ -166,7 +166,7 @@ func TestSplitBufferPubOp(t *testing.T) {
 }
 
 func TestSplitBufferPubOp2(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, subs: make(map[string]*subscription)}
+	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
 	pub := []byte("PUB foo.bar INBOX.22 11\r\nhello world\r\n")
 	pub1 := pub[:30]
 	pub2 := pub[30:]
@@ -186,7 +186,7 @@ func TestSplitBufferPubOp2(t *testing.T) {
 }
 
 func TestSplitBufferPubOp3(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, subs: make(map[string]*subscription)}
+	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
 	pubAll := []byte("PUB foo bar 11\r\nhello world\r\n")
 	pub := pubAll[:16]
 
@@ -212,7 +212,7 @@ func TestSplitBufferPubOp3(t *testing.T) {
 }
 
 func TestSplitBufferPubOp4(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, subs: make(map[string]*subscription)}
+	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
 	pubAll := []byte("PUB foo 11\r\nhello world\r\n")
 	pub := pubAll[:12]
 
@@ -238,7 +238,7 @@ func TestSplitBufferPubOp4(t *testing.T) {
 }
 
 func TestSplitBufferPubOp5(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, subs: make(map[string]*subscription)}
+	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
 	pubAll := []byte("PUB foo 11\r\nhello world\r\n")
 
 	// Splits need to be on MSG_END_R now too, so make sure we check that.
@@ -257,7 +257,7 @@ func TestSplitBufferPubOp5(t *testing.T) {
 }
 
 func TestSplitConnectArg(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, subs: make(map[string]*subscription)}
+	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
 	connectAll := []byte("CONNECT {\"verbose\":false,\"tls_required\":false," +
 		"\"user\":\"test\",\"pedantic\":true,\"pass\":\"pass\"}\r\n")
 
@@ -306,7 +306,7 @@ func TestSplitConnectArg(t *testing.T) {
 
 func TestSplitDanglingArgBuf(t *testing.T) {
 	s := New(&defaultServerOptions)
-	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, subs: make(map[string]*subscription)}
+	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
 
 	// We test to make sure we do not dangle any argBufs after processing
 	// since that could lead to performance issues.
@@ -445,7 +445,7 @@ func TestSplitRoutedMsgArg(t *testing.T) {
 }
 
 func TestSplitBufferMsgOp(t *testing.T) {
-	c := &client{msubs: -1, mpay: -1, subs: make(map[string]*subscription), kind: ROUTER}
+	c := &client{msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription), kind: ROUTER}
 	msg := []byte("RMSG $G foo.bar _INBOX.22 11\r\nhello world\r")
 	msg1 := msg[:2]
 	msg2 := msg[2:9]


### PR DESCRIPTION
1. Change outbound client structure to be smaller and more cache friendly.
2. Snapshot MaxControlLine into client structure (mcl) to avoid server opts lookup.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
