### PR TITLE
Add go import path for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
 - 1.10.x
 - 1.11.x
+go_import_path: github.com/nats-io/gnatsd
 install:
 - go get github.com/nats-io/go-nats
 - go get github.com/nats-io/nkeys


### PR DESCRIPTION
This allows being able to run test builds when forking the repo.

Signed-off-by: Waldemar Quevedo <wally@synadia.com>

/cc @nats-io/core
