### PR TITLE
Added type safety to Parser state

### DIFF
--- a/server/parser.go
+++ b/server/parser.go
@@ -28,8 +28,9 @@ type pubArg struct {
 	size    int
 }
 
+type parserState int
 type parseState struct {
-	state   int
+	state   parserState
 	as      int
 	drop    int
 	pa      pubArg
@@ -40,7 +41,7 @@ type parseState struct {
 
 // Parser constants
 const (
-	OP_START = iota
+	OP_START parserState = iota
 	OP_PLUS
 	OP_PLUS_O
 	OP_PLUS_OK
@@ -205,7 +206,7 @@ func (c *client) parse(buf []byte) error {
 				if err := c.processPub(c.trace, arg); err != nil {
 					return err
 				}
-				c.drop, c.as, c.state = OP_START, i+1, MSG_PAYLOAD
+				c.drop, c.as, c.state = 0, i+1, MSG_PAYLOAD
 				// If we don't have a saved buffer then jump ahead with
 				// the index. If this overruns what is left we fall out
 				// and process split buffer.


### PR DESCRIPTION
 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [x] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [x] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [x] Build is green in Travis CI
 - [x] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #

### Changes proposed in this pull request:

Added compile type safety for internal parser state. Uncovered single buggy behavior on line 209 (( drop should probably not be set to OP_START but 0, which OP_START has a value of in this case )) 

Furthermore, this change helps the debugger too, since the state isn't a naked int debug resolves the constant appropriately in debugging view (( for goland at least )). Makes it easier to follow through parser code. 
 -
 -
 -

/cc @nats-io/core
