### PR TITLE
New options for TLS quick start

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ Cluster Options:
         --cluster <cluster-url>      Cluster URL for solicited routes
         --no_advertise <bool>        Advertise known cluster IPs to clients
         --cluster_advertise <string> Cluster URL to advertise to other servers
-        --cluster_tls_insecure       Skip DNS/IP certificate checks in router interconnections.
+        --cluster_tls_insecure       Skip verification of the route's certificate chain and hostname.
         --connect_retries <number>   For implicit routes, number of connect retries
 
 

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ Cluster Options:
         --cluster <cluster-url>      Cluster URL for solicited routes
         --no_advertise <bool>        Advertise known cluster IPs to clients
         --cluster_advertise <string> Cluster URL to advertise to other servers
+        --cluster_tls_insecure       Skip DNS/IP certificate checks in router interconnections.
         --connect_retries <number>   For implicit routes, number of connect retries
 
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -1855,7 +1855,7 @@ func parseTLS(v interface{}) (*TLSConfigOpts, error) {
 		case "insecure":
 			insecure, ok := mv.(bool)
 			if !ok {
-				return nil, &configErr{tk, fmt.Sprintf("error parsing tls config, expected 'tls_insecure' to be a boolean")}
+				return nil, &configErr{tk, fmt.Sprintf("error parsing tls config, expected 'insecure' to be a boolean")}
 			}
 			tc.TLSInsecure = insecure
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -2492,7 +2492,7 @@ func overrideTLS(opts *Options) error {
 	return err
 }
 
-// overrideCluster updates Options.Cluster if that flag "cluster" (or "cluster_listen",)
+// overrideCluster updates Options.Cluster if that flag "cluster" (or "cluster_listen")
 // has explicitly be set in the command line. If it is set to empty string, it will
 // clear the Cluster options.
 func overrideCluster(opts *Options) error {


### PR DESCRIPTION
New --cluster_tls_insecure command line options and appropriate cluster.tls.insecure config file one to enable easier tls routes interconnection.

This will helps to fast start when you got following errors:
* TLS route handshake error: x509: certificate is valid for ****
* TLS route handshake error: x509: cannot validate certificate for **** because it doesn't contain any IP SANs