### PR TITLE
Gateways: Rework Account Sub/Unsub

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -243,8 +243,6 @@ func NewServer(opts *Options) (*Server, error) {
 	// Call this even if there is no gateway defined. It will
 	// initialize the structure so we don't have to check for
 	// it to be nil or not in various places in the code.
-	// Do this before calling registerAccount() since registerAccount
-	// may try to send things to gateways.
 	gws, err := newGateway(opts)
 	if err != nil {
 		return nil, err
@@ -695,11 +693,6 @@ func (s *Server) registerAccount(acc *Account) {
 	acc.srv = s
 	acc.mu.Unlock()
 	s.accounts[acc.Name] = acc
-	if s.gateway.enabled {
-		// Check and possibly send an A+ to gateways for which
-		// we had sent an A- because account did not exist at that time.
-		s.endAccountNoInterestForGateways(acc.Name)
-	}
 	s.enableAccountTracking(acc)
 }
 

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -144,6 +144,13 @@ func TestSendRouteSubAndUnsub(t *testing.T) {
 	routeSend("PING\r\n")
 	routeExpect(pongRe)
 
+	// Routes now send their subs list from a go routine,
+	// so it is possible that if we don't wait we get
+	// the client SUB being forwarded, then for the UNSUB,
+	// we get the go routine kicking-in and send the SUB again
+	// (which is ok since it is idempotent on the receiving side)
+	time.Sleep(100 * time.Millisecond)
+
 	// Send SUB via client connection
 	send("SUB foo 22\r\n")
 

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -364,26 +364,25 @@ func TestTLSGatewaysCertificateCNBasedAuth(t *testing.T) {
 	optsC.Gateway.Name = "C"
 	optsC.Gateway.Port = 9997
 
-	routes := make([]*url.URL, 3)
-	routes[0] = gwA
-	routes[1] = gwB
-	routes[2] = gwC
 	gateways := make([]*server.RemoteGatewayOpts, 3)
 	gateways[0] = &server.RemoteGatewayOpts{
 		Name: optsA.Gateway.Name,
-		URLs: routes,
+		URLs: []*url.URL{gwA},
 	}
 	gateways[1] = &server.RemoteGatewayOpts{
 		Name: optsB.Gateway.Name,
-		URLs: routes,
+		URLs: []*url.URL{gwB},
 	}
 	gateways[2] = &server.RemoteGatewayOpts{
 		Name: optsC.Gateway.Name,
-		URLs: routes,
+		URLs: []*url.URL{gwC},
 	}
 	optsA.Gateway.Gateways = gateways
 	optsB.Gateway.Gateways = gateways
 	optsC.Gateway.Gateways = gateways
+
+	server.SetGatewaysSolicitDelay(100 * time.Millisecond)
+	defer server.ResetGatewaysSolicitDelay()
 
 	srvA := RunServer(optsA)
 	defer srvA.Shutdown()


### PR DESCRIPTION
We now send A- if an account does not exists, or if there is no
interest on a given subject and no existing subscription.
An A+ is sent if an A- was previously sent and a subscription
for this account is registered.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
