### PR TITLE
Sends ROUTE subs from go routine only if more than a threshold

### DIFF
--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -144,13 +144,6 @@ func TestSendRouteSubAndUnsub(t *testing.T) {
 	routeSend("PING\r\n")
 	routeExpect(pongRe)
 
-	// Routes now send their subs list from a go routine,
-	// so it is possible that if we don't wait we get
-	// the client SUB being forwarded, then for the UNSUB,
-	// we get the go routine kicking-in and send the SUB again
-	// (which is ok since it is idempotent on the receiving side)
-	time.Sleep(100 * time.Millisecond)
-
 	// Send SUB via client connection
 	send("SUB foo 22\r\n")
 


### PR DESCRIPTION
There is really no need to use a go routine if the number is rather
small. Use a threshold to decide if the send is happening in a
go routine or in place. Eliminates flapping route tests.

Related to #912

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
