### PR TITLE
Allow explicit server name in tls.Config

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -631,14 +631,16 @@ func (s *Server) createGateway(cfg *gatewayCfg, url *url.URL, conn net.Conn) {
 			tlsConfig := cfg.TLSConfig
 			timeout = cfg.TLSTimeout
 			cfg.RUnlock()
-			// If the given url is a hostname, use this hostname for the
-			// ServerName. If it is an IP, use the cfg's tlsName. If none
-			// is available, resort to current IP.
-			host := url.Hostname()
-			if tlsName != "" && net.ParseIP(host) != nil {
-				host = tlsName
+			if tlsConfig.ServerName == "" {
+				// If the given url is a hostname, use this hostname for the
+				// ServerName. If it is an IP, use the cfg's tlsName. If none
+				// is available, resort to current IP.
+				host := url.Hostname()
+				if tlsName != "" && net.ParseIP(host) != nil {
+					host = tlsName
+				}
+				tlsConfig.ServerName = host
 			}
-			tlsConfig.ServerName = host
 			c.nc = tls.Client(c.nc, tlsConfig)
 		} else {
 			c.Debugf("Starting TLS gateway server handshake")


### PR DESCRIPTION
 - [ ] Link to issue, e.g. `Resolves #NNN`
 - [ ] Documentation added (if applicable)
 - [ ] Tests added
 - [ ] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [ ] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [ ] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

### Changes proposed in this pull request:

- The `ServerName` member of the `tls.Config` struct will not be overridden when connecting to a gateway if the provided `tls.Config` struct already has a value set.

#### Rationale

(same basic deal as https://github.com/nats-io/nats-streaming-server/pull/767)

I am integrating NATS into Chef's Automate product. Automate internally has a Microservices architecture with connections between services secured by mutual TLS cert verification. Automate is usually deployed by our customers on their own infrastructure so we have elected not to rely on using hostnames in our certificates' CN fields; instead we use the internal service names (i.e., something like event-service instead of host.example.com).

This already works for NATS go clients using the option to set a custom `tls.Config` but when using the gateway feature, the `ServerName` is getting overwritten.

Happy to look into adding tests if this approach to solving the problem looks good.

/cc @nats-io/core