### PR TITLE
Conditional send of routed subs from a go routine

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"net"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -824,6 +825,13 @@ func (c *client) handlePartialWrite(pnb net.Buffers) {
 // Lock must be held
 func (c *client) flushOutbound() bool {
 	if c.flags.isSet(flushOutbound) {
+		// Another go-routine has set this and is either
+		// doing the write or waiting to re-acquire the
+		// lock post write. Release lock to give it a
+		// chance to complete.
+		c.mu.Unlock()
+		runtime.Gosched()
+		c.mu.Lock()
 		return false
 	}
 	c.flags.set(flushOutbound)

--- a/server/route.go
+++ b/server/route.go
@@ -1032,15 +1032,7 @@ func (c *client) sendRouteSubOrUnSubProtos(subs []*subscription, isSubProto, tra
 			// the lock, which could cause pingTimer to think that this
 			// connection is stale otherwise.
 			c.last = time.Now()
-			if !c.flushOutbound() {
-				// It means that we could not flush because another go
-				// routine (likely the writeLoop) is doing (or is done with)
-				// the socket write and is waiting for the lock. Give it
-				// a chance to complete its operation by releasing
-				// the lock here.
-				c.mu.Unlock()
-				c.mu.Lock()
-			}
+			c.flushOutbound()
 			if closed = c.flags.isSet(clearConnection); closed {
 				break
 			}

--- a/test/routes_test.go
+++ b/test/routes_test.go
@@ -144,13 +144,6 @@ func TestSendRouteSubAndUnsub(t *testing.T) {
 	routeSend("PING\r\n")
 	routeExpect(pongRe)
 
-	// Routes now send their subs list from a go routine,
-	// so it is possible that if we don't wait we get
-	// the client SUB being forwarded, then for the UNSUB,
-	// we get the go routine kicking-in and send the SUB again
-	// (which is ok since it is idempotent on the receiving side)
-	time.Sleep(100 * time.Millisecond)
-
 	// Send SUB via client connection
 	send("SUB foo 22\r\n")
 


### PR DESCRIPTION
When a route is established, it is possible that each server sends
its list of subscriptions to each other at the same time. Doing
it in place from the readLoop could then cause problems because
each side could reach a point where the outbound socket buffer
is full and no one is dequeuing data (since readLoop is doing
the send of the subs list).
We changed sending this list from a go routine. However, for small
number of subscriptions, it is not required and was causing some
of the tests to fail because of timing issues.

We will now send in place if the estimated size of all protocols
is below a give threshold (1MB).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
