### PR TITLE
LeafNode: support for advertise

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -2948,7 +2948,6 @@ func (c *client) closeConnection(reason ClosedState) {
 		}
 	} else if c.isSolicitedLeafNode() {
 		// Check if this is a solicited leaf node. Start up a reconnect.
-		// FIXME(dlc) - use the connectedURLs info like a normal client.
 		srv.startGoRoutine(func() { srv.reConnectToRemoteLeafNode(c.leaf.remote) })
 	}
 }

--- a/server/const.go
+++ b/server/const.go
@@ -112,6 +112,9 @@ const (
 	// DEFAULT_ROUTE_DIAL Route dial timeout.
 	DEFAULT_ROUTE_DIAL = 1 * time.Second
 
+	// DEFAULT_LEAF_NODE_RECONNECT LeafNode reconnect interval.
+	DEFAULT_LEAF_NODE_RECONNECT = time.Second
+
 	// PROTO_SNIPPET_SIZE is the default size of proto to print on parse errors.
 	PROTO_SNIPPET_SIZE = 32
 

--- a/server/opts.go
+++ b/server/opts.go
@@ -82,17 +82,18 @@ type RemoteGatewayOpts struct {
 
 // LeafNodeOpts are options for a given server to accept leaf node connections and/or connect to a remote cluster.
 type LeafNodeOpts struct {
-	Host        string            `json:"addr,omitempty"`
-	Port        int               `json:"port,omitempty"`
-	Username    string            `json:"-"`
-	Password    string            `json:"-"`
-	AuthTimeout float64           `json:"auth_timeout,omitempty"`
-	TLSConfig   *tls.Config       `json:"-"`
-	TLSTimeout  float64           `json:"tls_timeout,omitempty"`
-	TLSMap      bool              `json:"-"`
-	Remotes     []*RemoteLeafOpts `json:"remotes,omitempty"`
-	Advertise   string            `json:"-"`
-	NoAdvertise bool              `json:"-"`
+	Host              string            `json:"addr,omitempty"`
+	Port              int               `json:"port,omitempty"`
+	Username          string            `json:"-"`
+	Password          string            `json:"-"`
+	AuthTimeout       float64           `json:"auth_timeout,omitempty"`
+	TLSConfig         *tls.Config       `json:"-"`
+	TLSTimeout        float64           `json:"tls_timeout,omitempty"`
+	TLSMap            bool              `json:"-"`
+	Remotes           []*RemoteLeafOpts `json:"remotes,omitempty"`
+	Advertise         string            `json:"-"`
+	NoAdvertise       bool              `json:"-"`
+	ReconnectInterval time.Duration     `json:"-"`
 }
 
 // RemoteLeafOpts are options for connecting to a remote server as a leaf node.

--- a/server/server.go
+++ b/server/server.go
@@ -77,6 +77,9 @@ type Info struct {
 	GatewayURL        string   `json:"gateway_url,omitempty"`         // Gateway URL on that server (sent by route's INFO)
 	GatewayCmd        byte     `json:"gateway_cmd,omitempty"`         // Command code for the receiving server to know what to do
 	GatewayCmdPayload []byte   `json:"gateway_cmd_payload,omitempty"` // Command payload when needed
+
+	// LeafNode Specific
+	LeafNodeURLs []string `json:"leafnode_urls,omitempty"` // LeafNode URLs that the server can reconnect to.
 }
 
 // Server is our main struct.
@@ -932,6 +935,8 @@ func (s *Server) Start() {
 		// Spin up the accept loop if needed
 		ch := make(chan struct{})
 		go s.leafNodeAcceptLoop(ch)
+		// This ensure that we have resolved or assigned the advertise
+		// address for the leafnode listener. We need that in StartRouting().
 		<-ch
 	}
 


### PR DESCRIPTION
A server that creates a LeafNode connection to a remote cluster
will now be notified of all possible LeafNode URLs in that cluster.
The list is updated when nodes in the cluster come and go.

Also support for advertise address, similar to cluster, gateway, etc..

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
