### PR TITLE
Fix the mkpasswd utility on Windows

### DIFF
--- a/util/mkpasswd.go
+++ b/util/mkpasswd.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"syscall"
 
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/ssh/terminal"
@@ -53,9 +54,15 @@ func main() {
 
 	if *pw {
 		fmt.Printf("Enter Password: ")
-		bytePassword, _ := terminal.ReadPassword(0)
+		bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			log.Fatalf("Error reading password: %v\n", err)
+		}
 		fmt.Printf("\nReenter Password: ")
-		bytePassword2, _ := terminal.ReadPassword(0)
+		bytePassword2, err := terminal.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			log.Fatalf("Error reading password: %v\n", err)
+		}
 		if !bytes.Equal(bytePassword, bytePassword2) {
 			log.Fatalf("Error, passwords do not match\n")
 		}


### PR DESCRIPTION
Fix the mkpasswd utility on Windows.

 - [X] Link to issue, e.g. `Resolves #NNN`
 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

Resolves #934 

### Changes proposed in this pull request:
Unlike other platforms, on windows the fd of `0` is an invalid handle. This was causing `terminal.ReadPassword` to fail resulting in the behavior that was described in #934.  Instead pass  `syscall.Stdin`.

Tested on windows and darwin.

/cc @nats-io/core
