### PR TITLE
LeafNode: do hostname resolution and get random one from result

### DIFF
--- a/server/leafnode_test.go
+++ b/server/leafnode_test.go
@@ -1,0 +1,75 @@
+// Copyright 2019 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+type captureLeafNodeRandomIPLogger struct {
+	DummyLogger
+	ch  chan struct{}
+	ips [3]int
+}
+
+func (c *captureLeafNodeRandomIPLogger) Debugf(format string, v ...interface{}) {
+	msg := fmt.Sprintf(format, v...)
+	if strings.Contains(msg, "hostname_to_resolve") {
+		ippos := strings.Index(msg, "127.0.0.")
+		if ippos != -1 {
+			n := int(msg[ippos+8] - '1')
+			c.ips[n]++
+			for _, v := range c.ips {
+				if v < 2 {
+					return
+				}
+			}
+			// All IPs got at least some hit, we are done.
+			c.ch <- struct{}{}
+		}
+	}
+}
+
+func TestLeafNodeRandomIP(t *testing.T) {
+	u, err := url.Parse("nats://hostname_to_resolve:1234")
+	if err != nil {
+		t.Fatalf("Error parsing: %v", err)
+	}
+
+	resolver := &myDummyDNSResolver{ips: []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"}}
+
+	o := DefaultOptions()
+	o.Host = "127.0.0.1"
+	o.Port = -1
+	o.LeafNode.Port = 0
+	o.LeafNode.Remotes = []*RemoteLeafOpts{&RemoteLeafOpts{URL: u}}
+	o.LeafNode.ReconnectInterval = 50 * time.Millisecond
+	o.LeafNode.resolver = resolver
+	o.LeafNode.dialTimeout = 15 * time.Millisecond
+	s := RunServer(o)
+	defer s.Shutdown()
+
+	l := &captureLeafNodeRandomIPLogger{ch: make(chan struct{})}
+	s.SetLogger(l, true, true)
+
+	select {
+	case <-l.ch:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("Does not seem to have used random IPs")
+	}
+}

--- a/server/opts.go
+++ b/server/opts.go
@@ -94,6 +94,10 @@ type LeafNodeOpts struct {
 	Advertise         string            `json:"-"`
 	NoAdvertise       bool              `json:"-"`
 	ReconnectInterval time.Duration     `json:"-"`
+
+	// Not exported, for tests.
+	resolver    netResolver
+	dialTimeout time.Duration
 }
 
 // RemoteLeafOpts are options for connecting to a remote server as a leaf node.
@@ -2366,6 +2370,10 @@ func setBaselineOptions(opts *Options) {
 		if opts.LeafNode.AuthTimeout == 0 {
 			opts.LeafNode.AuthTimeout = float64(AUTH_TIMEOUT) / float64(time.Second)
 		}
+	}
+	// Set this regardless of opts.LeafNode.Port
+	if opts.LeafNode.ReconnectInterval == 0 {
+		opts.LeafNode.ReconnectInterval = DEFAULT_LEAF_NODE_RECONNECT
 	}
 	if opts.MaxControlLine == 0 {
 		opts.MaxControlLine = MAX_CONTROL_LINE_SIZE

--- a/server/opts_test.go
+++ b/server/opts_test.go
@@ -56,6 +56,9 @@ func TestDefaultOptions(t *testing.T) {
 		WriteDeadline:    DEFAULT_FLUSH_DEADLINE,
 		MaxClosedClients: DEFAULT_MAX_CLOSED_CLIENTS,
 		LameDuckDuration: DEFAULT_LAME_DUCK_DURATION,
+		LeafNode: LeafNodeOpts{
+			ReconnectInterval: DEFAULT_LEAF_NODE_RECONNECT,
+		},
 	}
 
 	opts := &Options{}

--- a/server/server.go
+++ b/server/server.go
@@ -121,6 +121,10 @@ type Server struct {
 	leafNodeListener net.Listener
 	leafNodeInfo     Info
 	leafNodeInfoJSON []byte
+	leafNodeOpts     struct {
+		resolver    netResolver
+		dialTimeout time.Duration
+	}
 
 	quitCh chan struct{}
 
@@ -234,6 +238,9 @@ func NewServer(opts *Options) (*Server, error) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Ensure that non-exported options (used in tests) are properly set.
+	s.setLeafNodeNonExportedOptions()
 
 	// Used internally for quick look-ups.
 	s.clientConnectURLsMap = make(map[string]struct{})


### PR DESCRIPTION
This is similar to what we do with Gateways.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
