### PR TITLE
Add a warning if cluster's insecure setting is enabled

### DIFF
--- a/server/reload.go
+++ b/server/reload.go
@@ -280,6 +280,9 @@ func (c *clusterOption) Apply(server *Server) {
 	server.setRouteInfoHostPortAndIP()
 	server.mu.Unlock()
 	server.Noticef("Reloaded: cluster")
+	if tlsRequired && c.newValue.TLSConfig.InsecureSkipVerify {
+		server.Warnf(clusterTLSInsecureWarning)
+	}
 }
 
 func (c *clusterOption) IsClusterPermsChange() bool {

--- a/server/route.go
+++ b/server/route.go
@@ -96,6 +96,9 @@ const (
 // done in place or in separate go routine.
 const sendRouteSubsInGoRoutineThreshold = 1024 * 1024 // 1MB
 
+// Warning when user configures cluster TLS insecure
+const clusterTLSInsecureWarning = "TLS Hostname verification disabled, system will not verify identity of the solicited route"
+
 // This will add a timer to watch over remote reply subjects in case
 // they fail to receive a response. The duration will be taken from the
 // accounts map timeout to match.
@@ -1482,6 +1485,10 @@ func (s *Server) routeAcceptLoop(ch chan struct{}) {
 	}
 	// Setup state that can enable shutdown
 	s.routeListener = l
+	// Warn if using Cluster.Insecure
+	if tlsReq && opts.Cluster.TLSConfig.InsecureSkipVerify {
+		s.Warnf(clusterTLSInsecureWarning)
+	}
 	s.mu.Unlock()
 
 	// Let them know we are up


### PR DESCRIPTION
For cluster, we allow to skip hostname verification from certificate.
We now print a warning when this option is enabled, both on startup
or if the property is enabled on config reload.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
