### PR TITLE
Reduce startup memory for cluster

### DIFF
--- a/server/const.go
+++ b/server/const.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2018 The NATS Authors
+// Copyright 2012-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.0.0-RC5"
+	VERSION = "2.0.0-RC6"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original


### PR DESCRIPTION
Reduce memory during route setup to allow more moderate memory usage for larger clusters.

Addresses some of #954 

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
