### PR TITLE
Fixed invocations of startGoRoutine (continued)

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -583,10 +583,10 @@ func (s *Server) createLeafNode(conn net.Conn, remote *leafNodeCfg) *client {
 	}
 
 	// Spin up the read loop.
-	s.startGoRoutine(c.readLoop)
+	s.startGoRoutine(func() { c.readLoop() })
 
 	// Spin up the write loop.
-	s.startGoRoutine(c.writeLoop)
+	s.startGoRoutine(func() { c.writeLoop() })
 
 	// Set the Ping timer
 	c.setPingTimer()


### PR DESCRIPTION
The leafnode start of go routines for readloop and writeloop were
missing from PR #961

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
