### PR TITLE
Gateways: Fix race for request reply

### DIFF
--- a/server/accounts.go
+++ b/server/accounts.go
@@ -300,7 +300,7 @@ func (a *Account) removeServiceImport(subject string) {
 	delete(a.imports.services, subject)
 	a.mu.Unlock()
 	if a.srv != nil && a.srv.gateway.enabled {
-		a.srv.gatewayHandleServiceImport(a, []byte(subject), -1)
+		a.srv.gatewayHandleServiceImport(a, []byte(subject), nil, -1)
 	}
 }
 

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -2197,6 +2197,8 @@ func (c *client) sendMsgToGateways(acc *Account, msg, subject, reply []byte, qgr
 		mh = append(mh, CR_LF...)
 
 		// We reuse the subscription object that we pass to deliverMsg.
+		// So set/reset important fields.
+		sub.nm, sub.max = 0, 0
 		sub.client = gwc
 		sub.subject = c.pa.subject
 		c.deliverMsg(sub, mh, msg)
@@ -2431,13 +2433,14 @@ func (c *client) processInboundGatewayMsg(msg []byte) {
 				return
 			}
 		}
-		c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply, false, false)
+		c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply)
 	} else {
 		// We normally would not allow sending to a queue unless the
 		// RMSG contains the queue groups, however, if the incoming
 		// message was a "$GR." then we need to act as if this was
 		// a CLIENT connection..
-		qnames := c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply, true, true)
+		qnames := c.processMsgResultsEx(acc, r, msg, c.pa.subject, c.pa.reply,
+			collectQueueNames|treatGatewayAsClient)
 		c.sendMsgToGateways(c.acc, msg, c.pa.subject, c.pa.reply, qnames)
 	}
 }

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -1406,6 +1406,59 @@ func TestGatewayAccountInterest(t *testing.T) {
 	checkCount(t, gwcc, 1)
 }
 
+func TestGatewayAccountUnsub(t *testing.T) {
+	ob := testDefaultOptionsForGateway("B")
+	sb := runGatewayServer(ob)
+	defer sb.Shutdown()
+
+	oa := testGatewayOptionsFromToWithServers(t, "A", "B", sb)
+	sa := runGatewayServer(oa)
+	defer sa.Shutdown()
+
+	waitForOutboundGateways(t, sa, 1, time.Second)
+	waitForOutboundGateways(t, sb, 1, time.Second)
+	waitForInboundGateways(t, sa, 1, time.Second)
+	waitForInboundGateways(t, sb, 1, time.Second)
+
+	// Connect on B
+	ncb := natsConnect(t, fmt.Sprintf("nats://%s:%d", ob.Host, ob.Port))
+	defer ncb.Close()
+	// Create subscription
+	natsSub(t, ncb, "foo", func(m *nats.Msg) {
+		ncb.Publish(m.Reply, []byte("reply"))
+	})
+
+	// Connect on A
+	nca := natsConnect(t, fmt.Sprintf("nats://%s:%d", oa.Host, oa.Port))
+	defer nca.Close()
+	// Send a request
+	if _, err := nca.Request("foo", []byte("req"), time.Second); err != nil {
+		t.Fatalf("Error getting reply: %v", err)
+	}
+
+	// Now close connection on B
+	ncb.Close()
+
+	// Publish lots of messages on "foo" from A.
+	// We should receive an A- shortly and the number
+	// of outbound messages from A to B should not be
+	// close to the number of messages sent here.
+	total := 5000
+	for i := 0; i < total; i++ {
+		natsPub(t, nca, "foo", []byte("hello"))
+	}
+	natsFlush(t, nca)
+
+	c := sa.getOutboundGatewayConnection("B")
+	c.mu.Lock()
+	out := c.outMsgs
+	c.mu.Unlock()
+
+	if out >= int64(80*total)/100 {
+		t.Fatalf("Unexpected number of messages sent from A to B: %v", out)
+	}
+}
+
 func TestGatewaySubjectInterest(t *testing.T) {
 	o1 := testDefaultOptionsForGateway("A")
 	setAccountUserPassInOptions(o1, "$foo", "ivan", "password")
@@ -2869,18 +2922,16 @@ func TestGatewaySendAllSubs(t *testing.T) {
 	waitForInboundGateways(t, sb, 2, time.Second)
 	waitForInboundGateways(t, sc, 2, time.Second)
 
-	// On B, create a sub that will reply to requests
-	bURL := fmt.Sprintf("nats://%s:%d", ob.Host, ob.Port)
-	ncB := natsConnect(t, bURL)
-	defer ncB.Close()
-	natsSub(t, ncB, "foo", func(m *nats.Msg) {
-		ncB.Publish(m.Reply, m.Data)
-	})
-	natsFlush(t, ncB)
-	checkExpectedSubs(t, 1, sb)
+	// On A, create a sub to register some interest
+	aURL := fmt.Sprintf("nats://%s:%d", oa.Host, oa.Port)
+	ncA := natsConnect(t, aURL)
+	defer ncA.Close()
+	natsSub(t, ncA, "sub.on.a.*", func(m *nats.Msg) {})
+	natsFlush(t, ncA)
+	checkExpectedSubs(t, 1, sa)
 
-	// On C, have some delayed activity while it receives
-	// unwanted messages and switches to sendAllSubs.
+	// On C, have some sub activity while it receives
+	// unwanted messages and switches to interestOnly mode.
 	cURL := fmt.Sprintf("nats://%s:%d", oc.Host, oc.Port)
 	ncC := natsConnect(t, cURL)
 	defer ncC.Close()
@@ -2910,6 +2961,11 @@ func TestGatewaySendAllSubs(t *testing.T) {
 		}
 	}()
 
+	// From B publish on subjects for which C has an interest
+	bURL := fmt.Sprintf("nats://%s:%d", ob.Host, ob.Port)
+	ncB := natsConnect(t, bURL)
+	defer ncB.Close()
+
 	go func() {
 		defer wg.Done()
 		time.Sleep(10 * time.Millisecond)
@@ -2925,21 +2981,14 @@ func TestGatewaySendAllSubs(t *testing.T) {
 		}
 	}()
 
-	// From A, send a lot of requests.
-	aURL := fmt.Sprintf("nats://%s:%d", oa.Host, oa.Port)
-	ncA := natsConnect(t, aURL)
-	defer ncA.Close()
+	// From B, send a lot of messages that A is interested in,
+	// but not C.
 	// TODO(ik): May need to change that if we change the threshold
 	// for when the switch happens.
 	total := 300
 	for i := 0; i < total; i++ {
-		req := fmt.Sprintf("%d", i)
-		reply, err := ncA.Request("foo", []byte(req), time.Second)
-		if err != nil {
+		if err := ncB.Publish(fmt.Sprintf("sub.on.a.%d", i), []byte("hi")); err != nil {
 			t.Fatalf("Error waiting for reply: %v", err)
-		}
-		if string(reply.Data) != req {
-			t.Fatalf("Expected reply %q, got %q", req, reply.Data)
 		}
 	}
 	close(done)
@@ -2995,17 +3044,6 @@ func TestGatewaySendAllSubs(t *testing.T) {
 		}
 		return nil
 	})
-
-	for i := 0; i < total; i++ {
-		req := fmt.Sprintf("%d", i)
-		reply, err := ncA.Request("foo", []byte(req), time.Second)
-		if err != nil {
-			t.Fatalf("Error waiting for reply: %v", err)
-		}
-		if string(reply.Data) != req {
-			t.Fatalf("Expected reply %q, got %q", req, reply.Data)
-		}
-	}
 
 	// Also, after all that, if a sub is created on C, it should
 	// be sent to B (but not A). Check that this is the case.
@@ -3218,7 +3256,7 @@ func TestGatewayServiceImport(t *testing.T) {
 	subB := natsSubSync(t, clientB, "reply")
 	natsFlush(t, clientB)
 
-	for i := 0; i < 1; i++ {
+	for i := 0; i < 2; i++ {
 		// Send the request from clientB on foo.request,
 		natsPubReq(t, clientB, "foo.request", "reply", []byte("hi"))
 		natsFlush(t, clientB)
@@ -3263,10 +3301,14 @@ func TestGatewayServiceImport(t *testing.T) {
 			t.Fatalf("Expected %d outMsgs for A, got %v", expected, vz.OutMsgs)
 		}
 
+		// For B, we expect it to send on the two subjects: test.request and foo.request
+		// then send the reply (MSG + RMSG).
 		if i == 0 {
-			expected = 3
+			expected = 4
 		} else {
-			expected = 5
+			// The second time, one of the account will be suppressed, so we will get
+			// only 2 more messages.
+			expected = 6
 		}
 		vz, _ = sb.Varz(nil)
 		if vz.OutMsgs != expected {
@@ -3522,7 +3564,7 @@ func TestGatewayServiceImportWithQueue(t *testing.T) {
 	// on server B.
 	checkForRegisteredQSubInterest(t, sb, "A", "$foo", "test.request", 1, time.Second)
 
-	for i := 0; i < 1; i++ {
+	for i := 0; i < 2; i++ {
 		// Send the request from clientB on foo.request,
 		natsPubReq(t, clientB, "foo.request", "reply", []byte("hi"))
 		natsFlush(t, clientB)
@@ -3559,16 +3601,20 @@ func TestGatewayServiceImportWithQueue(t *testing.T) {
 			t.Fatalf("Unexpected msg: %v", msg)
 		}
 
-		expected := int64(i + 2)
+		expected := int64((i + 1) * 2)
 		vz, _ := sa.Varz(nil)
 		if vz.OutMsgs != expected {
 			t.Fatalf("Expected %d outMsgs for A, got %v", expected, vz.OutMsgs)
 		}
 
+		// For B, we expect it to send on the two subjects: test.request and foo.request
+		// then send the reply (MSG + RMSG).
 		if i == 0 {
-			expected = 3
-		} else {
 			expected = 4
+		} else {
+			// The second time, one of the account will be suppressed, so we will get
+			// only 2 more messages.
+			expected = 6
 		}
 		vz, _ = sb.Varz(nil)
 		if vz.OutMsgs != expected {
@@ -4475,5 +4521,69 @@ func TestGatewayMemUsage(t *testing.T) {
 
 	for _, s := range servers {
 		s.Shutdown()
+	}
+}
+
+func TestGatewayMapReplyOnlyForRecentSub(t *testing.T) {
+	o2 := testDefaultOptionsForGateway("B")
+	s2 := runGatewayServer(o2)
+	defer s2.Shutdown()
+
+	o1 := testGatewayOptionsFromToWithServers(t, "A", "B", s2)
+	s1 := runGatewayServer(o1)
+	defer s1.Shutdown()
+
+	waitForOutboundGateways(t, s1, 1, time.Second)
+	waitForOutboundGateways(t, s2, 1, time.Second)
+
+	// Change s1's recent sub expiration default value
+	s1.mu.Lock()
+	s1.gateway.pasi.Lock()
+	s1.gateway.recSubExp = 100 * time.Millisecond
+	s1.gateway.pasi.Unlock()
+	s1.mu.Unlock()
+
+	// Setup a replier on s2
+	nc2 := natsConnect(t, fmt.Sprintf("nats://%s:%d", o2.Host, o2.Port))
+	defer nc2.Close()
+	count := 0
+	errCh := make(chan error, 1)
+	natsSub(t, nc2, "foo", func(m *nats.Msg) {
+		// Send reply regardless..
+		nc2.Publish(m.Reply, []byte("reply"))
+		if count == 0 {
+			if strings.HasPrefix(m.Reply, nats.InboxPrefix) {
+				errCh <- fmt.Errorf("First reply expected to have a special prefix, got %v", m.Reply)
+				return
+			}
+			count++
+		} else {
+			if !strings.HasPrefix(m.Reply, nats.InboxPrefix) {
+				errCh <- fmt.Errorf("Second reply expected to have normal inbox, got %v", m.Reply)
+				return
+			}
+			errCh <- nil
+		}
+	})
+	natsFlush(t, nc2)
+	checkExpectedSubs(t, 1, s2)
+
+	// Create requestor on s1
+	nc1 := natsConnect(t, fmt.Sprintf("nats://%s:%d", o1.Host, o1.Port))
+	defer nc1.Close()
+	// Send first request, reply should be mapped
+	nc1.Request("foo", []byte("msg1"), time.Second)
+	// Wait more than the recent sub expiration (that we have set to 100ms)
+	time.Sleep(200 * time.Millisecond)
+	// Send second request (reply should not be mapped)
+	nc1.Request("foo", []byte("msg2"), time.Second)
+
+	select {
+	case e := <-errCh:
+		if e != nil {
+			t.Fatalf(e.Error())
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("Did not get replies")
 	}
 }

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1241,7 +1241,7 @@ func (c *client) processInboundLeafMsg(msg []byte) {
 			atomic.LoadInt64(&c.srv.gateway.totalQSubs) > 0 {
 			collect = true
 		}
-		qnames = c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply, collect)
+		qnames = c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply, collect, false)
 	}
 
 	// Now deal with gateways

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1232,16 +1232,16 @@ func (c *client) processInboundLeafMsg(msg []byte) {
 	// Check for no interest, short circuit if so.
 	// This is the fanout scale.
 	if len(r.psubs)+len(r.qsubs) > 0 {
-		flag := 0
+		flag := pmrNoFlag
 		// If we have queue subs in this cluster, then if we run in gateway
 		// mode and the remote gateways have queue subs, then we need to
 		// collect the queue groups this message was sent to so that we
 		// exclude them when sending to gateways.
 		if len(r.qsubs) > 0 && c.srv.gateway.enabled &&
 			atomic.LoadInt64(&c.srv.gateway.totalQSubs) > 0 {
-			flag = collectQueueNames
+			flag = pmrCollectQueueNames
 		}
-		qnames = c.processMsgResultsEx(acc, r, msg, c.pa.subject, c.pa.reply, flag)
+		qnames = c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply, flag)
 	}
 
 	// Now deal with gateways

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -1232,16 +1232,16 @@ func (c *client) processInboundLeafMsg(msg []byte) {
 	// Check for no interest, short circuit if so.
 	// This is the fanout scale.
 	if len(r.psubs)+len(r.qsubs) > 0 {
-		var collect bool
+		flag := 0
 		// If we have queue subs in this cluster, then if we run in gateway
 		// mode and the remote gateways have queue subs, then we need to
 		// collect the queue groups this message was sent to so that we
 		// exclude them when sending to gateways.
 		if len(r.qsubs) > 0 && c.srv.gateway.enabled &&
 			atomic.LoadInt64(&c.srv.gateway.totalQSubs) > 0 {
-			collect = true
+			flag = collectQueueNames
 		}
-		qnames = c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply, collect, false)
+		qnames = c.processMsgResultsEx(acc, r, msg, c.pa.subject, c.pa.reply, flag)
 	}
 
 	// Now deal with gateways

--- a/server/route.go
+++ b/server/route.go
@@ -299,7 +299,7 @@ func (c *client) processInboundRoutedMsg(msg []byte) {
 			c.mu.Unlock()
 		}
 	}
-	c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply)
+	c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply, pmrNoFlag)
 }
 
 // Helper function for routes and gateways to create qfilters need for

--- a/server/route.go
+++ b/server/route.go
@@ -299,7 +299,7 @@ func (c *client) processInboundRoutedMsg(msg []byte) {
 			c.mu.Unlock()
 		}
 	}
-	c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply, false, false)
+	c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply)
 }
 
 // Helper function for routes and gateways to create qfilters need for
@@ -1038,12 +1038,7 @@ func (c *client) sendRouteSubOrUnSubProtos(subs []*subscription, isSubProto, tra
 			// the lock, which could cause pingTimer to think that this
 			// connection is stale otherwise.
 			c.last = time.Now()
-			if !c.flushOutbound() {
-				// Another go routine is flushing already and does not
-				// have the lock. Give it a chance to finish...
-				c.mu.Unlock()
-				c.mu.Lock()
-			}
+			c.flushOutbound()
 			if closed = c.flags.isSet(clearConnection); closed {
 				break
 			}

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -983,6 +983,8 @@ func gatewaysBench(b *testing.B, optimisticMode bool, payload string, numPublish
 	startCh := make(chan bool)
 	l := b.N / numPublishers
 
+	lastMsgSendOp := []byte("PUB end.test 2\r\nok\r\n")
+
 	pubLoop := func(c net.Conn, ch chan bool) {
 		bw := bufio.NewWriterSize(c, defaultSendBufSize)
 
@@ -998,7 +1000,7 @@ func gatewaysBench(b *testing.B, optimisticMode bool, payload string, numPublish
 				return
 			}
 		}
-		if _, err := bw.Write([]byte("PUB end.test 2\r\nok\r\n")); err != nil {
+		if _, err := bw.Write(lastMsgSendOp); err != nil {
 			b.Errorf("Received error on PUB write: %v\n", err)
 			return
 		}
@@ -1011,6 +1013,7 @@ func gatewaysBench(b *testing.B, optimisticMode bool, payload string, numPublish
 	// Publish Connections SPINUP
 	for i := 0; i < numPublishers; i++ {
 		c := createClientConn(b, oa.Host, oa.Port)
+		defer c.Close()
 		doDefaultConnect(b, c)
 		flushConnection(b, c)
 		ch := make(chan bool)
@@ -1019,7 +1022,18 @@ func gatewaysBench(b *testing.B, optimisticMode bool, payload string, numPublish
 		<-ch
 	}
 
-	b.SetBytes(int64(len(sendOp) + len(msgOp)))
+	// To report the number of bytes:
+	// from publisher to server on cluster A:
+	numBytes := len(sendOp)
+	if subInterest {
+		// from server in cluster A to server on cluster B:
+		// RMSG $G foo <payload size> <payload>\r\n
+		numBytes += len("RMSG $G foo xxxx ") + len(payload) + 2
+
+		// From server in cluster B to sub:
+		numBytes += len(msgOp)
+	}
+	b.SetBytes(int64(numBytes))
 	b.ResetTimer()
 
 	// Closing this will start all publishers at once (roughly)
@@ -1031,51 +1045,51 @@ func gatewaysBench(b *testing.B, optimisticMode bool, payload string, numPublish
 	b.StopTimer()
 }
 
-func Benchmark_Gateways___Optimistic_1kx01x0(b *testing.B) {
+func Benchmark_Gateways_Optimistic_1kx01x0(b *testing.B) {
 	gatewaysBench(b, true, sizedString(1024), 1, false)
 }
 
-func Benchmark_Gateways___Optimistic_2kx01x0(b *testing.B) {
+func Benchmark_Gateways_Optimistic_2kx01x0(b *testing.B) {
 	gatewaysBench(b, true, sizedString(2048), 1, false)
 }
 
-func Benchmark_Gateways___Optimistic_4kx01x0(b *testing.B) {
+func Benchmark_Gateways_Optimistic_4kx01x0(b *testing.B) {
 	gatewaysBench(b, true, sizedString(4096), 1, false)
 }
 
-func Benchmark_Gateways___Optimistic_1kx10x0(b *testing.B) {
+func Benchmark_Gateways_Optimistic_1kx10x0(b *testing.B) {
 	gatewaysBench(b, true, sizedString(1024), 10, false)
 }
 
-func Benchmark_Gateways___Optimistic_2kx10x0(b *testing.B) {
+func Benchmark_Gateways_Optimistic_2kx10x0(b *testing.B) {
 	gatewaysBench(b, true, sizedString(2048), 10, false)
 }
 
-func Benchmark_Gateways___Optimistic_4kx10x0(b *testing.B) {
+func Benchmark_Gateways_Optimistic_4kx10x0(b *testing.B) {
 	gatewaysBench(b, true, sizedString(4096), 10, false)
 }
 
-func Benchmark_Gateways___Optimistic_1kx01x1(b *testing.B) {
+func Benchmark_Gateways_Optimistic_1kx01x1(b *testing.B) {
 	gatewaysBench(b, true, sizedString(1024), 1, true)
 }
 
-func Benchmark_Gateways___Optimistic_2kx01x1(b *testing.B) {
+func Benchmark_Gateways_Optimistic_2kx01x1(b *testing.B) {
 	gatewaysBench(b, true, sizedString(2048), 1, true)
 }
 
-func Benchmark_Gateways___Optimistic_4kx01x1(b *testing.B) {
+func Benchmark_Gateways_Optimistic_4kx01x1(b *testing.B) {
 	gatewaysBench(b, true, sizedString(4096), 1, true)
 }
 
-func Benchmark_Gateways___Optimistic_1kx10x1(b *testing.B) {
+func Benchmark_Gateways_Optimistic_1kx10x1(b *testing.B) {
 	gatewaysBench(b, true, sizedString(1024), 10, true)
 }
 
-func Benchmark_Gateways___Optimistic_2kx10x1(b *testing.B) {
+func Benchmark_Gateways_Optimistic_2kx10x1(b *testing.B) {
 	gatewaysBench(b, true, sizedString(2048), 10, true)
 }
 
-func Benchmark_Gateways___Optimistic_4kx10x1(b *testing.B) {
+func Benchmark_Gateways_Optimistic_4kx10x1(b *testing.B) {
 	gatewaysBench(b, true, sizedString(4096), 10, true)
 }
 
@@ -1125,4 +1139,97 @@ func Benchmark_Gateways_InterestOnly_2kx10x1(b *testing.B) {
 
 func Benchmark_Gateways_InterestOnly_4kx10x1(b *testing.B) {
 	gatewaysBench(b, false, sizedString(4096), 10, true)
+}
+
+// This bench only sends the requests to verify impact of reply
+// reply mapping in GW code.
+func gatewaySendRequestsBench(b *testing.B, singleReplySub bool) {
+	server.SetGatewaysSolicitDelay(10 * time.Millisecond)
+	defer server.ResetGatewaysSolicitDelay()
+
+	ob := testDefaultOptionsForGateway("B")
+	sb := RunServer(ob)
+	defer sb.Shutdown()
+
+	gwbURL, err := url.Parse(fmt.Sprintf("nats://%s:%d", ob.Gateway.Host, ob.Gateway.Port))
+	if err != nil {
+		b.Fatalf("Error parsing url: %v", err)
+	}
+	oa := testDefaultOptionsForGateway("A")
+	oa.Gateway.Gateways = []*server.RemoteGatewayOpts{
+		&server.RemoteGatewayOpts{
+			Name: "B",
+			URLs: []*url.URL{gwbURL},
+		},
+	}
+	sa := RunServer(oa)
+	defer sa.Shutdown()
+
+	sub := createClientConn(b, ob.Host, ob.Port)
+	defer sub.Close()
+	doDefaultConnect(b, sub)
+	sendProto(b, sub, "SUB foo 1\r\n")
+	flushConnection(b, sub)
+
+	lenMsg := len("MSG foo reply.xxxxxxxxxx 1 2\r\nok\r\n")
+	expected := b.N * lenMsg
+	if !singleReplySub {
+		expected += b.N * len("$GR.1234.")
+	}
+	ch := make(chan bool, 1)
+	go drainConnection(b, sub, ch, expected)
+
+	c := createClientConn(b, oa.Host, oa.Port)
+	defer c.Close()
+	doDefaultConnect(b, c)
+	if singleReplySub {
+		sendProto(b, c, "SUB reply.* 1\r\n")
+	}
+	flushConnection(b, c)
+
+	// If a single sub for replies is created, wait for more
+	// than the duration under which we do reply mapping
+	if singleReplySub {
+		time.Sleep(1100 * time.Millisecond)
+	}
+
+	bw := bufio.NewWriterSize(c, defaultSendBufSize)
+
+	// From pub to server in cluster A:
+	numBytes := len("PUB foo reply.0123456789 2\r\nok\r\n")
+	if !singleReplySub {
+		// Add the preceding SUB
+		numBytes += len("SUB reply.0123456789 0123456789\r\n")
+	}
+	// From server in cluster A to cluster B
+	numBytes += len("RMSG $G foo reply.0123456789 2\r\nok\r\n")
+	// If mapping of reply...
+	if !singleReplySub {
+		// the mapping uses about 10 more bytes. So add them
+		// for RMSG from server to server, and MSG to sub.
+		numBytes += 20
+	}
+	// From server in cluster B to sub
+	numBytes += lenMsg
+	b.SetBytes(int64(numBytes))
+	b.ResetTimer()
+
+	var subStr string
+	for i := 0; i < b.N; i++ {
+		if !singleReplySub {
+			subStr = fmt.Sprintf("SUB reply.%010d %010d\r\n", i+1, i+1)
+		}
+		bw.Write([]byte(fmt.Sprintf("%sPUB foo reply.%010d 2\r\nok\r\n", subStr, i+1)))
+	}
+	bw.Flush()
+
+	<-ch
+}
+
+func Benchmark_Gateways_Requests_CreateOneSubForAll(b *testing.B) {
+	gatewaySendRequestsBench(b, true)
+}
+
+func Benchmark_Gateways_Requests_CreateOneSubForEach(b *testing.B) {
+	gatewaySendRequestsBench(b, true)
 }


### PR DESCRIPTION
This addresses the following race:
- client connection creates a subscription on a reply subject
- client connection sends a request
- server sends the subscription to inbound gateway
- server sends the message to outbound gateway (those may be
  to different servers)
- receiving server sends to sub interested in request subject
- app sends reply
- its server then check for interest on the reply's subject

In interestOnly mode, there is a possibility that this server
has not received the interest on the reply subject yet and would
then drop the reply.

This PR detects above scenario and will prefix the reply subject
to identify the origin cluster if it is detected that the last
subscription from the sending connection was created less than
a second ago.
Once the destination has this prefix, the destination cluster
will always send back that message to origin cluster even if
there is no registered interest.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
