### PR TITLE
Make account lookup faster with sync.Map

### DIFF
--- a/server/accounts_test.go
+++ b/server/accounts_test.go
@@ -106,8 +106,8 @@ func TestAccountFromOptions(t *testing.T) {
 	s := New(&opts)
 
 	ta := s.numReservedAccounts() + 2
-	if la := len(s.accounts); la != ta {
-		t.Fatalf("Expected to have a server with %d total accounts, got %v", ta, la)
+	if la := s.numAccounts(); la != ta {
+		t.Fatalf("Expected to have a server with %d active accounts, got %v", ta, la)
 	}
 	// Check that sl is filled in.
 	fooAcc, _ := s.LookupAccount("foo")
@@ -201,7 +201,7 @@ func TestActiveAccounts(t *testing.T) {
 		t.Fatalf("Expected account bar to have 1 client, got %d", nc)
 	}
 
-	waitTilActiveCount := func(n int) {
+	waitTilActiveCount := func(n int32) {
 		t.Helper()
 		checkFor(t, time.Second, 10*time.Millisecond, func() error {
 			if active := s.NumActiveAccounts(); active != n {

--- a/server/auth.go
+++ b/server/auth.go
@@ -201,7 +201,9 @@ func (s *Server) configureAuthorization() {
 			for _, u := range opts.Nkeys {
 				copy := u.clone()
 				if u.Account != nil {
-					copy.Account = s.accounts[u.Account.Name]
+					if v, ok := s.accounts.Load(u.Account.Name); ok {
+						copy.Account = v.(*Account)
+					}
 				}
 				s.nkeys[u.Nkey] = copy
 			}
@@ -211,7 +213,9 @@ func (s *Server) configureAuthorization() {
 			for _, u := range opts.Users {
 				copy := u.clone()
 				if u.Account != nil {
-					copy.Account = s.accounts[u.Account.Name]
+					if v, ok := s.accounts.Load(u.Account.Name); ok {
+						copy.Account = v.(*Account)
+					}
 				}
 				s.users[u.Username] = copy
 			}

--- a/server/client.go
+++ b/server/client.go
@@ -2895,9 +2895,7 @@ func (c *client) closeConnection(reason ClosedState) {
 				srv.updateLeafNodes(acc, esub.sub, -(esub.n))
 			}
 			if prev := acc.removeClient(c); prev == 1 && srv != nil {
-				srv.mu.Lock()
-				srv.activeAccounts--
-				srv.mu.Unlock()
+				srv.decActiveAccounts()
 			}
 		}
 	}

--- a/server/gateway_test.go
+++ b/server/gateway_test.go
@@ -2987,9 +2987,7 @@ func TestGatewaySendAllSubs(t *testing.T) {
 		if scount != consCount {
 			return fmt.Errorf("Expected %v consumers for global account, got %v", consCount, scount)
 		}
-		sc.mu.Lock()
-		acount := len(sc.accounts)
-		sc.mu.Unlock()
+		acount := sc.numAccounts()
 		if acount != accsCount+1 {
 			return fmt.Errorf("Expected %v accounts, got %v", accsCount+1, acount)
 		}
@@ -4434,6 +4432,7 @@ func TestGatewayServiceExportWithWildcards(t *testing.T) {
 	}
 }
 
+// NOTE: if this fails for you and says only has <10 outbound, make sure ulimit for open files > 256.
 func TestGatewayMemUsage(t *testing.T) {
 	// Try to clean up.
 	runtime.GC()

--- a/server/reload.go
+++ b/server/reload.go
@@ -789,8 +789,8 @@ func (s *Server) reloadAuthorization() {
 
 	// We need to drain the old accounts here since we have something
 	// new configured. We do not want s.accounts to change since that would
-	// mean adding a lock to lookupAccount which is what we are tryin to optimize
-	// with the change from a map to a sync.Map.
+	// mean adding a lock to lookupAccount which is what we are trying to
+	// optimize for with the change from a map to a sync.Map.
 	oldAccounts := make(map[string]*Account)
 	s.accounts.Range(func(k, v interface{}) bool {
 		acc := v.(*Account)

--- a/server/route.go
+++ b/server/route.go
@@ -890,8 +890,9 @@ func (s *Server) sendSubsToRoute(route *client) {
 	eSize := 0
 	// Send over our account subscriptions.
 	// copy accounts into array first
-	accs := make([]*Account, 0, len(s.accounts))
-	for _, a := range s.accounts {
+	accs := make([]*Account, 0, 32)
+	s.accounts.Range(func(k, v interface{}) bool {
+		a := v.(*Account)
 		accs = append(accs, a)
 		a.mu.RLock()
 		// Proto looks like: "RS+ <account name> <subject>[ <queue weight>]\r\n"
@@ -900,7 +901,8 @@ func (s *Server) sendSubsToRoute(route *client) {
 		// later going over each account.
 		eSize += len(a.rm) * (4 + len(a.Name) + 256)
 		a.mu.RUnlock()
-	}
+		return true
+	})
 	s.mu.Unlock()
 
 	sendSubs := func(accs []*Account) {

--- a/server/split_test.go
+++ b/server/split_test.go
@@ -28,7 +28,7 @@ func TestSplitBufferSubOp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating gateways: %v", err)
 	}
-	s := &Server{gacc: NewAccount(globalAccountName), accounts: make(map[string]*Account), gateway: gws}
+	s := &Server{gacc: NewAccount(globalAccountName), gateway: gws}
 	s.registerAccount(s.gacc)
 	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription), nc: cli}
 
@@ -65,7 +65,7 @@ func TestSplitBufferSubOp(t *testing.T) {
 }
 
 func TestSplitBufferUnsubOp(t *testing.T) {
-	s := &Server{gacc: NewAccount(globalAccountName), accounts: make(map[string]*Account), gateway: &srvGateway{}}
+	s := &Server{gacc: NewAccount(globalAccountName), gateway: &srvGateway{}}
 	s.registerAccount(s.gacc)
 	c := &client{srv: s, acc: s.gacc, msubs: -1, mpay: -1, mcl: 1024, subs: make(map[string]*subscription)}
 

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -1126,3 +1126,132 @@ func Benchmark_Gateways_InterestOnly_2kx10x1(b *testing.B) {
 func Benchmark_Gateways_InterestOnly_4kx10x1(b *testing.B) {
 	gatewaysBench(b, false, sizedString(4096), 10, true)
 }
+
+// Run some benchmarks against interest churn across routes.
+// Watching for contention retrieving accounts, etc.
+func Benchmark_________________LookupAccount(b *testing.B) {
+	s := runBenchServer()
+	defer s.Shutdown()
+
+	const acc = "$foo.bar"
+
+	if _, err := s.RegisterAccount(acc); err != nil {
+		b.Fatalf("Error registering '%s' - %v", acc, err)
+	}
+	// Now create Go routines to cycle through Lookups.
+	numRoutines := 100
+	loop := b.N / numRoutines
+
+	startCh := make(chan bool)
+
+	lookupLoop := func(ready, done chan bool) {
+		// Signal we are ready
+		close(ready)
+		// Wait to start up actual unsubs.
+		<-startCh
+
+		for i := 0; i < loop; i++ {
+			if _, err := s.LookupAccount(acc); err != nil {
+				b.Errorf("Error looking up account: %v", err)
+			}
+		}
+		close(done)
+	}
+
+	da := make([]chan bool, 0, numRoutines)
+	for i := 0; i < numRoutines; i++ {
+		ready := make(chan bool)
+		done := make(chan bool)
+		go lookupLoop(ready, done)
+		da = append(da, done)
+		<-ready
+	}
+
+	b.ResetTimer()
+	close(startCh)
+	for _, ch := range da {
+		<-ch
+	}
+	b.StopTimer()
+}
+
+func Benchmark___________RoutedInterestGraph(b *testing.B) {
+	s, o := RunServerWithConfig("./configs/srv_a.conf")
+	o.AllowNewAccounts = true
+	defer s.Shutdown()
+
+	numRoutes := 100
+	loop := b.N / numRoutes
+
+	type rh struct {
+		r      net.Conn
+		send   sendFun
+		expect expectFun
+		done   chan bool
+	}
+
+	routes := make([]*rh, 0, numRoutes)
+	for i := 0; i < numRoutes; i++ {
+		r := createRouteConn(b, o.Cluster.Host, o.Cluster.Port)
+		defer r.Close()
+
+		checkInfoMsg(b, r)
+		send, expect := setupRoute(b, r, o)
+		send("PING\r\n")
+		expect(pongRe)
+
+		bw := bufio.NewWriterSize(r, defaultSendBufSize)
+
+		account := fmt.Sprintf("$foo.account.%d", i)
+		for s := 0; s < loop; s++ {
+			bw.Write([]byte(fmt.Sprintf("RS+ %s foo.bar.%d\r\n", account, s)))
+		}
+		bw.Flush()
+		send("PING\r\n")
+		expect(pongRe)
+		routes = append(routes, &rh{r, send, expect, make(chan bool)})
+	}
+
+	startCh := make(chan bool)
+
+	unsubLoop := func(route *rh, ch chan bool, index int) {
+		bw := bufio.NewWriterSize(route.r, defaultSendBufSize)
+		account := fmt.Sprintf("$foo.account.%d", index)
+
+		// Signal we are ready
+		close(ch)
+
+		// Wait to start up actual unsubs.
+		<-startCh
+
+		for i := 0; i < loop; i++ {
+			_, err := bw.Write([]byte(fmt.Sprintf("RS- %s foo.bar.%d\r\n", account, i)))
+			if err != nil {
+				b.Errorf("Received error on RS- write: %v\n", err)
+				return
+			}
+		}
+		err := bw.Flush()
+		if err != nil {
+			b.Errorf("Received error on FLUSH write: %v\n", err)
+			return
+		}
+		route.send("PING\r\n")
+		route.expect(pongRe)
+		close(route.done)
+	}
+
+	for i, route := range routes {
+		ch := make(chan bool)
+		go unsubLoop(route, ch, i)
+		<-ch
+	}
+
+	// Actual unsub test here.
+	b.ResetTimer()
+	close(startCh)
+	for _, route := range routes {
+		<-route.done
+	}
+	b.StopTimer()
+}


### PR DESCRIPTION
This switches account lookup to use sync.Map. This should help in concurrent access from routes and gateways when interest graph churn forces cache misses.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
