### PR TITLE
Revert "Allow using quotes around include"

### DIFF
--- a/conf/lex.go
+++ b/conf/lex.go
@@ -343,10 +343,7 @@ func lexKeyStart(lx *lexer) stateFn {
 func lexDubQuotedKey(lx *lexer) stateFn {
 	r := lx.peek()
 	if r == dqStringEnd {
-		include := lx.keyCheckKeyword(nil, nil)
-		if include != nil {
-			return include
-		}
+		lx.emit(itemKey)
 		lx.next()
 		return lexSkip(lx, lexKeyEnd)
 	} else if r == eof {
@@ -364,10 +361,7 @@ func lexDubQuotedKey(lx *lexer) stateFn {
 func lexQuotedKey(lx *lexer) stateFn {
 	r := lx.peek()
 	if r == sqStringEnd {
-		include := lx.keyCheckKeyword(nil, nil)
-		if include != nil {
-			return include
-		}
+		lx.emit(itemKey)
 		lx.next()
 		return lexSkip(lx, lexKeyEnd)
 	} else if r == eof {
@@ -400,7 +394,7 @@ func (lx *lexer) keyCheckKeyword(fallThrough, push stateFn) stateFn {
 // lexIncludeStart will consume the whitespace til the start of the value.
 func lexIncludeStart(lx *lexer) stateFn {
 	r := lx.next()
-	if isWhitespace(r) || r == dqStringEnd || r == sqStringEnd || isKeySeparator(r) {
+	if isWhitespace(r) {
 		return lexSkip(lx, lexIncludeStart)
 	}
 	lx.backup()
@@ -447,7 +441,7 @@ func lexIncludeString(lx *lexer) stateFn {
 		lx.backup()
 		lx.emit(itemInclude)
 		return lx.pop()
-	case r == sqStringEnd || r == dqStringEnd:
+	case r == sqStringEnd:
 		lx.backup()
 		lx.emit(itemInclude)
 		lx.next()
@@ -674,10 +668,7 @@ func lexMapKeyStart(lx *lexer) stateFn {
 func lexMapQuotedKey(lx *lexer) stateFn {
 	r := lx.peek()
 	if r == sqStringEnd {
-		include := lx.keyCheckKeyword(nil, lexMapValueEnd)
-		if include != nil {
-			return include
-		}
+		lx.emit(itemKey)
 		lx.next()
 		return lexSkip(lx, lexMapKeyEnd)
 	}
@@ -689,10 +680,7 @@ func lexMapQuotedKey(lx *lexer) stateFn {
 func lexMapDubQuotedKey(lx *lexer) stateFn {
 	r := lx.peek()
 	if r == dqStringEnd {
-		include := lx.keyCheckKeyword(nil, lexMapValueEnd)
-		if include != nil {
-			return include
-		}
+		lx.emit(itemKey)
 		lx.next()
 		return lexSkip(lx, lexMapKeyEnd)
 	}

--- a/conf/parse_test.go
+++ b/conf/parse_test.go
@@ -2,9 +2,7 @@ package conf
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -360,98 +358,4 @@ func TestIncludeVariablesWithChecks(t *testing.T) {
 	expectKeyVal(t, m, "ALICE_PASS", "$2a$10$UHR6GhotWhpLsKtVP0/i6.Nh9.fuY73cWjLoJjb2sKT8KISBcUW5q", 2, 1)
 	expectKeyVal(t, m, "BOB_PASS", "$2a$11$dZM98SpGeI7dCFFGSpt.JObQcix8YHml4TBUZoge9R1uxnMIln5ly", 3, 1)
 	expectKeyVal(t, m, "CAROL_PASS", "foo", 6, 3)
-}
-
-func TestIncludesJSONSyntax(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "includes")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-
-	content := `
-        {
-          "debug": true,
-          "include": "simple.json",
-          "cluster": {
-            "include": "cluster.json"
-          }
-        }       
-        `
-	configFile := filepath.Join(tmpdir, "multiple.json")
-	if err := ioutil.WriteFile(configFile, []byte(content), 0666); err != nil {
-		t.Fatal(err)
-	}
-
-	content = `
-        {
-          "listen": "127.0.0.1:4223"
-        }       
-        `
-	include := filepath.Join(tmpdir, "simple.json")
-	if err := ioutil.WriteFile(include, []byte(content), 0666); err != nil {
-		t.Fatal(err)
-	}
-
-	content = `
-        {
-          "routes": [
-            "nats://nats-A:6222",
-            "nats://nats-C:6222",
-            "nats://nats-B:6222"
-          ]
-        }
-        `
-	include = filepath.Join(tmpdir, "cluster.json")
-	if err := ioutil.WriteFile(include, []byte(content), 0666); err != nil {
-		t.Fatal(err)
-	}
-
-	m, err := ParseFile(configFile)
-	if err != nil {
-		t.Fatalf("Received err: %v\n", err)
-	}
-	if m == nil {
-		t.Fatal("Received nil map")
-	}
-
-	ex := map[string]interface{}{
-		"listen": "127.0.0.1:4223",
-		"debug":  true,
-		"cluster": map[string]interface{}{
-			"routes": []interface{}{
-				"nats://nats-A:6222",
-				"nats://nats-C:6222",
-				"nats://nats-B:6222",
-			},
-		},
-	}
-	if !reflect.DeepEqual(m, ex) {
-		t.Fatalf("Not Equal:\nReceived: '%+v'\nExpected: '%+v'\n", m, ex)
-	}
-
-	content = `
-        'debug': true
-
-        'include': 'simple.json'
-
-        'cluster': {
-          'include': 'cluster.json'
-        }
-        `
-	configFile = filepath.Join(tmpdir, "multiple.json")
-	if err := ioutil.WriteFile(configFile, []byte(content), 0666); err != nil {
-		t.Fatal(err)
-	}
-
-	m2, err := ParseFile(configFile)
-	if err != nil {
-		t.Fatalf("Received err: %v\n", err)
-	}
-	if m2 == nil {
-		t.Fatal("Received nil map")
-	}
-	if !reflect.DeepEqual(m2, ex) {
-		t.Fatalf("Not Equal:\nReceived: '%+v'\nExpected: '%+v'\n", m2, ex)
-	}
 }


### PR DESCRIPTION
Reverts nats-io/gnatsd#891 since it would mean not being able to use `"include":` as part of map. Only way that another file can be included would be via this syntax:

```
include "path/to/file"
```

and all the following would result in `unknown field "include"` error:

```java
include: "path/to/file"
"include": "path/to/file"
'include': "path/to/file"
"include" "path/to/file"
'include' "path/to/file"
```

/cc @nats-io/core