### PR TITLE
Update JSON tag used for leaf node option

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -142,7 +142,7 @@ type Options struct {
 	MaxPending       int64         `json:"max_pending"`
 	Cluster          ClusterOpts   `json:"cluster,omitempty"`
 	Gateway          GatewayOpts   `json:"gateway,omitempty"`
-	LeafNode         LeafNodeOpts  `json:"leaf_node,omitempty"`
+	LeafNode         LeafNodeOpts  `json:"leaf,omitempty"`
 	ProfPort         int           `json:"-"`
 	PidFile          string        `json:"-"`
 	PortsFileDir     string        `json:"-"`


### PR DESCRIPTION
Config options can be configured with either `leaf` or `leafnodes` but JSON tag used is `leaf_node`: 

https://github.com/nats-io/gnatsd/blob/031267dfd6fe6389bc1e4610afcb363aa6ca2afe/server/opts.go#L464

This changes it to `leaf` to be consistent as well with the limits field set in the [nats-io/jwt lib](https://github.com/nats-io/jwt/blob/ef45966189e5d14c3294b1ddea08998d314a5e29/account_claims.go#L31
)

 - [X] Branch rebased on top of current master (`git pull --rebase origin master`)
 - [X] Changes squashed to a single commit (described [here](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 - [ ] Build is green in Travis CI
 - [X] You have certified that the contribution is your original work and that you license the work to the project under the [Apache 2 license](https://github.com/nats-io/gnatsd/blob/master/LICENSE)

/cc @nats-io/core
