### PR TITLE
Fixed panic with leafnode and gateway when no interest registered

### DIFF
--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1831,7 +1831,7 @@ func (s *Server) switchAccountToInterestMode(accName string) {
 		var ok bool
 
 		gin.mu.Lock()
-		if e, ok = gin.gw.insim[accName]; !ok {
+		if e, ok = gin.gw.insim[accName]; !ok || e == nil {
 			e = &insie{}
 			gin.gw.insim[accName] = e
 		}


### PR DESCRIPTION
Say there are 2 clusters, A and B. A client connects to A and
publishes messages on an account that B has no interest in.
Then a leaf node server connects to B (using same account than
the no-interest is for). Cluster B will ask cluster
A to switch to interest mode only for leaf node account. This
would cause a panic.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
