### PR TITLE
Make sure we use correct MSG prefix

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -2567,6 +2567,8 @@ sendToRoutesOrLeafs:
 		kind := rt.sub.client.kind
 		mh := c.msgb[:msgHeadProtoLen]
 		if kind == ROUTER {
+			// Router (and Gateway) nodes are RMSG. Set here since leafnodes may rewrite.
+			mh[0] = 'R'
 			mh = append(mh, acc.Name...)
 			mh = append(mh, ' ')
 		} else {

--- a/server/const.go
+++ b/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.0.0-RC8"
+	VERSION = "2.0.0-RC9"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -2139,6 +2139,9 @@ func (c *client) sendMsgToGateways(acc *Account, msg, subject, reply []byte, qgr
 	// Get a subscription from the pool
 	sub := subPool.Get().(*subscription)
 
+	// Make sure we are an 'R' proto
+	c.msgb[0] = 'R'
+
 	// Check if the subject is on "$GR.<cluster hash>.",
 	// and if so, send to that GW regardless of its
 	// interest on the real subject (that is, skip the

--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -503,6 +503,12 @@ func (s *Server) createLeafNode(conn net.Conn, remote *leafNodeCfg) *client {
 
 			url := c.leaf.remote.getCurrentURL()
 			host, _, _ := net.SplitHostPort(url.Host)
+			// We need to check if this host is an IP. If so, we probably
+			// had this advertised to us an should use the configured host
+			// name for the TLS server name.
+			if net.ParseIP(host) != nil {
+				host, _, _ = net.SplitHostPort(c.leaf.remote.RemoteLeafOpts.URL.Host)
+			}
 			tlsConfig.ServerName = host
 
 			c.nc = tls.Client(c.nc, tlsConfig)


### PR DESCRIPTION
When having a connection like a client or a gateway that was sending to both routes and leafnodes the prefix for the MSG protocol could get stuck with 'L', causing router protocol violations.

This PR also reuses hostnames for soliciting leafnode connections when TLS is utilized.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
