### PR TITLE
Fixed LeafNode failed to create TLS connection when CA needed

### DIFF
--- a/server/opts.go
+++ b/server/opts.go
@@ -1050,6 +1050,10 @@ func parseRemoteLeafNodes(v interface{}, errors *[]error, warnings *[]error) ([]
 					*errors = append(*errors, &configErr{tk, err.Error()})
 					continue
 				}
+				// If ca_file is defined, GenTLSConfig() sets TLSConfig.ClientCAs.
+				// Set RootCAs since this tls.Config is used when soliciting
+				// a connection (therefore behaves as a client).
+				remote.TLSConfig.RootCAs = remote.TLSConfig.ClientCAs
 				remote.TLSTimeout = tc.Timeout
 			default:
 				if !tk.IsUsedVariable() {


### PR DESCRIPTION
If server solicits leaf node TLS connection and needs to verify
the server certificate, it did not have the root CAs set in its
config.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
