### PR TITLE
Make sure remotes send existing sub interest

### DIFF
--- a/server/leafnode.go
+++ b/server/leafnode.go
@@ -610,6 +610,7 @@ func (s *Server) createLeafNode(conn net.Conn, remote *leafNodeCfg) *client {
 		// Make sure we register with the account here.
 		c.registerWithAccount(c.acc)
 		s.addLeafNodeConnection(c)
+		s.initLeafNodeSmap(c)
 		c.sendAllAccountSubs()
 	}
 


### PR DESCRIPTION
Remotes were not sending existing subject interest. Detected when a local app was trying to reconnect on a remote leafnode restart.

Signed-off-by: Derek Collison <derek@nats.io>

/cc @nats-io/core
